### PR TITLE
feat: change default beta to 1.0 for balanced F1

### DIFF
--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -96,7 +96,7 @@ export function s(
 
   // Merge user-provided configuration with defaults
   const options = {
-    beta: 0.5,
+    beta: 1.0,
     skipBigram: utils.skipBigram,
     tokenizer: utils.treeBankTokenize,
     ...opts,
@@ -155,7 +155,7 @@ export function l(
 
   // Merge user-provided configuration with defaults
   const options = {
-    beta: 0.5,
+    beta: 1.0,
     lcs: utils.lcs,
     segmenter: utils.sentenceSegment,
     tokenizer: utils.treeBankTokenize,


### PR DESCRIPTION
## Summary
- Change default beta from 0.5 to 1.0 across all ROUGE functions
- Beta=1.0 provides standard balanced F1 score (equal precision/recall weighting)
- Aligns with common practice in NLP evaluation

## Test plan
- [x] All tests pass with updated default values
- [x] Verified F1 calculation is correct with beta=1.0