### PR TITLE
feat: add maxSkip parameter to ROUGE-S

### DIFF
--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -67,7 +67,7 @@ export function n(
  * ```
  * {
  * 	beta: 1                             // The beta value used for the f-measure
- * 	gapLength: 2                        // The skip window
+ * 	maxSkip: Infinity                   // Maximum skip distance between words
  * 	skipBigram: <inbuilt function>,     // The skip-bigram generator function
  * 	tokenizer: <inbuilt function>       // The string tokenizer
  * }
@@ -87,7 +87,8 @@ export function s(
   ref: string,
   opts: {
     beta?: number;
-    skipBigram?: (tokens: string[]) => string[];
+    maxSkip?: number;
+    skipBigram?: (tokens: string[], maxSkip?: number) => string[];
     tokenizer?: (input: string) => string[];
   }
 ): number {
@@ -97,13 +98,14 @@ export function s(
   // Merge user-provided configuration with defaults
   const options = {
     beta: 1.0,
+    maxSkip: Infinity,
     skipBigram: utils.skipBigram,
     tokenizer: utils.treeBankTokenize,
     ...opts,
   };
 
-  const candGrams = options.skipBigram(options.tokenizer(cand));
-  const refGrams = options.skipBigram(options.tokenizer(ref));
+  const candGrams = options.skipBigram(options.tokenizer(cand), options.maxSkip);
+  const refGrams = options.skipBigram(options.tokenizer(ref), options.maxSkip);
 
   const skip2 = utils.intersection(candGrams, refGrams).length;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -237,14 +237,16 @@ export const fact = memoize(factRec);
  *
  * @method skipBigram
  * @param  {Array<string>}    tokens      An array of word tokens
+ * @param  {number}           maxSkip     Maximum skip distance between words. Defaults to Infinity (all pairs).
  * @return {Array<string>}                An array of skip bigram strings
  */
-export function skipBigram(tokens: string[]): string[] {
+export function skipBigram(tokens: string[], maxSkip: number = Infinity): string[] {
   if (tokens.length < 2) throw new RangeError('Input must have at least two words');
 
   const acc: string[] = [];
   for (let baseIdx = 0; baseIdx < tokens.length - 1; baseIdx++) {
-    for (let sweepIdx = baseIdx + 1; sweepIdx < tokens.length; sweepIdx++) {
+    const maxIdx = Math.min(baseIdx + 1 + maxSkip, tokens.length);
+    for (let sweepIdx = baseIdx + 1; sweepIdx < maxIdx; sweepIdx++) {
       acc.push(`${tokens[baseIdx]} ${tokens[sweepIdx]}`);
     }
   }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -205,6 +205,22 @@ describe('Utility Functions', () => {
     test('should return the correct result', () => {
       expect(sb(data)).toEqual(result);
     });
+
+    test('should return all pairs with default maxSkip (Infinity)', () => {
+      expect(sb(data, Infinity)).toEqual(result);
+    });
+
+    test('should return only adjacent pairs with maxSkip=1', () => {
+      expect(sb(data, 1)).toEqual(['a b', 'b c', 'c d']);
+    });
+
+    test('should return pairs within skip distance of 2', () => {
+      expect(sb(data, 2)).toEqual(['a b', 'a c', 'b c', 'b d', 'c d']);
+    });
+
+    test('should return pairs within skip distance of 3', () => {
+      expect(sb(data, 3)).toEqual(['a b', 'a c', 'a d', 'b c', 'b d', 'c d']);
+    });
   });
 
   describe('sentenceSegment', () => {
@@ -641,6 +657,14 @@ describe('Core Functions', () => {
     });
     test('should correctly compute ROUGE-S score for cand 3 with different opts', () => {
       expect(s(cands[2], ref, { beta: 1 })).toBe(1 / 3);
+    });
+
+    test('should respect maxSkip option', () => {
+      // With maxSkip=1, only adjacent pairs are considered
+      // cand: 'police kill the gunman' -> adjacent pairs: 'police kill', 'kill the', 'the gunman'
+      // ref: 'police killed the gunman' -> adjacent pairs: 'police killed', 'killed the', 'the gunman'
+      // Only 'the gunman' matches, so precision = 1/3, recall = 1/3, F1 = 1/3
+      expect(s(cands[0], ref, { beta: 1, maxSkip: 1 })).toBe(1 / 3);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add maxSkip parameter to skipBigram function to limit skip distance
- Enables ROUGE-S4, ROUGE-S9, etc. variants as described in the original paper
- Default is Infinity (unlimited skip) for backwards compatibility

## Test plan
- [x] New tests for maxSkip parameter
- [x] Existing skip bigram tests pass
- [x] Verified behavior matches paper description