### PR TITLE
fix: add exports field to package.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code Guidelines
+
+See [AGENTS.md](./AGENTS.md) for all project guidelines and documentation.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,13 @@
   "main": "dist/rouge.js",
   "module": "dist/rouge.mjs",
   "types": "dist/rouge.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/rouge.d.ts",
+      "import": "./dist/rouge.mjs",
+      "require": "./dist/rouge.js"
+    }
+  },
   "scripts": {
     "test": "jest",
     "build": "npm run clean && npm run build:js && npm run build:types",


### PR DESCRIPTION
## Summary
- Add exports field for proper ESM/CJS dual package support
- Enables correct resolution in modern bundlers and Node.js
- Specifies types, import (ESM), and require (CJS) entry points

## Test plan
- [x] Package builds successfully
- [x] Verified exports work in both ESM and CJS contexts