### PR TITLE
fix: add files field and fix directories in package.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code Guidelines
+
+See [AGENTS.md](./AGENTS.md) for all project guidelines and documentation.

--- a/package.json
+++ b/package.json
@@ -55,8 +55,12 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "directories": {
-    "lib": "lib",
+    "lib": "dist",
     "test": "test"
   }
 }


### PR DESCRIPTION
## Summary
- Add files field to explicitly include only dist/ and README.md in published package
- Fix directories.lib to point to dist/ instead of lib/
- Reduces published package size and ensures correct file structure

## Test plan
- [x] npm pack shows correct files included
- [x] Package installs and works correctly