### PR TITLE
chore: remove unused ts-jest dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code Guidelines
+
+See [AGENTS.md](./AGENTS.md) for all project guidelines and documentation.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
-    "ts-jest": "^29.2.4",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.1.0"
   },


### PR DESCRIPTION
## Summary
- Remove ts-jest from devDependencies
- Project uses @swc/jest for TypeScript transformation, not ts-jest
- Reduces unnecessary dependencies

## Test plan
- [x] Tests still pass with @swc/jest
- [x] No references to ts-jest in codebase