### PR TITLE
fix: enable ESLint to lint test files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,12 +40,20 @@ export default tseslint.config(
   {
     files: ['test/**/*.ts', 'test/**/*.js'],
     ...jest.configs['flat/recommended'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        project: null,
+      },
+    },
     rules: {
       ...jest.configs['flat/recommended'].rules,
       'jest/prefer-expect-assertions': 'off',
+      // Disable rules that require type information for test files
+      '@typescript-eslint/explicit-function-return-type': 'off',
     },
   },
   {
-    ignores: ['dist/**', 'jest.config.js', '**/*.d.ts', '**/*.js', 'test/**.ts']
+    ignores: ['dist/**', 'jest.config.js', '**/*.d.ts', '**/*.js'],
   },
 );


### PR DESCRIPTION
## Summary
- Remove errant `test/**.ts` from ESLint ignores that prevented test file linting
- Configure test file overrides to use null project for TypeScript ESLint
- Disable explicit-function-return-type for test files

## Test plan
- [x] ESLint now runs on test files
- [x] All lint checks pass
- [x] Tests still pass