### PR TITLE
docs: fix fMeasure documentation comment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code Guidelines
+
+See [AGENTS.md](./AGENTS.md) for all project guidelines and documentation.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -366,15 +366,16 @@ export function jackKnife(
  * Calculates the ROUGE f-measure for a given precision
  * and recall score.
  *
- * DUC evaluation favors precision by setting beta to an
- * arbitrary large number. To replicate this, set beta to
- * any value larger than 1.
+ * Beta controls the tradeoff between precision and recall:
+ * - beta = 1: F1 score (harmonic mean, equal weight)
+ * - beta < 1: Favors precision
+ * - beta > 1: Favors recall (DUC evaluation style)
  *
  * @method fMeasure
  * @param  {number}     p       Precision score
  * @param  {number}     r       Recall score
  * @param  {number}     beta    Weighing value (precision vs. recall).
- *                              Defaults to 0.5, i.e. mean f-score
+ *                              Defaults to 0.5 (precision-favoring).
  * @return {number}             Computed f-score
  */
 export function fMeasure(p: number, r: number, beta: number = 0.5): number {


### PR DESCRIPTION
## Summary
- Fix JSDoc comment for fMeasure function
- Correct the description of beta parameter behavior
- Clarify that beta < 1 favors precision, beta > 1 favors recall

## Test plan
- [x] Documentation accurately describes function behavior
- [x] No code changes, only comments