### PR TITLE
fix: make charIsUpperCase i18n-compatible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code Guidelines
+
+See [AGENTS.md](./AGENTS.md) for all project guidelines and documentation.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -170,7 +170,7 @@ export function strIsTitleCase(input: string): boolean {
 }
 
 /**
- * Checks if a character is uppercase
+ * Checks if a character is uppercase (i18n-compatible)
  * @method charIsUpperCase
  * @param  {string}   input     The character to be tested
  * @return {boolean}            True if the character is uppercase and false otherwise.
@@ -178,8 +178,8 @@ export function strIsTitleCase(input: string): boolean {
 export function charIsUpperCase(input: string): boolean {
   if (input.length !== 1) throw new RangeError('Input should be a single character');
 
-  const char = input.charCodeAt(0);
-  return char >= 65 && char <= 90;
+  // Use locale-aware comparison to support international characters
+  return input.toUpperCase() === input && input.toLowerCase() !== input;
 }
 
 /**

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -548,6 +548,17 @@ describe('Utility Functions', () => {
     test('should return false for non-alphabetical input', () => {
       expect(isUpper('1')).toBe(false);
     });
+
+    test('should return true for uppercase international characters', () => {
+      expect(isUpper('Ü')).toBe(true);
+      expect(isUpper('É')).toBe(true);
+      expect(isUpper('Ñ')).toBe(true);
+    });
+    test('should return false for lowercase international characters', () => {
+      expect(isUpper('ü')).toBe(false);
+      expect(isUpper('é')).toBe(false);
+      expect(isUpper('ñ')).toBe(false);
+    });
   });
 
   describe('strIsTitleCase', () => {


### PR DESCRIPTION
## Summary
- Replace ASCII char code check with locale-aware comparison
- Now correctly handles international uppercase letters (Ü, É, Ñ, etc.)
- Uses `toUpperCase() === input && toLowerCase() !== input` pattern

## Test plan
- [x] Existing ASCII tests pass
- [x] New tests for international characters (Ü, É, Ñ)
- [x] Non-alphabetic characters still return false