### PR TITLE
fix: use npm OIDC for publish authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,9 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
+      # Publishing uses npm's OIDC integration for authentication.
+      # Requires the npm package to be configured to trust GitHub Actions:
+      # 1. Go to npmjs.com > Package Settings > Publishing access
+      # 2. Enable "Require two-factor authentication or an automation or granular access token"
+      # 3. Configure trusted publishers to allow this GitHub repository
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove `NODE_AUTH_TOKEN` env var from npm publish step
- Use npm's native OIDC integration for authentication instead
- Add documentation comments explaining the OIDC setup requirements

## Why OIDC?
- **More secure**: Uses short-lived tokens from GitHub Actions instead of long-lived npm tokens
- **No secret management**: No need to rotate or manage NPM_TOKEN secrets
- **Provenance**: Works seamlessly with `--provenance` flag for supply chain security

## Setup Required on npm
For this to work, the npm package must be configured to trust GitHub Actions:

1. Go to [npmjs.com](https://npmjs.com) > Package Settings > Publishing access
2. Enable "Require two-factor authentication or an automation or granular access token"
3. Add this repository as a trusted publisher under "Configure trusted publishers"

## Test plan
- [ ] Verify npm package settings are configured for OIDC
- [ ] Trigger a release and confirm publish succeeds