### PR TITLE
fix: remove registry-url to enable npm OIDC authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,11 +54,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+          # Note: NOT using registry-url here to allow npm OIDC authentication
       - run: npm ci
-      # Publishing uses npm's OIDC integration for authentication.
-      # Requires the npm package to be configured to trust GitHub Actions:
-      # 1. Go to npmjs.com > Package Settings > Publishing access
-      # 2. Enable "Require two-factor authentication or an automation or granular access token"
-      # 3. Configure trusted publishers to allow this GitHub repository
+      # Publishing uses npm's OIDC trusted publishers for authentication.
+      # This requires the npm package to be configured to trust this GitHub repository.
+      # See: https://docs.npmjs.com/generating-provenance-statements
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
Remove `registry-url` from `actions/setup-node` to enable npm OIDC authentication.

## Problem
When `registry-url` is set, `actions/setup-node` creates an `.npmrc` file expecting `NODE_AUTH_TOKEN`. Without that token, npm fails with "Access token expired or revoked".

## Solution
Remove `registry-url` so npm can use OIDC trusted publishers for authentication directly.

## Test plan
- [ ] Merge and verify next release publishes successfully