### PR TITLE
fix: add registry-url for npm OIDC authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,9 +54,10 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-          # Note: NOT using registry-url here to allow npm OIDC authentication
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       # Publishing uses npm's OIDC trusted publishers for authentication.
       # This requires the npm package to be configured to trust this GitHub repository.
       # See: https://docs.npmjs.com/generating-provenance-statements
+      # Note: NODE_AUTH_TOKEN is not needed when using npm trusted publishing with OIDC.
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Adds `registry-url: 'https://registry.npmjs.org'` to the publish-npm job
- npm's OIDC trusted publishing requires the registry URL to be set so npm knows which registry to authenticate with
- Without it, npm doesn't attempt OIDC token exchange and fails with `ENEEDAUTH`

## Background
The previous commit removed `registry-url` thinking it was causing issues, but npm OIDC actually needs it to know where to send the OIDC token for verification.

The `NODE_AUTH_TOKEN` environment variable is NOT required when using npm trusted publishers - npm will automatically use OIDC when `--provenance` is used in a trusted CI environment.

## Test plan
- [ ] Merge this PR
- [ ] Merge the release-please PR that will be created
- [ ] Verify the publish workflow succeeds with OIDC authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)