### PR TITLE
fix: update repository URLs to match actual repo name

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/promptfoo/rouge.git"
+    "url": "git+https://github.com/promptfoo/js-rouge.git"
   },
   "keywords": [
     "ROUGE",
@@ -40,9 +40,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/promptfoo/rouge/issues"
+    "url": "https://github.com/promptfoo/js-rouge/issues"
   },
-  "homepage": "https://github.com/promptfoo/rouge",
+  "homepage": "https://github.com/promptfoo/js-rouge",
   "devDependencies": {
     "@swc/core": "^1.7.12",
     "@swc/jest": "^0.2.36",


### PR DESCRIPTION
## Summary
Updates package.json repository URLs from `promptfoo/rouge` to `promptfoo/js-rouge`.

## Root Cause
npm's provenance verification was failing because the `repository.url` in package.json didn't match the actual repository where the code is hosted:
```
Error verifying sigstore provenance bundle: package.json: "repository.url" is "git+https://github.com/promptfoo/rouge.git", expected to match "https://github.com/promptfoo/js-rouge" from provenance
```

## Changes
- `repository.url`: `promptfoo/rouge` → `promptfoo/js-rouge`
- `bugs.url`: `promptfoo/rouge` → `promptfoo/js-rouge`
- `homepage`: `promptfoo/rouge` → `promptfoo/js-rouge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)