### PR TITLE
fix: correct off-by-one error in treeBankTokenize loop

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,10 +57,9 @@ export function treeBankTokenize(input: string): string[] {
     .replace(/'([sSmMdD]) /g, " '$1 ")
     .replace(/('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) /g, ' $1 ');
 
-  let iterator = -1;
-  while (iterator++ < TREEBANK_CONTRACTIONS.length) {
+  for (let i = 0; i < TREEBANK_CONTRACTIONS.length; i++) {
     // Break uncommon contractions with a space and wrap-in spaces
-    parse = parse.replace(TREEBANK_CONTRACTIONS[iterator], ' $1 $2 ');
+    parse = parse.replace(TREEBANK_CONTRACTIONS[i], ' $1 $2 ');
   }
 
   // Concatenate double spaces and remove start/end spaces


### PR DESCRIPTION
## Summary

- Fixes off-by-one error in `treeBankTokenize` loop that accessed undefined array index
- The `while (iterator++ < length)` pattern caused iteration with index 10 when array only has indices 0-9
- Replaced with standard `for` loop for correct bounds

## Test plan

- [x] All 141 tests pass
- [x] 100% code coverage maintained
- [x] Verified tokenization still works correctly for all contraction patterns