### PR TITLE
fix: apply F-beta formula for all non-negative beta values

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -371,29 +371,35 @@ export function jackKnife(
  * Calculates the ROUGE f-measure for a given precision
  * and recall score.
  *
+ * Uses the standard F-beta formula:
+ * F_β = ((1 + β²) × P × R) / (β² × P + R)
+ *
  * Beta controls the tradeoff between precision and recall:
+ * - beta = 0: Pure precision (F₀ = P)
  * - beta = 1: F1 score (harmonic mean, equal weight)
- * - beta < 1: Favors precision
- * - beta > 1: Favors recall (DUC evaluation style)
+ * - beta = 2: F2 score (weighs recall twice as much as precision)
+ * - beta = Infinity: Pure recall
  *
  * @method fMeasure
- * @param  {number}     p       Precision score
- * @param  {number}     r       Recall score
- * @param  {number}     beta    Weighing value (precision vs. recall).
- *                              Defaults to 0.5 (precision-favoring).
+ * @param  {number}     p       Precision score (0 to 1)
+ * @param  {number}     r       Recall score (0 to 1)
+ * @param  {number}     beta    Weighing value (precision vs. recall). Defaults to 1.0 (F1).
  * @return {number}             Computed f-score
  */
-export function fMeasure(p: number, r: number, beta: number = 0.5): number {
+export function fMeasure(p: number, r: number, beta: number = 1.0): number {
   if (p < 0 || p > 1) throw new RangeError('Precision value p must have bounds 0 ≤ p ≤ 1');
   if (r < 0 || r > 1) throw new RangeError('Recall value r must have bounds 0 ≤ r ≤ 1');
+  if (beta < 0) throw new RangeError('beta value must be >= 0');
 
-  if (beta < 0) {
-    throw new RangeError('beta value must be greater than 0');
-  } else if (0 <= beta && beta <= 1) {
-    return ((1 + beta * beta) * r * p) / (r + beta * beta * p);
-  } else {
-    return r;
-  }
+  // Handle special cases
+  if (p === 0 && r === 0) return 0;
+  if (!Number.isFinite(beta)) return r; // β → ∞ means pure recall
+
+  const betaSq = beta * beta;
+  const denominator = betaSq * p + r;
+  if (denominator === 0) return 0;
+
+  return ((1 + betaSq) * p * r) / denominator;
 }
 
 /**

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -607,11 +607,32 @@ describe('Utility Functions', () => {
       expect(() => fm(0.5, 0.75, -1)).toThrow(RangeError);
     });
 
-    test('should ignore precision when beta > 1', () => {
+    test('should return pure recall when beta is Infinity', () => {
       expect(fm(0.5, 0.75, Infinity)).toBe(0.75);
     });
-    test('should correctly compute DUC score', () => {
+    test('should correctly compute F1 score (beta=1)', () => {
       expect(fm(0.5, 0.75, 1)).toBe(0.6);
+    });
+    test('should correctly compute F2 score (beta=2, favors recall)', () => {
+      // F2 = (1 + 4) * P * R / (4 * P + R) = 5 * 0.5 * 0.75 / (2 + 0.75) = 1.875 / 2.75
+      expect(fm(0.5, 0.75, 2)).toBeCloseTo(1.875 / 2.75, 10);
+    });
+    test('should correctly compute F0.5 score (beta=0.5, favors precision)', () => {
+      // F0.5 = (1 + 0.25) * P * R / (0.25 * P + R) = 1.25 * 0.5 * 0.75 / (0.125 + 0.75)
+      expect(fm(0.5, 0.75, 0.5)).toBeCloseTo((1.25 * 0.5 * 0.75) / 0.875, 10);
+    });
+    test('should return 0 when both precision and recall are 0', () => {
+      expect(fm(0, 0, 1)).toBe(0);
+    });
+    test('should return 0 when precision is 0', () => {
+      expect(fm(0, 0.5, 1)).toBe(0);
+    });
+    test('should return 0 when recall is 0', () => {
+      expect(fm(0.5, 0, 1)).toBe(0);
+    });
+    test('should return 0 when beta=0 and recall=0 (edge case denominator=0)', () => {
+      // When beta=0, denominator = 0*p + r = r. If r=0, denominator=0
+      expect(fm(0.5, 0, 0)).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- Fixes `fMeasure` to apply the standard F-beta formula for all finite `beta >= 0`
- Previously, any `beta > 1` incorrectly returned only recall
- Now correctly computes F2, F0.5, and other beta values
- Updates default beta from 0.5 to 1.0 to match actual usage in ROUGE functions

## Breaking Change

The default `beta` parameter for `fMeasure` changed from `0.5` to `1.0`. However, all ROUGE functions (`n`, `s`, `l`) already explicitly set `beta: 1.0`, so this change only affects direct callers of `fMeasure` who relied on the default.

## Test plan

- [x] All 147 tests pass
- [x] 100% code coverage maintained
- [x] Added tests for F2 score (beta=2)
- [x] Added tests for F0.5 score (beta=0.5)
- [x] Added edge case tests (p=0, r=0, denominator=0)