### PR TITLE
fix: correct ROUGE-L precision and recall calculation

### DIFF
--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -203,8 +203,10 @@ export function l(
     return 0;
   }
 
-  const lcsRecall = lcsSum / candWords.length;
-  const lcsPrec = lcsSum / refWords.length;
+  // Recall = LCS / |reference| (how much of reference is captured)
+  // Precision = LCS / |candidate| (how precise is the candidate)
+  const lcsRecall = lcsSum / refWords.length;
+  const lcsPrec = lcsSum / candWords.length;
 
   return utils.fMeasure(lcsPrec, lcsRecall, options.beta);
 }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -781,6 +781,18 @@ describe('Core Functions', () => {
       // LCS should find matches from both candidate sentences
       expect(score).toBeGreaterThan(0);
     });
+
+    test('should correctly distinguish precision from recall', () => {
+      // Short candidate, long reference - tests that P and R are not swapped
+      // candidate: "the cat" (2 words), reference: "the cat sat" (3 words)
+      // LCS: "the cat" (2 words)
+      // Correct: Recall = 2/3 (ref coverage), Precision = 2/2 = 1 (candidate precision)
+      const shortCand = 'the cat';
+      const longRef = 'the cat sat';
+      // With beta=Infinity (pure recall), should return recall = 2/3
+      const recallScore = l(shortCand, longRef, { beta: Infinity });
+      expect(recallScore).toBeCloseTo(2 / 3, 5);
+    });
   });
 
   describe('caseSensitive option', () => {


### PR DESCRIPTION
## Summary

- Fixes swapped precision and recall in ROUGE-L calculation
- Standard definitions:
  - **Recall** = LCS / |reference| (how much of reference is covered)
  - **Precision** = LCS / |candidate| (how precise is the candidate)
- Previous code divided by the wrong lengths

## Breaking Change

This changes the behavior when using `beta != 1` with ROUGE-L. For `beta = 1` (F1 score), the result is unchanged since F1 is symmetric. For other beta values, results will now be mathematically correct.

## Test plan

- [x] All 142 tests pass
- [x] 100% code coverage maintained
- [x] Added test case with asymmetric candidate/reference lengths
- [x] Verified with `beta=Infinity` to isolate recall value