### PR TITLE
fix: remove duplicate 'sep' entry in ABBR_DATES

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -184,11 +184,10 @@ export const ABBR_DATES: string[] = [
   'jul',
   'aug',
   'sep',
+  'sept',
   'oct',
   'nov',
   'dec',
-  'sept',
-  'sep',
 ];
 
 export const GATE_EXCEPTIONS: string[] = [


### PR DESCRIPTION
## Summary

- Removes duplicate `'sep'` entry from `ABBR_DATES` array in `constants.ts`
- Reorders entries to be in calendar month order

## Test plan

- [x] All 141 tests pass
- [x] 100% code coverage maintained