### PR TITLE
docs: update branch reference from master to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Guidelines for bug reports:
    reported.
 
 2. **Check if the issue has been fixed** &mdash; try to reproduce it using the
-   latest `master` or development branch in the repository.
+   latest `main` branch in the repository.
 
 3. **Isolate the problem** &mdash; create a [reduced test
    case](http://css-tricks.com/6263-reduced-test-cases/) and a live example.


### PR DESCRIPTION
## Summary

- Updates CONTRIBUTING.md to reference `main` branch instead of `master`
- The project's default branch is `main`

## Test plan

- [x] All 141 tests pass
- [x] 100% code coverage maintained