### PR TITLE
docs: add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # js-rouge
 
+[![npm version](https://img.shields.io/npm/v/js-rouge.svg)](https://www.npmjs.com/package/js-rouge)
+[![CI](https://github.com/promptfoo/js-rouge/actions/workflows/ci.yml/badge.svg)](https://github.com/promptfoo/js-rouge/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A JavaScript implementation of the Recall-Oriented Understudy for Gisting Evaluation (ROUGE) evaluation metric for summaries. This package implements the following metrics:
 
 - n-gram (ROUGE-N)


### PR DESCRIPTION
## Summary

Adds status badges to README:

- npm version badge
- CI status badge
- MIT license badge

## Test plan

- [x] All 141 tests pass
- [x] 100% code coverage maintained