### PR TITLE
chore: add promptfoo to LICENSE copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Kenneth Lim
+Copyright (c) 2024 promptfoo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Adds promptfoo as co-copyright holder in LICENSE file
- Original author Kenneth Lim remains credited
- Reflects current project maintenance by promptfoo

## Test plan
- [ ] Verify LICENSE file renders correctly on GitHub
- [ ] Verify npm package includes updated LICENSE