### PR TITLE
docs: clean up CHANGELOG and configure release-please sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,55 +1,75 @@
 # Changelog
 
-## [3.1.5](https://github.com/promptfoo/js-rouge/compare/js-rouge-v3.1.4...js-rouge-v3.1.5) (2025-12-17)
+## [3.1.5](https://github.com/promptfoo/js-rouge/compare/js-rouge-v3.1.0...js-rouge-v3.1.5) (2025-12-17)
 
 ### Bug Fixes
 
 - update repository URLs to match actual repo name ([#44](https://github.com/promptfoo/js-rouge/issues/44)) ([80d6210](https://github.com/promptfoo/js-rouge/commit/80d621059f53db48cc5d3c3dc256abda4a18820d))
 
-## [3.1.4](https://github.com/promptfoo/js-rouge/compare/js-rouge-v3.1.3...js-rouge-v3.1.4) (2025-12-17)
+### Internal
 
-### Bug Fixes
+- 3.1.1–3.1.4 were internal releases fixing npm OIDC publishing and were not published to npm
 
-- use Node 24 for npm OIDC trusted publishing ([#40](https://github.com/promptfoo/js-rouge/issues/40)) ([399398e](https://github.com/promptfoo/js-rouge/commit/399398e3c13e24bc3d19a7b76d027d37afa93109))
+## [3.1.0](https://github.com/promptfoo/js-rouge/compare/3.0.0...js-rouge-v3.1.0) (2025-12-17)
 
-## [3.1.3](https://github.com/promptfoo/js-rouge/compare/js-rouge-v3.1.2...js-rouge-v3.1.3) (2025-12-17)
+### ⚠ BREAKING CHANGES
 
-### Bug Fixes
-
-- add registry-url for npm OIDC authentication ([#38](https://github.com/promptfoo/js-rouge/issues/38)) ([20f0068](https://github.com/promptfoo/js-rouge/commit/20f0068b32edd075f48faab80d0a637dd563dd55))
-
-## [3.1.2](https://github.com/promptfoo/js-rouge/compare/js-rouge-v3.1.1...js-rouge-v3.1.2) (2025-12-17)
-
-### Bug Fixes
-
-- remove registry-url to enable npm OIDC authentication ([#36](https://github.com/promptfoo/js-rouge/issues/36)) ([33b4d38](https://github.com/promptfoo/js-rouge/commit/33b4d38c1c2bb20fb7322c09cfca67b8f6ab31a1))
-
-## [3.1.1](https://github.com/promptfoo/js-rouge/compare/js-rouge-v3.1.0...js-rouge-v3.1.1) (2025-12-17)
-
-### Bug Fixes
-
-- add NODE_AUTH_TOKEN to npm publish step ([9a1bb06](https://github.com/promptfoo/js-rouge/commit/9a1bb06613f027b52f68cbdf0e216eeb2fdbc2c2))
-- use npm OIDC for publish authentication ([#35](https://github.com/promptfoo/js-rouge/issues/35)) ([82dd724](https://github.com/promptfoo/js-rouge/commit/82dd724eebefb81d90ebd58a945121fb533fe76d))
-
-## [3.1.0](https://github.com/promptfoo/js-rouge/compare/js-rouge-v3.0.0...js-rouge-v3.1.0) (2025-12-17)
+- ROUGE-N now returns F-score instead of recall-only. If you were relying on recall-only behavior, you'll need to adjust your code.
+- Default `beta` changed from `Infinity` to `1.0` for balanced F1 score. Pass `beta: Infinity` explicitly to restore recall-only behavior.
 
 ### Features
 
-- add caseSensitive option to all ROUGE functions ([#33](https://github.com/promptfoo/js-rouge/issues/33)) ([996ffbd](https://github.com/promptfoo/js-rouge/commit/996ffbd31b6b30985c64f6a0e1b9671acf41ee82))
-- add maxSkip parameter to ROUGE-S ([#20](https://github.com/promptfoo/js-rouge/issues/20)) ([05d1f3a](https://github.com/promptfoo/js-rouge/commit/05d1f3a39d9ebd2869790573defa44895e245dc2))
-- add skip window (maxSkip) support to ROUGE-S ([05d1f3a](https://github.com/promptfoo/js-rouge/commit/05d1f3a39d9ebd2869790573defa44895e245dc2))
+- add `caseSensitive` option to all ROUGE functions ([#33](https://github.com/promptfoo/js-rouge/issues/33)) ([996ffbd](https://github.com/promptfoo/js-rouge/commit/996ffbd31b6b30985c64f6a0e1b9671acf41ee82))
+- add `maxSkip` parameter to ROUGE-S for controlling skip distance ([#20](https://github.com/promptfoo/js-rouge/issues/20)) ([05d1f3a](https://github.com/promptfoo/js-rouge/commit/05d1f3a39d9ebd2869790573defa44895e245dc2))
 - change default beta to 1.0 for balanced F1 ([#19](https://github.com/promptfoo/js-rouge/issues/19)) ([ccc6615](https://github.com/promptfoo/js-rouge/commit/ccc66159cd50477210fd3c11a6fabab8d73cb1ee))
 - make ROUGE-N return F-score instead of recall ([#18](https://github.com/promptfoo/js-rouge/issues/18)) ([034f52c](https://github.com/promptfoo/js-rouge/commit/034f52cd88e2a5934b8406b72bd238183c177cec))
-- make ROUGE-N return F-score instead of recall-only ([034f52c](https://github.com/promptfoo/js-rouge/commit/034f52cd88e2a5934b8406b72bd238183c177cec))
-- rename package to js-rouge and add npm publish workflow ([0b9394b](https://github.com/promptfoo/js-rouge/commit/0b9394b6ef6fafd6d44f84a8b33998db3bd06c2d))
-- update project structure and modernize tooling ([#1](https://github.com/promptfoo/js-rouge/issues/1)) ([7631ebf](https://github.com/promptfoo/js-rouge/commit/7631ebfc4c0bf01d1e6acc9813e14f67ae8a7273))
 
 ### Bug Fixes
 
-- add exports field to package.json ([#22](https://github.com/promptfoo/js-rouge/issues/22)) ([5f7f3f8](https://github.com/promptfoo/js-rouge/commit/5f7f3f84cf2b127a01d83566dd7f2180bd38d19a))
-- add files field and fix directories in package.json ([#23](https://github.com/promptfoo/js-rouge/issues/23)) ([b18ff71](https://github.com/promptfoo/js-rouge/commit/b18ff716dae0e54a3b18dc0dc6406ec9a0e7621b))
-- align default beta values with documentation ([ccc6615](https://github.com/promptfoo/js-rouge/commit/ccc66159cd50477210fd3c11a6fabab8d73cb1ee))
+- add `exports` field to package.json for ESM/CJS support ([#22](https://github.com/promptfoo/js-rouge/issues/22)) ([5f7f3f8](https://github.com/promptfoo/js-rouge/commit/5f7f3f84cf2b127a01d83566dd7f2180bd38d19a))
+- add `files` field and fix directories in package.json ([#23](https://github.com/promptfoo/js-rouge/issues/23)) ([b18ff71](https://github.com/promptfoo/js-rouge/commit/b18ff716dae0e54a3b18dc0dc6406ec9a0e7621b))
 - correct ROUGE-L union LCS calculation ([#17](https://github.com/promptfoo/js-rouge/issues/17)) ([29a77b6](https://github.com/promptfoo/js-rouge/commit/29a77b62891288514be37d8c4e50bb453f8a4e39))
 - enable ESLint to lint test files ([#25](https://github.com/promptfoo/js-rouge/issues/25)) ([943d185](https://github.com/promptfoo/js-rouge/commit/943d185884028869d69e1ad9a98a94b313afe4b5))
-- make charIsUpperCase i18n-compatible ([#31](https://github.com/promptfoo/js-rouge/issues/31)) ([eca0020](https://github.com/promptfoo/js-rouge/commit/eca0020f0be8e25a442fd2e3e926808af1922316))
-- move workflow ([4f33c5a](https://github.com/promptfoo/js-rouge/commit/4f33c5a5d01f474e5a32e4adb8ade9571dac229f))
+- make `charIsUpperCase` i18n-compatible ([#31](https://github.com/promptfoo/js-rouge/issues/31)) ([eca0020](https://github.com/promptfoo/js-rouge/commit/eca0020f0be8e25a442fd2e3e926808af1922316))
+
+## [3.0.0](https://github.com/promptfoo/js-rouge/releases/tag/3.0.0) (2024-08-19)
+
+This release represents a major modernization of the original [`rouge`](https://www.npmjs.com/package/rouge) package by [Kenneth Lim](https://github.com/kenlimmj). The package has been forked and is now maintained by [promptfoo](https://github.com/promptfoo).
+
+### ⚠ BREAKING CHANGES
+
+- Package renamed from `rouge` to `js-rouge`
+- Rewritten in TypeScript with strict mode
+- Minimum Node.js version: 18.0.0
+- Build output changed from Babel to esbuild
+
+### Features
+
+- Full TypeScript support with bundled type definitions
+- ESM module support alongside CommonJS
+- Dual CJS/ESM package exports
+- Automated CI/CD with GitHub Actions
+- 100% test coverage
+
+### Migration from 2.x
+
+```javascript
+// Before (rouge 2.x)
+const rouge = require('rouge');
+rouge.n(candidate, reference);
+
+// After (js-rouge 3.x)
+const { n, l, s } = require('js-rouge');
+// or
+import { n, l, s } from 'js-rouge';
+n(candidate, reference);
+```
+
+## 2.x and Earlier
+
+Versions 2.0.0, 2.0.1, and earlier were published by the original author [Kenneth Lim](https://github.com/kenlimmj) under the package name `rouge`. See the [original repository](https://github.com/kenlimmj/rouge) for historical changelog.
+
+Key milestones in the original package:
+
+- **2.0.0** – ES6 rewrite with Babel transpilation
+- **1.x** – Initial implementation

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,19 @@
     ".": {
       "release-type": "node",
       "package-name": "js-rouge",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous", "hidden": true },
+        { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Cleans up the CHANGELOG to be more useful for users and configures release-please to generate cleaner changelogs going forward.

### Changes to CHANGELOG.md

- **Remove duplicate entries from 3.1.0** - Same features were listed twice with different wording
- **Consolidate 3.1.1–3.1.4** - These were internal CI iterations fixing npm OIDC publishing and were never published to npm. Added a note instead of cluttering with details.
- **Add proper 3.0.0 section** - Documents the fork from Kenneth Lim's original `rouge` package to promptfoo's `js-rouge`, including migration guide
- **Add historical context for 2.x** - Links to original repository for users coming from the old package
- **Document breaking changes in 3.1.0** - F-score change and beta default change are now properly marked as breaking

### Changes to release-please-config.json

Configure changelog sections to hide internal changes:
- **Visible:** feat, fix, perf, revert
- **Hidden:** docs, chore, refactor, test, ci, build

This keeps the changelog focused on user-facing changes.

## Test plan

- [ ] CHANGELOG.md renders correctly on GitHub
- [ ] release-please config is valid JSON
- [ ] Future releases will use the new section configuration