### PR TITLE
build!: require node 20 and up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [18, 20, 22, 24]
+        node-version: [20, 22, 24]
     steps:
     - uses: actions/checkout@v6
     - name: Verify dist is not committed
@@ -37,3 +37,4 @@ jobs:
         test -f dist/rouge.mjs || (echo "Missing dist/rouge.mjs" && exit 1)
         test -f dist/rouge.d.ts || (echo "Missing dist/rouge.d.ts" && exit 1)
     - run: npm test
+    

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ F_β = ((1 + β²) × P × R) / (β² × P + R)
 
 GitHub Actions runs on push/PR to main:
 
-1. Matrix test: Node 18, 20, 22
+1. Matrix test: Node 20, 22, 24
 2. Format check
 3. Lint check
 4. Build

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "typescript-eslint": "^8.50.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "test": "jest",
     "build": "npm run clean && npm run build:js && npm run build:types",
-    "build:js": "esbuild src/rouge.ts --bundle --minify --sourcemap --platform=node --target=node18 --outfile=dist/rouge.js && esbuild src/rouge.ts --bundle --minify --sourcemap --platform=neutral --format=esm --outfile=dist/rouge.mjs",
+    "build:js": "esbuild src/rouge.ts --bundle --minify --sourcemap --platform=node --target=node20 --outfile=dist/rouge.js && esbuild src/rouge.ts --bundle --minify --sourcemap --platform=neutral --format=esm --outfile=dist/rouge.mjs",
     "build:types": "tsc -p tsconfig.json --emitDeclarationOnly --outDir dist",
     "clean": "rimraf dist",
     "type-check": "tsc --noEmit",
@@ -62,7 +62,7 @@
     "typescript-eslint": "^8.50.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
BREAKING CHANGE:  This library no longer supports node.js 18, and requires node.js 20.x and up.  