### PR TITLE
refactor(ci): add shared ci success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,19 @@ jobs:
           test -f dist/rouge.mjs || (echo "Missing dist/rouge.mjs" && exit 1)
           test -f dist/rouge.d.ts || (echo "Missing dist/rouge.d.ts" && exit 1)
       - run: npm test
+
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    needs: [dependency-review, build]
+    if: always()
+    timeout-minutes: 5
+    permissions:
+      checks: read
+      statuses: read
+    steps:
+      - name: Wait for all PR checks to complete
+        uses: promptfoo/.github/.github/actions/ci-success@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          timeout-seconds: 300


### PR DESCRIPTION
## Summary

- add a `CI Success` job to the existing `CI` workflow
- use the shared first-party action from `promptfoo/.github`
- keep the current dependency-review and matrix build jobs intact

## Test plan

- verify the updated workflow parses and runs on the PR
- confirm `CI Success` waits for dependency review plus the matrix build checks
- after merge, apply the ruleset cutover for this repo