### PR TITLE
docs: clarify agent commit guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ refactor: code change that neither fixes bug nor adds feature
 test: adding or correcting tests
 ```
 
-Do NOT include AI attribution in commits.
+Do not include assistant-specific marketing/provenance text in commit subjects or bodies. If your local tooling requires a commit trailer, keep it in the trailer block only.
 
 ### Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
-# Claude Code Guidelines
+# Compatibility Note
 
-See [AGENTS.md](./AGENTS.md) for all project guidelines and documentation.
+The canonical repository guide is [AGENTS.md](./AGENTS.md).
+
+This file remains as a compatibility shim for tools that still auto-load `CLAUDE.md`.


### PR DESCRIPTION
## Summary

- Relax the blanket "no AI attribution" commit rule so required trailer blocks are allowed.
- Update `CLAUDE.md` to a plain compatibility shim that points to `AGENTS.md`.

## Test plan

- Docs-only change; no tests run.