### PR TITLE
fix: preserve repeated matches in ROUGE-N and ROUGE-S

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ rougeN(candidate, reference, { n: 1 }); // => 1.0
 rougeN(candidate, reference, { n: 2 }); // => 1.0
 
 // With partial match
-rougeN("the cat sat", "the cat sat on the mat", { n: 1 }); // => 0.75
+rougeN("the cat sat", "the cat sat on the mat", { n: 1 }); // => 2/3
 ```
 
 ### ROUGE-L Example
@@ -129,9 +129,13 @@ rougeN("Hello World", "hello world", { caseSensitive: false }); // => 1.0
 | --------------- | -------- | ------------- | ------------------------------------ |
 | `beta`          | number   | `1.0`         | F-measure weight                     |
 | `caseSensitive` | boolean  | `true`        | Whether comparison is case-sensitive |
-| `maxSkip`       | number   | `Infinity`    | Maximum skip distance between words  |
+| `maxSkip`       | number   | `Infinity`    | Maximum token index distance         |
 | `tokenizer`     | function | Penn Treebank | Custom tokenizer function            |
 | `skipBigram`    | function | built-in      | Custom skip-bigram generator         |
+
+`maxSkip` measures the distance between token indices: `1` includes adjacent pairs, and `2` allows one intervening token. A value of `0` produces no pairs. To match a maximum gap of `d` intervening words in the ROUGE paper or Perl implementation, use `maxSkip: d + 1`. The default `Infinity` considers all in-order token pairs.
+
+ROUGE-N and ROUGE-S count repeated matching grams up to the smaller of their frequencies in the candidate and reference. Correcting earlier versions' set-based counting changes scores for repeated grams; rerun evaluation baselines when comparing versions.
 
 ### Limitations
 

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -22,7 +22,7 @@ export interface RougeSOptions {
   beta?: number;
   /** Whether comparison is case-sensitive (default: true) */
   caseSensitive?: boolean;
-  /** Maximum skip distance between words (default: Infinity) */
+  /** Maximum token index distance (1 includes adjacent words; default: Infinity) */
   maxSkip?: number;
   /** Custom skip-bigram generator function */
   skipBigram?: (tokens: string[], maxSkip?: number) => string[];
@@ -42,6 +42,23 @@ export interface RougeLOptions {
   segmenter?: (input: string) => string[];
   /** Custom string tokenizer */
   tokenizer?: (input: string) => string[];
+}
+
+function countMatchingGrams(candidate: string[], reference: string[]): number {
+  const remaining = new Map<string, number>();
+  for (const gram of reference) {
+    remaining.set(gram, (remaining.get(gram) ?? 0) + 1);
+  }
+
+  let matches = 0;
+  for (const gram of candidate) {
+    const count = remaining.get(gram) ?? 0;
+    if (count > 0) {
+      matches++;
+      remaining.set(gram, count - 1);
+    }
+  }
+  return matches;
 }
 
 /**
@@ -91,14 +108,14 @@ export function n(cand: string, ref: string, opts?: RougeNOptions): number {
   const candGrams = options.nGram(options.tokenizer(candText), options.n);
   const refGrams = options.nGram(options.tokenizer(refText), options.n);
 
-  const match = utils.intersection(candGrams, refGrams);
+  const matches = countMatchingGrams(candGrams, refGrams);
 
-  if (match.length === 0) {
+  if (matches === 0) {
     return 0;
   }
 
-  const precision = match.length / candGrams.length;
-  const recall = match.length / refGrams.length;
+  const precision = matches / candGrams.length;
+  const recall = matches / refGrams.length;
 
   return utils.fMeasure(precision, recall, options.beta);
 }
@@ -111,7 +128,7 @@ export function n(cand: string, ref: string, opts?: RougeNOptions): number {
  * {
  * 	beta: 1.0                           // The beta value used for the f-measure
  * 	caseSensitive: true                 // Whether comparison is case-sensitive
- * 	maxSkip: Infinity                   // Maximum skip distance between words
+ * 	maxSkip: Infinity                   // Maximum token index distance
  * 	skipBigram: <inbuilt function>,     // The skip-bigram generator function
  * 	tokenizer: <inbuilt function>       // The string tokenizer
  * }
@@ -150,7 +167,7 @@ export function s(cand: string, ref: string, opts?: RougeSOptions): number {
   const candGrams = options.skipBigram(options.tokenizer(candText), options.maxSkip);
   const refGrams = options.skipBigram(options.tokenizer(refText), options.maxSkip);
 
-  const skip2 = utils.intersection(candGrams, refGrams).length;
+  const skip2 = countMatchingGrams(candGrams, refGrams);
 
   if (skip2 === 0) {
     return 0;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -256,7 +256,7 @@ export const fact = memoize(factRec);
  *
  * @method skipBigram
  * @param  {Array<string>}    tokens      An array of word tokens
- * @param  {number}           maxSkip     Maximum skip distance between words. Defaults to Infinity (all pairs).
+ * @param  {number}           maxSkip     Maximum token index distance; 1 includes adjacent words. Defaults to Infinity (all pairs).
  * @return {Array<string>}                An array of skip bigram strings
  */
 export function skipBigram(tokens: string[], maxSkip: number = Number.POSITIVE_INFINITY): string[] {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -95,6 +95,9 @@ describe('Utility Functions', () => {
     test('should return ["2", "3"] for ["1", "2", "3"] and ["2", "3", "6"]', () => {
       expect(ins(['1', '2', '3'], ['2', '3', '6'])).toEqual(['2', '3']);
     });
+    test('should retain set semantics for repeated elements', () => {
+      expect(ins(['a', 'a', 'b'], ['a', 'a', 'a'])).toEqual(['a']);
+    });
     test('should return ["1", "2", "3"] for ["1", "2", "3"] and ["1", "2", "3", "6"]', () => {
       expect(ins(['1', '2', '3'], ['1', '2', '3', '6'])).toEqual(['1', '2', '3']);
     });
@@ -727,6 +730,32 @@ describe('Core Functions', () => {
       expect(n(cand, refs[1], { n: 2, beta: 1 })).toBe(0);
     });
 
+    test.each<[number, string]>([
+      [1, 'the cat sat on the mat'],
+      [2, 'a b a b'],
+      [3, 'a b a b a'],
+    ])('should give repeated %i-gram identity a perfect score', (size, text) => {
+      expect(n(text, text, { n: size })).toBe(1);
+    });
+
+    test('should count each matching occurrence up to the reference frequency', () => {
+      expect(n('a a a b', 'a a b b')).toBeCloseTo(3 / 4);
+    });
+
+    test.each([
+      [0, 2 / 3],
+      [1, 4 / 5],
+      [Number.POSITIVE_INFINITY, 1],
+    ])('should clip repeated matches with beta=%s', (beta, expected) => {
+      expect(n('a a a', 'a a', { beta })).toBeCloseTo(expected);
+    });
+
+    test('should count repeated grams from custom tokenizer and ngram callbacks', () => {
+      const tokenizer = (text: string): string[] => text.split('');
+      const nGram = (tokens: string[]): string[] => tokens;
+      expect(n('aaa', 'aa', { tokenizer, nGram })).toBeCloseTo(4 / 5);
+    });
+
     test('should correctly compute ROUGE-N score with custom beta', () => {
       // With beta=0, F-score equals precision
       // 3 matching bigrams out of 4 candidate bigrams = 3/4
@@ -762,6 +791,30 @@ describe('Core Functions', () => {
     });
     test('should correctly compute ROUGE-S score for cand 3 with different opts', () => {
       expect(s(cands[2], ref, { beta: 1 })).toBe(1 / 3);
+    });
+
+    test.each([
+      1,
+      2,
+      Number.POSITIVE_INFINITY,
+    ])('should give repeated skip-bigram identity a perfect score with maxSkip=%s', (maxSkip) => {
+      expect(s('a a a', 'a a a', { maxSkip })).toBe(1);
+    });
+
+    test.each([
+      [0, 1 / 2],
+      [1, 2 / 3],
+      [Number.POSITIVE_INFINITY, 1],
+    ])('should clip repeated skip-bigram matches with beta=%s', (beta, expected) => {
+      expect(s('a a a a', 'a a a', { beta })).toBeCloseTo(expected);
+    });
+
+    test('should use the bounded skip-bigram counts as denominators', () => {
+      expect(s('a a a a', 'a a a', { maxSkip: 2 })).toBeCloseTo(3 / 4);
+    });
+
+    test('should preserve the zero-window behavior', () => {
+      expect(s('a b', 'a b', { maxSkip: 0 })).toBe(0);
     });
 
     test('should respect maxSkip option', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -793,11 +793,7 @@ describe('Core Functions', () => {
       expect(s(cands[2], ref, { beta: 1 })).toBe(1 / 3);
     });
 
-    test.each([
-      1,
-      2,
-      Number.POSITIVE_INFINITY,
-    ])('should give repeated skip-bigram identity a perfect score with maxSkip=%s', (maxSkip) => {
+    test.each([1, 2, Number.POSITIVE_INFINITY])('should count repeats at window %s', (maxSkip) => {
       expect(s('a a a', 'a a a', { maxSkip })).toBe(1);
     });
 


### PR DESCRIPTION
## Summary

ROUGE-N and ROUGE-S used set intersection for their numerators while their denominators counted every gram occurrence. Identical inputs containing repeated grams could therefore score below 1.

Count matching occurrences with a frequency budget, clipping each gram at its reference count. The shared helper is private; the exported `intersection()` function retains its documented set behavior. Tokenization, custom generators, beta weighting, and skip-window behavior are unchanged.

The README now fixes the partial-match arithmetic, documents the existing `maxSkip` convention and its translation to the paper/Perl gap parameter, and notes that repeated-gram score baselines change.

## Verification

- Added 17 focused tests; 15 failed before the fix and all 167 tests pass afterward.
- All 11,044 controlled N/S comparisons match the original Perl scoring counts: 3,844 ROUGE-1, 3,600 ROUGE-2, and 3,600 ROUGE-S cases. N was also cross-checked against Google's scoring code during the audit.
- Build, type-check, Biome CI check, and `git diff --check` pass locally.
- Local tools are a snapshot of the existing installation. The pinned Biome/Prettier downloads were blocked by Socket policy, so local checks used Biome 2.4.15 and Prettier 3.8.3; GitHub CI validates the committed lockfile. No package manifest or lockfile changes are included.

## Scope and rollout

This is the N/S counting PR from the four-part correctness audit. ROUGE-L, text preprocessing, and sentence-scanning performance are handled separately. There are no new runtime dependencies or public API changes. Scores for repeated grams intentionally change; rerun evaluation baselines when comparing versions.

## Combined validation

Related fixes: #116 (N/S overlap), #117 (summary LCS), #118 (preprocessing), and #119 (boundary-scan performance). Each targets `main` independently. The final heads merge cleanly together in that order in an isolated checkout.

That combined checkout passes 227 tests, all 16,652 controlled reference-score comparisons, and all 18 original audit regressions. An additional 500-input smoke check verified CJS/ESM parity, perfect self-scores, and bounded scores. Build, type-check, and local formatting checks also pass. This is local integration evidence, not a claim that any PR has been merged or released.
