### PR TITLE
fix: correct summary-level ROUGE-L scoring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ js-rouge is a TypeScript implementation of ROUGE (Recall-Oriented Understudy for
 ```
 src/
 ├── rouge.ts      # Main API: n(), s(), l() functions
+├── lcs.ts        # Internal position-aware LCS implementation
 ├── utils.ts      # Utility functions: tokenization, LCS, n-grams, etc.
 └── constants.ts  # NLP constants: abbreviations, contractions, etc.
 
@@ -95,13 +96,7 @@ Returns F-score using precision and recall:
 
 ### ROUGE-L
 
-Uses summary-level LCS with union across sentence pairs:
-
-```typescript
-const lcsUnion = new Set(
-  candSents.flatMap((c) => options.lcs(options.tokenizer(c), rTokens)),
-);
-```
+Uses summary-level LCS with a union of matched reference-token positions across candidate sentences. Each reference position counts once, and a remaining candidate-token budget prevents reuse across reference sentences. Compute match counts and denominators from the same sentence-token arrays, and apply case folding only after sentence segmentation. The public `lcs()` utility continues to return token values.
 
 ### ROUGE-S
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ const candidate = "police kill the gunman";
 rougeL(candidate, reference); // => 0.75
 ```
 
+`l()` computes summary-level union LCS (called `rougeLsum` in Google's ROUGE package). It unions matched reference-token positions across candidate sentences and clips credit to the candidate's token counts. Sentence tokenization supplies both the matches and their denominators. Case-insensitive comparison preserves sentence boundaries by applying case folding after segmentation.
+
+The exported `lcs(a, b)` utility still returns token values. A custom `lcs` callback must return an ordered token subsequence; its values are aligned to successive reference occurrences from left to right. The built-in implementation retains the exact reference positions from its LCS alignment.
+
+These corrections change ROUGE-L scores for repeated words and multi-sentence summaries. Rerun evaluation baselines when comparing versions.
+
 ### ROUGE-S Example
 
 ```javascript

--- a/src/lcs.ts
+++ b/src/lcs.ts
@@ -1,0 +1,33 @@
+/** Returns the positions in b matched by a longest common subsequence of a and b. */
+export function lcsIndices(a: string[], b: string[]): number[] {
+  if (a.length === 0 || b.length === 0) {
+    return [];
+  }
+
+  const dp: number[][] = new Array(a.length + 1).fill(0).map(() => new Array(b.length + 1).fill(0));
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  const indices: number[] = [];
+  let i = a.length;
+  let j = b.length;
+  while (i > 0 && j > 0) {
+    if (a[i - 1] === b[j - 1]) {
+      indices.push(j - 1);
+      i--;
+      j--;
+    } else if (dp[i - 1][j] > dp[i][j - 1]) {
+      i--;
+    } else {
+      j--;
+    }
+  }
+  return indices.reverse();
+}

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -1,3 +1,4 @@
+import { lcsIndices } from './lcs';
 import * as utils from './utils';
 
 export * from './utils';
@@ -36,7 +37,7 @@ export interface RougeLOptions {
   beta?: number;
   /** Whether comparison is case-sensitive (default: true) */
   caseSensitive?: boolean;
-  /** Custom LCS function */
+  /** Custom LCS function returning an ordered token subsequence */
   lcs?: (a: string[], b: string[]) => string[];
   /** Custom sentence segmenter */
   segmenter?: (input: string) => string[];
@@ -169,7 +170,7 @@ export function s(cand: string, ref: string, opts?: RougeSOptions): number {
  * {
  * 	beta: 1.0                           // The beta value used for the f-measure
  * 	caseSensitive: true                 // Whether comparison is case-sensitive
- * 	lcs: <inbuilt function>             // The least common subsequence function
+ * 	lcs: <inbuilt function>             // The longest common subsequence function
  * 	segmenter: <inbuilt function>,      // The sentence segmenter
  * 	tokenizer: <inbuilt function>       // The string tokenizer
  * }
@@ -203,36 +204,69 @@ export function l(cand: string, ref: string, opts?: RougeLOptions): number {
     ...opts,
   };
 
-  const candText = options.caseSensitive ? cand : cand.toLowerCase();
-  const refText = options.caseSensitive ? ref : ref.toLowerCase();
+  const tokenizeSentence = (sentence: string): string[] =>
+    options.tokenizer(options.caseSensitive ? sentence : sentence.toLowerCase());
+  const candSents = options.segmenter(cand).map(tokenizeSentence);
+  const refSents = options.segmenter(ref).map(tokenizeSentence);
 
-  const candSents = options.segmenter(candText);
-  const refSents = options.segmenter(refText);
-
-  const candWords = options.tokenizer(candText);
-  const refWords = options.tokenizer(refText);
-
-  const lcsAcc = refSents.map((r) => {
-    const rTokens = options.tokenizer(r);
-    const lcsUnion = new Set(candSents.flatMap((c) => options.lcs(options.tokenizer(c), rTokens)));
-
-    return lcsUnion.size;
-  });
-
-  // Sum the array as quickly as we can
-  let lcsSum = 0;
-  while (lcsAcc.length > 0) {
-    lcsSum += lcsAcc.pop() || 0;
+  const remaining = new Map<string, number>();
+  let candLength = 0;
+  for (const sentence of candSents) {
+    for (const token of sentence) {
+      candLength++;
+      remaining.set(token, (remaining.get(token) ?? 0) + 1);
+    }
   }
+  const refLength = refSents.reduce((total, sentence) => total + sentence.length, 0);
 
-  if (lcsSum === 0) {
+  if (candLength === 0 || refLength === 0) {
     return 0;
   }
 
-  // Recall = LCS / |reference| (how much of reference is captured)
-  // Precision = LCS / |candidate| (how precise is the candidate)
-  const lcsRecall = lcsSum / refWords.length;
-  const lcsPrec = lcsSum / candWords.length;
+  let matches = 0;
+  for (const reference of refSents) {
+    const union = new Set<number>();
+    for (const candidate of candSents) {
+      for (const index of matchedReferenceIndices(candidate, reference, options.lcs)) {
+        union.add(index);
+      }
+    }
 
-  return utils.fMeasure(lcsPrec, lcsRecall, options.beta);
+    // Each reference position counts once, and candidate occurrences cannot be reused.
+    for (const index of union) {
+      const token = reference[index];
+      const count = remaining.get(token) ?? 0;
+      if (count > 0) {
+        matches++;
+        remaining.set(token, count - 1);
+      }
+    }
+  }
+
+  if (matches === 0) {
+    return 0;
+  }
+  return utils.fMeasure(matches / candLength, matches / refLength, options.beta);
+}
+
+function matchedReferenceIndices(
+  candidate: string[],
+  reference: string[],
+  getLcs: (a: string[], b: string[]) => string[],
+): number[] {
+  if (getLcs === utils.lcs) {
+    return lcsIndices(candidate, reference);
+  }
+
+  // The public callback returns values, so align them to successive reference occurrences.
+  const indices: number[] = [];
+  let next = 0;
+  for (const token of getLcs(candidate, reference)) {
+    const index = reference.indexOf(token, next);
+    if (index !== -1) {
+      indices.push(index);
+      next = index + 1;
+    }
+  }
+  return indices;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { GATE_EXCEPTIONS, GATE_SUBSTITUTIONS, TREEBANK_CONTRACTIONS } from './constants';
+import { lcsIndices } from './lcs';
 
 /**
  * Splits a sentence into an array of word tokens
@@ -469,46 +470,11 @@ export function intersection<T>(a: T[], b: T[]): T[] {
  * This function returns the elements from the two arrays
  * that form the LCS, in order of their appearance.
  *
- * For speed, the search-space is pruned by eliminating
- * common entities at the start and end of both input arrays.
- *
  * @method lcs
  * @param  {Array<string>}    a     The first array
  * @param  {Array<string>}    b     The second array
  * @return {Array<string>}          The longest common subsequence between the first and second array
  */
 export function lcs(a: string[], b: string[]): string[] {
-  if (a.length === 0 || b.length === 0) {
-    return [];
-  }
-
-  const dp: number[][] = new Array(a.length + 1).fill(0).map(() => new Array(b.length + 1).fill(0));
-
-  for (let i = 1; i <= a.length; i++) {
-    for (let j = 1; j <= b.length; j++) {
-      if (a[i - 1] === b[j - 1]) {
-        dp[i][j] = dp[i - 1][j - 1] + 1;
-      } else {
-        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
-      }
-    }
-  }
-
-  const lcsResult: string[] = [];
-  let i = a.length;
-  let j = b.length;
-
-  while (i > 0 && j > 0) {
-    if (a[i - 1] === b[j - 1]) {
-      lcsResult.unshift(a[i - 1]);
-      i--;
-      j--;
-    } else if (dp[i - 1][j] > dp[i][j - 1]) {
-      i--;
-    } else {
-      j--;
-    }
-  }
-
-  return lcsResult;
+  return lcsIndices(a, b).map((index) => b[index]);
 }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -122,6 +122,9 @@ describe('Utility Functions', () => {
     test('should return ["2", "3"] for ["1", "2", "3"] and ["2", "3", "5"]', () => {
       expect(lcs(['1', '2', '3'], ['2', '3', '5'])).toEqual(['2', '3']);
     });
+    test('should preserve its choice when multiple longest subsequences exist', () => {
+      expect(lcs(['a', 'b'], ['b', 'a'])).toEqual(['b']);
+    });
     test('should return ["w1", "w3", "w5"] for ["w1", "w2", "w3", "w4", "w5"] and ["w1", "w3", "w8", "w9", "w5"]', () => {
       expect(lcs(['w1', 'w2', 'w3', 'w4', 'w5'], ['w1', 'w3', 'w8', 'w9', 'w5'])).toEqual([
         'w1',
@@ -796,23 +799,79 @@ describe('Core Functions', () => {
       expect(l(cands[2], ref, { beta: 1 })).toBe(2 / 4);
     });
 
+    const identitySummaries = ['a a a', 'the cat sat on the mat', 'Alpha. Beta.'];
+    test.each(identitySummaries)('should give identical summaries a perfect score: %s', (text) => {
+      expect(l(text, text)).toBe(1);
+    });
+
+    test('should union reference positions instead of repeated token values', () => {
+      const tokenizer = (text: string): string[] => text.split(/[| ]+/);
+      const segmenter = (text: string): string[] => text.split('|');
+      expect(l('a b|a', 'a b a', { tokenizer, segmenter })).toBe(1);
+    });
+
+    test('should credit each reference position only once across candidate sentences', () => {
+      const tokenizer = (text: string): string[] => text.split(/[| ]+/);
+      const segmenter = (text: string): string[] => text.split('|');
+      expect(l('a|a', 'a b', { tokenizer, segmenter })).toBeCloseTo(1 / 2);
+    });
+
+    test.each([
+      ['cat dog fish', 2 / 5],
+      ['cat', 2 / 3],
+    ] as const)('should clip candidate reuse: %s', (text, expected) => {
+      const tokenizer = (input: string): string[] => input.match(/[A-Za-z]+/g) || [];
+      expect(l(text, 'cat. cat.', { tokenizer })).toBeCloseTo(expected);
+    });
+
+    test.each([true, false])('keeps boundaries with caseSensitive=%s', (caseSensitive) => {
+      const tokenizer = (text: string): string[] => text.match(/[A-Za-z]+/g) || [];
+      const first = 'Alpha works at Acme Co. Beta sleeps near Luna Inc.';
+      const second = 'Beta sleeps near Luna Inc. Alpha works at Acme Co.';
+      expect(l(first, second, { tokenizer, caseSensitive })).toBe(1);
+    });
+
+    test('should preserve custom callbacks and normalize only after segmentation', () => {
+      const segmenter = jest.fn((text: string): string[] => text.split('|'));
+      const tokenizer = jest.fn((text: string): string[] => text.split(' '));
+      const customLcs = jest.fn((a: string[], b: string[]): string[] => rouge.lcs(a, b));
+      expect(
+        l('A A|B', 'A A B', { segmenter, tokenizer, lcs: customLcs, caseSensitive: false }),
+      ).toBe(1);
+      expect(segmenter).toHaveBeenCalledWith('A A|B');
+      expect(tokenizer).toHaveBeenCalledWith('a a');
+      expect(customLcs).toHaveBeenCalledWith(['a', 'a'], ['a', 'a', 'b']);
+    });
+
+    test('should use the subsequence selected by a custom LCS callback', () => {
+      const customLcs = (): string[] => ['b'];
+      expect(l('a b', 'a b', { lcs: customLcs })).toBeCloseTo(1 / 2);
+    });
+
+    test('should preserve repeated occurrences returned by a custom LCS callback', () => {
+      const customLcs = (): string[] => ['a', 'a'];
+      expect(l('a a a', 'a a', { lcs: customLcs })).toBeCloseTo(4 / 5);
+    });
+
+    test('should return zero when custom tokenization removes every token', () => {
+      expect(l('a', 'b', { tokenizer: () => [] })).toBe(0);
+    });
+
     test('should compute union LCS across all candidate sentences', () => {
-      // This test verifies the fix for the Set spread bug
-      // Multiple candidate sentences should all contribute to the LCS union
       const multiSentCand = 'The cat sat. The dog ran. The bird flew.';
       const multiSentRef = 'The cat sat on the mat.';
       const score = l(multiSentCand, multiSentRef, { beta: 1 });
-      // All three candidate sentences have "The" which should contribute
-      expect(score).toBeGreaterThan(0);
+      // Four matched reference positions, twelve candidate tokens, seven reference tokens.
+      expect(score).toBeCloseTo(8 / 19);
     });
 
     test('should handle multi-sentence summaries correctly', () => {
       // Candidate has words spread across multiple sentences
       const cand = 'Police arrived. They killed the gunman.';
       const reference = 'police killed the gunman';
-      const score = l(cand, reference, { beta: 1 });
+      const score = l(cand, reference, { beta: 1, caseSensitive: false });
       // LCS should find matches from both candidate sentences
-      expect(score).toBeGreaterThan(0);
+      expect(score).toBeCloseTo(2 / 3);
     });
 
     test('should correctly distinguish precision from recall', () => {


### PR DESCRIPTION
## Summary

Fix summary-level ROUGE-L accounting so repeated words retain their individual matches and ordinary multi-sentence summaries have consistent numerator/denominator token counts. A shared internal LCS routine retains reference positions; the public `lcs(a, b)` utility keeps its string-array return type and existing tie-breaking behavior.

Reference-position unions prevent duplicate credit within a reference sentence. A remaining candidate-token budget prevents reuse across reference sentences. Sentence tokenization supplies both the matches and total lengths, and case folding happens after segmentation so case-insensitive comparison does not erase sentence boundaries.

The custom LCS callback signature is unchanged. Its returned token values are aligned to successive reference occurrences from left to right, as documented; the built-in matcher uses its exact matched indices. No internal position helper is added to the public exports.

## Verification

- Added 14 targeted tests. Nine initial regression assertions failed before the fix; all 164 tests pass afterward.
- Strengthened the existing multi-sentence tests from nonzero checks to exact expected scores.
- All 5,608 controlled L comparisons match the original Perl reference counts: 3,844 single-sentence and 1,764 summary-union cases, with the oracle also checked against Google's `rougeLsum` implementation.
- All 3,969 short-input comparisons preserve the public `lcs()` utility's exact returned values, including tie cases. Public exports are unchanged.
- Build, type-check, local Biome CI check, and `git diff --check` pass.
- Local tools are a snapshot of the existing installation. Socket policy blocked pinned formatter downloads, so local checks used Biome 2.4.15 and Prettier 3.8.3; remote CI validates the committed lockfile. No dependency files changed.

## Scope and rollout

This is the ROUGE-L PR from the four-part correctness audit. N/S counting, tokenizer/segmenter edge cases, and sentence-scanning performance are separate. The README and agent guidance now describe position-based summary LCS and the score-baseline impact. There are no runtime dependencies or public signature changes. Repeated-word and multi-sentence evaluation baselines should be rerun when comparing versions.

## Combined validation

Related fixes: #116 (N/S overlap), #117 (summary LCS), #118 (preprocessing), and #119 (boundary-scan performance). Each targets `main` independently. The final heads merge cleanly together in that order in an isolated checkout.

That combined checkout passes 227 tests, all 16,652 controlled reference-score comparisons, and all 18 original audit regressions. An additional 500-input smoke check verified CJS/ESM parity, perfect self-scores, and bounded scores. Build, type-check, and local formatting checks also pass. This is local integration evidence, not a claim that any PR has been merged or released.
