### PR TITLE
fix: correct tokenization and sentence preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,16 @@ rougeN("Hello World", "hello world", { caseSensitive: false }); // => 1.0
 | `tokenizer`     | function | Penn Treebank | Custom tokenizer function            |
 | `skipBigram`    | function | built-in      | Custom skip-bigram generator         |
 
+### Text Preprocessing
+
+The default tokenizer treats spaces, tabs, line breaks, and other whitespace as word separators. It returns no tokens for whitespace-only text and expands every occurrence of supported contractions. Punctuation remains part of the token stream.
+
+The default sentence segmenter handles LF, CRLF, and CR line endings and ignores blank separator chunks. Abbreviations such as `e.g.` are matched literally, and sentences ending in an initial or acronym are retained even when the following fragment has no punctuation.
+
+The scoring functions reject empty or whitespace-only candidate/reference summaries with `RangeError`. Existing minimum-token requirements still apply: ROUGE-N needs at least `n` tokens, and ROUGE-S needs at least two. The standalone `sentenceSegment` utility retains its single-sentence fallback for whitespace-only input.
+
+These preprocessing corrections can change scores for affected inputs. Keep the same tokenizer and segmenter configuration when comparing evaluation runs across versions.
+
 ### Limitations
 
 - **English-centric tokenizer**: The default Penn Treebank tokenizer is designed for English text. For other languages, provide a custom `tokenizer` function that appropriately segments text in your target language.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ rougeN("Hello World", "hello world"); // => 0 (no match)
 rougeN("Hello World", "hello world", { caseSensitive: false }); // => 1.0
 ```
 
+### Text Preprocessing
+
+The default tokenizer treats spaces, tabs, line breaks, and other whitespace as word separators. It returns no tokens for whitespace-only text and expands every occurrence of supported contractions. Punctuation remains part of the token stream.
+
+The default sentence segmenter handles LF, CRLF, and CR line endings and ignores blank separator chunks. Abbreviations such as `e.g.` are matched literally, and sentences ending in an initial or acronym are retained even when the following fragment has no punctuation.
+
+The scoring functions reject empty or whitespace-only candidate/reference summaries with `RangeError`. Existing minimum-token requirements still apply: ROUGE-N needs at least `n` tokens, and ROUGE-S needs at least two. The standalone `sentenceSegment` utility retains its single-sentence fallback for whitespace-only input.
+
+These preprocessing corrections can change scores for affected inputs. Keep the same tokenizer and segmenter configuration when comparing evaluation runs across versions.
+
 ## Options
 
 ### ROUGE-N Options
@@ -132,16 +142,6 @@ rougeN("Hello World", "hello world", { caseSensitive: false }); // => 1.0
 | `maxSkip`       | number   | `Infinity`    | Maximum skip distance between words  |
 | `tokenizer`     | function | Penn Treebank | Custom tokenizer function            |
 | `skipBigram`    | function | built-in      | Custom skip-bigram generator         |
-
-### Text Preprocessing
-
-The default tokenizer treats spaces, tabs, line breaks, and other whitespace as word separators. It returns no tokens for whitespace-only text and expands every occurrence of supported contractions. Punctuation remains part of the token stream.
-
-The default sentence segmenter handles LF, CRLF, and CR line endings and ignores blank separator chunks. Abbreviations such as `e.g.` are matched literally, and sentences ending in an initial or acronym are retained even when the following fragment has no punctuation.
-
-The scoring functions reject empty or whitespace-only candidate/reference summaries with `RangeError`. Existing minimum-token requirements still apply: ROUGE-N needs at least `n` tokens, and ROUGE-S needs at least two. The standalone `sentenceSegment` utility retains its single-sentence fallback for whitespace-only input.
-
-These preprocessing corrections can change scores for affected inputs. Keep the same tokenizer and segmenter configuration when comparing evaluation runs across versions.
 
 ### Limitations
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,14 +1,14 @@
 export const TREEBANK_CONTRACTIONS: RegExp[] = [
-  /\b(can)(not)\b/i,
-  /\b(d)('ye)\b/i,
-  /\b(gim)(me)\b/i,
-  /\b(gon)(na)\b/i,
-  /\b(got)(ta)\b/i,
-  /\b(lem)(me)\b/i,
-  /\b(more)('n)\b/i,
-  /\b(wan)(na) /i,
-  / ('t)(is)\b/i,
-  / ('t)(was)\b/i,
+  /\b(can)(not)\b/gi,
+  /\b(d)('ye)\b/gi,
+  /\b(gim)(me)\b/gi,
+  /\b(gon)(na)\b/gi,
+  /\b(got)(ta)\b/gi,
+  /\b(lem)(me)\b/gi,
+  /\b(more)('n)\b/gi,
+  /\b(wan)(na) /gi,
+  / ('t)(is)\b/gi,
+  / ('t)(was)\b/gi,
 ];
 
 export const HONORIFICS: string[] = [

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -68,10 +68,10 @@ export interface RougeLOptions {
  * @return {number}                 The ROUGE-N F-score
  */
 export function n(cand: string, ref: string, opts?: RougeNOptions): number {
-  if (cand.length === 0) {
+  if (cand.trim().length === 0) {
     throw new RangeError('Candidate cannot be an empty string');
   }
-  if (ref.length === 0) {
+  if (ref.trim().length === 0) {
     throw new RangeError('Reference cannot be an empty string');
   }
 
@@ -127,10 +127,10 @@ export function n(cand: string, ref: string, opts?: RougeNOptions): number {
  * @return {number}                 The ROUGE-S score
  */
 export function s(cand: string, ref: string, opts?: RougeSOptions): number {
-  if (cand.length === 0) {
+  if (cand.trim().length === 0) {
     throw new RangeError('Candidate cannot be an empty string');
   }
-  if (ref.length === 0) {
+  if (ref.trim().length === 0) {
     throw new RangeError('Reference cannot be an empty string');
   }
 
@@ -186,10 +186,10 @@ export function s(cand: string, ref: string, opts?: RougeSOptions): number {
  * @return {number}                 The ROUGE-L score
  */
 export function l(cand: string, ref: string, opts?: RougeLOptions): number {
-  if (cand.length === 0) {
+  if (cand.trim().length === 0) {
     throw new RangeError('Candidate cannot be an empty string');
   }
-  if (ref.length === 0) {
+  if (ref.trim().length === 0) {
     throw new RangeError('Reference cannot be an empty string');
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -129,8 +129,8 @@ export function sentenceSegment(input: string): string[] {
         if (chunks[idx + 1] && strIsTitleCase(chunks[idx])) {
           // Catch line breaks embedded within valid sentences
           // i.e. sentences that start with a capital letter
-          // and merge them with a delimiting space
-          chunks[idx + 1] = `${chunks[idx].trim()} ${chunks[idx + 1].replace(/ +/g, ' ')}`;
+          // and normalize every wrap before reprocessing the joined chunk.
+          chunks[idx + 1] = `${chunks[idx]} ${chunks[idx + 1]}`.trim().replace(/\s+/g, ' ');
         } else {
           // Assume that all other embedded line breaks are
           // valid sentence breakpoints

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -101,12 +101,7 @@ export function sentenceSegment(input: string): string[] {
     return [];
   }
 
-  // Split sentences naively based on common terminals (.?!")
-  // Pattern uses a "tempered greedy token" to avoid ReDoS:
-  // - (?:[^.?!\r\n]|[.?!](?!\s|$|"))* matches any char except newlines, OR a terminator NOT at a boundary
-  // - [^.?!\r\n] excludes newlines to match original behavior (JS regex . doesn't match newlines)
-  // - This allows matching through "U.S.A." and "$100.00" without polynomial backtracking
-  // - [.?!]{1,3} limits consecutive terminators (e.g., "!!", "?!", "...") to prevent ReDoS
+  // Keep captured sentences and unmatched separators for the rules below.
   const chunks = input.split(/(\S(?:[^.?!\r\n]|[.?!](?!\s|$|"))*[.?!]{1,3})(?=\s|$|")/g);
 
   const acc: string[] = [];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -160,19 +160,20 @@ export function sentenceSegment(input: string): string[] {
           // Catch small-letter abbreviations and merge them.
           chunks[idx + 1] = `${chunks[idx]} ${chunks[idx + 1].replace(/ +/g, ' ')}`;
         } else {
-          // The next sentence may be a captured chunk or an unterminated tail.
-          const nextIdx = chunks[idx + 2] ? idx + 2 : idx + 1;
+          const nextSentence = chunks[idx + 2];
           const previousWord = words.at(-2);
-          if (previousWord && strIsTitleCase(previousWord) && strIsTitleCase(chunks[nextIdx])) {
+          if (
+            nextSentence &&
+            previousWord &&
+            strIsTitleCase(previousWord) &&
+            strIsTitleCase(nextSentence)
+          ) {
             // Catch name abbreviations (e.g. Albert I. Jones) by checking if
-            // the previous and next words are all capitalized.
-            const suffix =
-              nextIdx === idx + 2
-                ? chunks[idx + 1].replace(/ +/g, ' ') + chunks[nextIdx]
-                : ` ${chunks[nextIdx].trim()}`;
-            chunks[nextIdx] = chunks[idx] + suffix;
+            // the previous and next words are all capitalized. Normalize line
+            // wrapping in the separator so it cannot split the joined name again.
+            chunks[idx + 2] = chunks[idx] + chunks[idx + 1].replace(/\s+/g, ' ') + nextSentence;
           } else {
-            // Assume that remaining entities are indeed end-of-sentence markers.
+            // Retain a boundary for other entities and unterminated final fragments.
             acc.push(chunks[idx]);
             chunks[idx] = '';
           }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,7 +18,9 @@ import { GATE_EXCEPTIONS, GATE_SUBSTITUTIONS, TREEBANK_CONTRACTIONS } from './co
  * @return {Array<string>}              An array of word tokens
  */
 export function treeBankTokenize(input: string): string[] {
-  if (input.length === 0) {
+  // Contraction rules below expect spaces, including at word boundaries.
+  const text = input.trim().replace(/\s+/g, ' ');
+  if (text.length === 0) {
     return [];
   }
 
@@ -34,7 +36,7 @@ export function treeBankTokenize(input: string): string[] {
   // 6. Wrap spaces around all exclamation marks and question marks
   // 7. Wrap spaces around opening and closing brackets
   // 8. Wrap spaces around en and em-dashes
-  let parse = input
+  let parse = text
     .replace(/^"/, ' `` ')
     .replace(/([ ([{<])"/g, '$1 `` ')
     .replace(/\.\.\.*/g, ' ... ')
@@ -71,6 +73,10 @@ export function treeBankTokenize(input: string): string[] {
   return parse.split(' ');
 }
 
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  * Splits a body of text into an array of sentences
  * using a rule-based segmentation approach.
@@ -88,13 +94,16 @@ export function sentenceSegment(input: string): string[] {
     return [];
   }
 
-  const abbrvReg = new RegExp(`\\b(${GATE_SUBSTITUTIONS.join('|')})[.!?] ?$`, 'i');
+  const abbrvReg = new RegExp(
+    `\\b(${GATE_SUBSTITUTIONS.map(escapeRegExp).join('|')})[.!?] ?$`,
+    'i',
+  );
   const acronymReg = new RegExp(/[ |.][A-Z].?$/, 'i');
-  const breakReg = new RegExp(/[\r\n]+/, 'g');
+  const breakReg = /[\r\n]+/;
   // Match 2-10 dots at end of string (ellipsis pattern)
   // Using bounded {2,10} quantifier to avoid ReDoS with extremely long dot sequences
   const ellipseReg = /\.{2,10}$/;
-  const excepReg = new RegExp(`\\b(${GATE_EXCEPTIONS.join('|')})[.!?] ?$`, 'i');
+  const excepReg = new RegExp(`\\b(${GATE_EXCEPTIONS.map(escapeRegExp).join('|')})[.!?] ?$`, 'i');
 
   // Split sentences naively based on common terminals (.?!")
   // Pattern uses a "tempered greedy token" to avoid ReDoS:
@@ -111,6 +120,11 @@ export function sentenceSegment(input: string): string[] {
       // Note: Using separate replacements instead of alternation to avoid ReDoS
       chunks[idx] = chunks[idx].replace(/^ +/, '').replace(/ +$/, '');
 
+      // Separators are not sentences and have no character to test for titlecase.
+      if (chunks[idx].trim().length === 0) {
+        continue;
+      }
+
       if (breakReg.test(chunks[idx])) {
         if (chunks[idx + 1] && strIsTitleCase(chunks[idx])) {
           // Catch line breaks embedded within valid sentences
@@ -120,7 +134,12 @@ export function sentenceSegment(input: string): string[] {
         } else {
           // Assume that all other embedded line breaks are
           // valid sentence breakpoints
-          acc.push(...chunks[idx].trim().split('\n'));
+          for (const line of chunks[idx].split(breakReg)) {
+            const sentence = line.trim();
+            if (sentence.length > 0) {
+              acc.push(sentence);
+            }
+          }
         }
       } else if (chunks[idx + 1] && abbrvReg.test(chunks[idx])) {
         const nextChunk = chunks[idx + 1];
@@ -134,17 +153,24 @@ export function sentenceSegment(input: string): string[] {
           chunks[idx + 1] = `${chunks[idx]} ${nextChunk.replace(/ +/g, ' ')}`;
         }
       } else if (chunks[idx].length > 1 && chunks[idx + 1] && acronymReg.test(chunks[idx])) {
-        const words = chunks[idx].split(' ');
-        const lastWord = words.at(-1)!;
+        const words = chunks[idx].split(/\s+/);
+        const lastWord = words.at(-1) ?? '';
 
         if (lastWord === lastWord.toLowerCase()) {
           // Catch small-letter abbreviations and merge them.
           chunks[idx + 1] = `${chunks[idx]} ${chunks[idx + 1].replace(/ +/g, ' ')}`;
-        } else if (chunks[idx + 2]) {
-          if (strIsTitleCase(words.at(-2)!) && strIsTitleCase(chunks[idx + 2])) {
+        } else {
+          // The next sentence may be a captured chunk or an unterminated tail.
+          const nextIdx = chunks[idx + 2] ? idx + 2 : idx + 1;
+          const previousWord = words.at(-2);
+          if (previousWord && strIsTitleCase(previousWord) && strIsTitleCase(chunks[nextIdx])) {
             // Catch name abbreviations (e.g. Albert I. Jones) by checking if
             // the previous and next words are all capitalized.
-            chunks[idx + 2] = chunks[idx] + chunks[idx + 1].replace(/ +/g, ' ') + chunks[idx + 2];
+            const suffix =
+              nextIdx === idx + 2
+                ? chunks[idx + 1].replace(/ +/g, ' ') + chunks[nextIdx]
+                : ` ${chunks[nextIdx].trim()}`;
+            chunks[nextIdx] = chunks[idx] + suffix;
           } else {
             // Assume that remaining entities are indeed end-of-sentence markers.
             acc.push(chunks[idx]);
@@ -173,7 +199,7 @@ export function sentenceSegment(input: string): string[] {
  */
 export function strIsTitleCase(input: string): boolean {
   const firstChar = input.trim().slice(0, 1);
-  return charIsUpperCase(firstChar);
+  return firstChar.length > 0 && charIsUpperCase(firstChar);
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -101,7 +101,12 @@ export function sentenceSegment(input: string): string[] {
     return [];
   }
 
-  // Keep captured sentences and unmatched separators for the rules below.
+  // Split sentences naively based on common terminals (.?!")
+  // Pattern uses a "tempered greedy token" to avoid ReDoS:
+  // - (?:[^.?!\r\n]|[.?!](?!\s|$|"))* matches any char except newlines, OR a terminator NOT at a boundary
+  // - [^.?!\r\n] excludes newlines to match original behavior (JS regex . doesn't match newlines)
+  // - This allows matching through "U.S.A." and "$100.00" without polynomial backtracking
+  // - [.?!]{1,3} limits consecutive terminators (e.g., "!!", "?!", "...") to prevent ReDoS
   const chunks = input.split(/(\S(?:[^.?!\r\n]|[.?!](?!\s|$|"))*[.?!]{1,3})(?=\s|$|")/g);
 
   const acc: string[] = [];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,6 +77,13 @@ function escapeRegExp(input: string): string {
   return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+const abbrvReg = new RegExp(`\\b(${GATE_SUBSTITUTIONS.map(escapeRegExp).join('|')})[.!?] ?$`, 'i');
+const acronymReg = /[ |.][A-Z].?$/i;
+const breakReg = /[\r\n]+/;
+// Match a bounded ellipsis suffix to avoid excessive backtracking.
+const ellipseReg = /\.{2,10}$/;
+const excepReg = new RegExp(`\\b(${GATE_EXCEPTIONS.map(escapeRegExp).join('|')})[.!?] ?$`, 'i');
+
 /**
  * Splits a body of text into an array of sentences
  * using a rule-based segmentation approach.
@@ -93,17 +100,6 @@ export function sentenceSegment(input: string): string[] {
   if (input.length === 0) {
     return [];
   }
-
-  const abbrvReg = new RegExp(
-    `\\b(${GATE_SUBSTITUTIONS.map(escapeRegExp).join('|')})[.!?] ?$`,
-    'i',
-  );
-  const acronymReg = new RegExp(/[ |.][A-Z].?$/, 'i');
-  const breakReg = /[\r\n]+/;
-  // Match 2-10 dots at end of string (ellipsis pattern)
-  // Using bounded {2,10} quantifier to avoid ReDoS with extremely long dot sequences
-  const ellipseReg = /\.{2,10}$/;
-  const excepReg = new RegExp(`\\b(${GATE_EXCEPTIONS.map(escapeRegExp).join('|')})[.!?] ?$`, 'i');
 
   // Split sentences naively based on common terminals (.?!")
   // Pattern uses a "tempered greedy token" to avoid ReDoS:
@@ -172,6 +168,7 @@ export function sentenceSegment(input: string): string[] {
             // the previous and next words are all capitalized. Normalize line
             // wrapping in the separator so it cannot split the joined name again.
             chunks[idx + 2] = chunks[idx] + chunks[idx + 1].replace(/\s+/g, ' ') + nextSentence;
+            chunks[idx + 1] = '';
           } else {
             // Retain a boundary for other entities and unterminated final fragments.
             acc.push(chunks[idx]);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -419,11 +419,14 @@ describe('Utility Functions', () => {
 
     test('should preserve text before an unterminated final fragment', () => {
       expect(ss('We chose option A. Next step')).toEqual(['We chose option A.', 'Next step']);
+      expect(ss('Use Plan A. Next step')).toEqual(['Use Plan A.', 'Next step']);
       expect(ss('We visited D.C. Today')).toEqual(['We visited D.C.', 'Today']);
     });
 
-    test('should preserve a name initial before an unterminated surname', () => {
-      expect(ss('My name is Jonas E. Smith')).toEqual(['My name is Jonas E. Smith']);
+    test.each(lineBreaks)('should join line-wrapped name initials across %j', (lineBreak) => {
+      expect(ss(`Did you see Albert I.${lineBreak}Jones yesterday?`)).toEqual([
+        'Did you see Albert I. Jones yesterday?',
+      ]);
     });
 
     test('should handle a standalone initialism', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -399,6 +399,47 @@ describe('Utility Functions', () => {
       ]);
     });
 
+    const lineBreaks = ['\n', '\r\n', '\r'];
+    test.each(lineBreaks)('should split sentences across %j', (lineBreak) => {
+      expect(ss(`Alpha.${lineBreak}Beta.${lineBreak}Gamma.`)).toEqual([
+        'Alpha.',
+        'Beta.',
+        'Gamma.',
+      ]);
+    });
+
+    test.each(lineBreaks)('should split lists across %j', (lineBreak) => {
+      expect(ss(`alpha${lineBreak}beta${lineBreak}gamma`)).toEqual(['alpha', 'beta', 'gamma']);
+    });
+
+    test('should ignore blank separator chunks', () => {
+      expect(ss('\nAlpha.\r\n \t\nBeta.\n')).toEqual(['Alpha.', 'Beta.']);
+      expect(ss('alpha\n\n \n beta\n')).toEqual(['alpha', 'beta']);
+    });
+
+    test('should preserve text before an unterminated final fragment', () => {
+      expect(ss('We chose option A. Next step')).toEqual(['We chose option A.', 'Next step']);
+      expect(ss('We visited D.C. Today')).toEqual(['We visited D.C.', 'Today']);
+    });
+
+    test('should preserve a name initial before an unterminated surname', () => {
+      expect(ss('My name is Jonas E. Smith')).toEqual(['My name is Jonas E. Smith']);
+    });
+
+    test('should handle a standalone initialism', () => {
+      expect(ss('D.C. Next.')).toEqual(['D.C.', 'Next.']);
+    });
+
+    test('should match abbreviation punctuation literally', () => {
+      expect(ss('I ate an egg. Tomorrow is Monday.')).toEqual([
+        'I ate an egg.',
+        'Tomorrow is Monday.',
+      ]);
+      expect(ss('She ate ice. We left.')).toEqual(['She ate ice.', 'We left.']);
+      expect(ss('Use e.g. Examples.')).toEqual(['Use e.g. Examples.']);
+      expect(ss('That is i.e. An example.')).toEqual(['That is i.e. An example.']);
+    });
+
     test('should split geo-coordinate as a sentence boundary', () => {
       expect(ss('You can find it at N°. 1026.253.553. That is where the treasure is.')).toEqual([
         'You can find it at N°. 1026.253.553.',
@@ -500,9 +541,10 @@ describe('Utility Functions', () => {
 
       test('should handle whitespace-only input', () => {
         // Whitespace gets trimmed to empty string, so no chunks are added to acc
-        // Returns [input] when acc is empty (line 166)
+        // Preserve the single-sentence fallback for whitespace-only input.
         expect(ss('   ')).toEqual(['   ']);
         expect(ss('\t\t')).toEqual(['\t\t']);
+        expect(ss('\r\n')).toEqual(['\r\n']);
       });
 
       test('should handle abbreviation followed by lowercase text', () => {
@@ -528,6 +570,41 @@ describe('Utility Functions', () => {
 
     test('should return empty array for empty input', () => {
       expect(tbt('')).toEqual([]);
+    });
+
+    const whitespace = [' ', '\t', '\n', '\r\n', '\u00a0'];
+    test.each(whitespace)('should split words separated by %j', (separator) => {
+      expect(tbt(`alpha${separator}beta`)).toEqual(['alpha', 'beta']);
+      expect(tbt(`${separator}They'll${separator}go.${separator}`)).toEqual([
+        'They',
+        "'ll",
+        'go',
+        '.',
+      ]);
+    });
+
+    test.each(whitespace)('should not invent tokens for %j', (separator) => {
+      expect(tbt(separator.repeat(3))).toEqual([]);
+    });
+
+    const uncommonContractions: [string, string[]][] = [
+      ['cannot', ['can', 'not']],
+      ["d'ye", ['d', "'ye"]],
+      ['gimme', ['gim', 'me']],
+      ['gonna', ['gon', 'na']],
+      ['gotta', ['got', 'ta']],
+      ['lemme', ['lem', 'me']],
+      ["more'n", ['more', "'n"]],
+      ['wanna', ['wan', 'na']],
+      ["'tis", ["'t", 'is']],
+      ["'twas", ["'t", 'was']],
+    ];
+    test.each(uncommonContractions)('should split every %s', (word, tokens) => {
+      const input = `${word} ${word} ${word.toUpperCase()}`;
+      const expected = [...tokens, ...tokens, ...tokens.map((token) => token.toUpperCase())];
+      expect(tbt(input)).toEqual(expected);
+      // Global patterns must also reset between tokenizer calls.
+      expect(tbt(input)).toEqual(expected);
     });
 
     test("should split 'll contractions", () => {
@@ -697,10 +774,33 @@ describe('Utility Functions', () => {
     test('should return false for lowercase input with interspesed capitals', () => {
       expect(isTitle('aBcD')).toBe(false);
     });
+
+    test('should return false when there is no first character', () => {
+      expect(isTitle('')).toBe(false);
+      expect(isTitle(' \t\r\n')).toBe(false);
+    });
   });
 });
 
 describe('Core Functions', () => {
+  const metrics = [
+    ['ROUGE-N', rouge.n],
+    ['ROUGE-S', rouge.s],
+    ['ROUGE-L', rouge.l],
+  ] as const;
+  describe.each(metrics)('%s input handling', (_name, score) => {
+    test('should treat word-separating whitespace consistently', () => {
+      expect(score('alpha\tbeta', 'alpha beta')).toBe(1);
+      expect(score('alpha\nbeta', 'alpha beta')).toBe(1);
+      expect(score('alpha\u00a0beta', 'alpha beta')).toBe(1);
+    });
+
+    test('should reject whitespace-only summaries like empty strings', () => {
+      expect(() => score(' \t\r\n', 'alpha beta')).toThrow('Candidate cannot be an empty string');
+      expect(() => score('alpha beta', ' \t\r\n')).toThrow('Reference cannot be an empty string');
+    });
+  });
+
   describe('ROUGE-N', () => {
     const { n } = rouge;
 
@@ -784,6 +884,11 @@ describe('Core Functions', () => {
     });
     test('should throw RangeError for empty ref', () => {
       expect(() => l(cands[0], '', undefined as any)).toThrow(RangeError);
+    });
+
+    test('should accept newline-separated sentences', () => {
+      const tokenizer = (text: string): string[] => text.match(/[A-Za-z]+/g) || [];
+      expect(l('Alpha.\r\nBeta.', 'Alpha.\nBeta.', { tokenizer })).toBe(1);
     });
 
     test('should correctly compute ROUGE-L score for cand 1 with different opts', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -412,6 +412,12 @@ describe('Utility Functions', () => {
       expect(ss(`alpha${lineBreak}beta${lineBreak}gamma`)).toEqual(['alpha', 'beta', 'gamma']);
     });
 
+    test.each(lineBreaks)('should join every sentence wrap across %j', (lineBreak) => {
+      expect(ss(`The quick${lineBreak}brown${lineBreak}fox jumps.`)).toEqual([
+        'The quick brown fox jumps.',
+      ]);
+    });
+
     test('should ignore blank separator chunks', () => {
       expect(ss('\nAlpha.\r\n \t\nBeta.\n')).toEqual(['Alpha.', 'Beta.']);
       expect(ss('alpha\n\n \n beta\n')).toEqual(['alpha', 'beta']);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -435,6 +435,15 @@ describe('Utility Functions', () => {
       ]);
     });
 
+    test.each(lineBreaks)('should consume wrapped name fragments once across %j', (lineBreak) => {
+      expect(ss(`I met${lineBreak}Albert\tI.${lineBreak}Jones at${lineBreak}Acme.`)).toEqual([
+        'I met Albert I. Jones at Acme.',
+      ]);
+      expect(ss(`I met${lineBreak}Albert\tI.${lineBreak}van der${lineBreak}Meer.`)).toEqual([
+        'I met Albert I. van der Meer.',
+      ]);
+    });
+
     test('should handle a standalone initialism', () => {
       expect(ss('D.C. Next.')).toEqual(['D.C.', 'Next.']);
     });


### PR DESCRIPTION
## Summary

Fix text preprocessing without changing the scoring formulas, adding runtime dependencies, or changing public exports:

- Normalize word-separating whitespace and apply every supported Treebank contraction rule to every occurrence.
- Reject whitespace-only scoring inputs with the existing `RangeError` contract; preserve the standalone segmenter's blank-input fallback.
- Handle LF, CRLF, and CR consistently, escape abbreviation literals, and retain text after initials and acronyms.
- Consume copied name fragments once. Previously, `I met\nAlbert\tI.\nJones at\nAcme.` repeated `Jones at` in the output.
- Compile the static, non-global sentence regexes once instead of escaping lists and rebuilding patterns on every call.

## Verification

- All 197 tests pass, including the existing sentence-segmentation Golden Rules.
- The three new line-ending regressions fail before the fix and pass afterward. They cover both capitalized and lowercase intervening name fragments.
- 50,000 generated inputs preserve every non-whitespace character exactly once. CJS/ESM outputs agree, and moving regex initialization does not change the correctness-only results.
- CJS/ESM builds, declaration generation, type checking, and local Biome checks pass. Local Biome is 2.4.15; CI validates the pinned 2.5.10.

## Scope and known limitation

N/S counting (#116), summary LCS (#117), and boundary-scanning performance (#119) remain separate PRs targeting `main`.

The pre-existing capitalization heuristic can still merge fully punctuated labels such as `Use Plan A. Next step.`. That name-versus-label policy is deferred; this PR fixes crashes, text loss, and duplication without adding keyword exceptions. See the [existing review discussion](https://github.com/promptfoo/js-rouge/pull/118#discussion_r3834306531).

## Combined validation

The current four heads merge cleanly in forward and reverse order on main `c61e88142c186ec9f3a46f1d55c5e312d092dda6`, producing the same tree. The combined checkout passes 230 tests, 32,652 reference-based N/S/L comparisons, all 18 original audit regressions, and 50,000 preprocessing cases. An additional 500-pair smoke check verifies bounded scores, perfect self-scores, and CJS/ESM agreement.

These are local integration results, not a merge or release. Affected score baselines should be rerun after upgrading.
