### PR TITLE
fix: scan sentence boundaries in one pass

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,7 +96,7 @@ export function sentenceSegment(input: string): string[] {
   const ellipseReg = /\.{2,10}$/;
   const excepReg = new RegExp(`\\b(${GATE_EXCEPTIONS.join('|')})[.!?] ?$`, 'i');
 
-  // Keep captured sentences and unmatched separators for the rules below.
+  // Split sentences naively based on common terminals (.?!")
   const chunks = sentenceChunks(input);
 
   const acc: string[] = [];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,20 +96,14 @@ export function sentenceSegment(input: string): string[] {
   const ellipseReg = /\.{2,10}$/;
   const excepReg = new RegExp(`\\b(${GATE_EXCEPTIONS.join('|')})[.!?] ?$`, 'i');
 
-  // Split sentences naively based on common terminals (.?!")
-  // Pattern uses a "tempered greedy token" to avoid ReDoS:
-  // - (?:[^.?!\r\n]|[.?!](?!\s|$|"))* matches any char except newlines, OR a terminator NOT at a boundary
-  // - [^.?!\r\n] excludes newlines to match original behavior (JS regex . doesn't match newlines)
-  // - This allows matching through "U.S.A." and "$100.00" without polynomial backtracking
-  // - [.?!]{1,3} limits consecutive terminators (e.g., "!!", "?!", "...") to prevent ReDoS
-  const chunks = input.split(/(\S(?:[^.?!\r\n]|[.?!](?!\s|$|"))*[.?!]{1,3})(?=\s|$|")/g);
+  // Keep captured sentences and unmatched separators for the rules below.
+  const chunks = sentenceChunks(input);
 
   const acc: string[] = [];
   for (let idx = 0; idx < chunks.length; idx++) {
     if (chunks[idx]) {
       // Trim only spaces (i.e. preserve line breaks/carriage feeds)
-      // Note: Using separate replacements instead of alternation to avoid ReDoS
-      chunks[idx] = chunks[idx].replace(/^ +/, '').replace(/ +$/, '');
+      chunks[idx] = trimSpaces(chunks[idx]);
 
       if (breakReg.test(chunks[idx])) {
         if (chunks[idx + 1] && strIsTitleCase(chunks[idx])) {
@@ -163,6 +157,52 @@ export function sentenceSegment(input: string): string[] {
 
   // If no matches were found, return the input treated as a single sentence
   return acc.length === 0 ? [input] : acc;
+}
+
+/** Scan sentence boundaries once, preserving the former captured-split layout. */
+function sentenceChunks(input: string): string[] {
+  const chunks: string[] = [];
+  let lastEnd = 0;
+  let start = -1;
+
+  for (let index = 0; index < input.length; index++) {
+    const char = input[index];
+    if (char === '\r' || char === '\n') {
+      // A match cannot cross CR/LF; its prefix remains unmatched text.
+      start = -1;
+      continue;
+    }
+    if (start === -1) {
+      if (/\S/.test(char)) {
+        start = index;
+      }
+      // A terminal must follow the initial character, even if it is punctuation.
+      continue;
+    }
+    if (
+      (char === '.' || char === '?' || char === '!') &&
+      (index + 1 === input.length || /[\s"]/.test(input[index + 1]))
+    ) {
+      chunks.push(input.slice(lastEnd, start), input.slice(start, index + 1));
+      lastEnd = index + 1;
+      start = -1;
+    }
+  }
+
+  chunks.push(input.slice(lastEnd));
+  return chunks;
+}
+
+function trimSpaces(input: string): string {
+  let start = 0;
+  let end = input.length;
+  while (start < end && input[start] === ' ') {
+    start++;
+  }
+  while (end > start && input[end - 1] === ' ') {
+    end--;
+  }
+  return input.slice(start, end);
 }
 
 /**

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -441,10 +441,20 @@ describe('Utility Functions', () => {
       const TIMEOUT_MS = 500;
 
       test('should handle long strings without sentence terminators quickly', () => {
-        const input = 'a'.repeat(10_000);
+        const input = 'a'.repeat(64_000);
         const start = Date.now();
-        ss(input);
+        const sentences = ss(input);
         const elapsed = Date.now() - start;
+        expect(sentences).toEqual([input]);
+        expect(elapsed).toBeLessThan(TIMEOUT_MS);
+      });
+
+      test('should trim long chunks without rescanning internal spaces', () => {
+        const input = `prefix${' '.repeat(64_000)}suffix.`;
+        const start = Date.now();
+        const sentences = ss(`  ${input}  `);
+        const elapsed = Date.now() - start;
+        expect(sentences).toEqual([input]);
         expect(elapsed).toBeLessThan(TIMEOUT_MS);
       });
 
@@ -496,6 +506,10 @@ describe('Utility Functions', () => {
         expect(ss('just some text without any ending')).toEqual([
           'just some text without any ending',
         ]);
+      });
+
+      test('should retain unmatched fragments around line breaks', () => {
+        expect(ss('intro\nAlpha. Beta.\ntail')).toEqual(['intro', 'Alpha.', 'Beta.', 'tail']);
       });
 
       test('should handle whitespace-only input', () => {


### PR DESCRIPTION
## Summary

Replace two quadratic operations in sentence segmentation:

- Scan sentence boundaries once while preserving the old captured-sentence and unmatched-fragment layout.
- Trim ASCII spaces from the endpoints without repeatedly scanning long internal space runs.

The helpers are private. Sentence heuristics, public exports, dependencies, and exception behavior are unchanged. This PR makes the boundary scan and endpoint trimming linear; it does not claim that every later NLP heuristic is linear.

The follow-up only preserves the existing chunking heading so this PR and #118 remain independently mergeable. It changes no executable code.

## Verification

- All 152 tests pass, including 64,000-character performance regressions that also assert their output.
- The exact current private helpers match the old implementation across 597,871 exhaustive and 20,000 randomized inputs; ASCII-only trimming agrees in all 617,871 cases.
- CJS/ESM builds, declaration generation, type checking, and local Biome checks pass. Local Biome is 2.4.15; CI validates the pinned 2.5.10.

## Scope and combined validation

N/S counting (#116), summary LCS (#117), and preprocessing correctness (#118) remain separate PRs targeting `main`. There are no new runtime dependencies or public API changes.

The four current heads merge cleanly in forward and reverse order on main `c61e88142c186ec9f3a46f1d55c5e312d092dda6`, producing the same tree. The combined checkout passes 230 tests, 32,652 reference-based N/S/L comparisons, all 18 original audit regressions, and 50,000 preprocessing cases. An additional 500-pair smoke check verifies bounded scores, perfect self-scores, and CJS/ESM agreement.

These are local integration results, not a merge or release.
