### PR TITLE
ci: reject lint warnings and remove Biome notices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - name: Biome CI check
-        run: npx biome ci .
+        run: npx biome ci . --error-on-warnings
       - run: npm run build
       - name: Verify build artifacts
         run: |

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -30,7 +30,6 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
       "complexity": {
         "noExcessiveCognitiveComplexity": {
           "level": "warn",


### PR DESCRIPTION
## Summary

The non-null assertions in #119's old check annotations were already removed by #118. Current main has no code-lint warnings. This follow-up prevents new warnings from passing CI and removes the Biome configuration notices repeated on all four Node jobs.

- Run Biome CI with `--error-on-warnings`.
- Use the schema bundled with the installed Biome package instead of maintaining a separate schema version.
- Remove deprecated `recommended: true`; recommended rules remain enabled by default.

No library code, dependencies, rule suppressions, or release behavior changes.

## Validation

- Build, type checking, and all **230 Jest tests** pass.
- Strict Biome check reports **zero errors, warnings, or info diagnostics** locally.
- Temporary probes show that non-null assertions and parameter reassignment pass without the warning gate and fail with it. An unconfigured recommended-rule probe also remains enforced. Probe files were removed.
- Workflow YAML formatting passes.
- Local lint checks used the existing Biome 2.4.15 installation. The pinned Biome 2.5.10 passed CI on Node 18, 20, 22, and 24. All nine PR checks pass, and all four build jobs have zero annotations.

Biome documents the [bundled schema and default recommended rules](https://biomejs.dev/reference/configuration/) and the [warning gate](https://biomejs.dev/reference/cli/#--error-on-warnings).
