### PR TITLE
docs: clarify jackknife orientation and multi-reference adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ ROUGE-N and ROUGE-S count repeated matching grams up to the smaller of their fre
 
 ## Jackknife Resampling
 
-The package also exports utility functions, including jackknife resampling as described in the original paper:
+`jackKnife(candidates, reference, scorer, statistic?)` scores each candidate against one fixed reference. It omits each candidate in turn, takes the maximum remaining score, then applies `statistic` to those leave-one-out maxima (the arithmetic mean by default). At least two candidates are required. The callback is always called as `scorer(candidate, reference)`.
 
 ```javascript
 import { n as rougeN, jackKnife } from "js-rouge";
@@ -171,13 +171,32 @@ const candidates = [
   "the gunman police killed",
 ];
 
-// Standard evaluation taking the arithmetic mean
+// Mean of the leave-one-candidate-out maximum scores
 jackKnife(candidates, reference, rougeN);
 
-// Modified evaluation taking the distribution maximum
+// Maximum of the leave-one-candidate-out maximum scores
 const distMax = (arr) => Math.max(...arr);
 jackKnife(candidates, reference, rougeN, distMax);
 ```
+
+### One Candidate, Multiple References
+
+The procedure in [Lin (2004), Section 2.1](https://aclanthology.org/W04-1013.pdf) instead keeps the candidate fixed and resamples the reference set, averaging the best pairwise score in each leave-one-reference-out set. Use an adapter to preserve candidate/reference orientation with the existing API:
+
+```javascript
+import { n as rougeN, jackKnife } from "js-rouge";
+
+const candidate = "a";
+const references = ["a b", "a c d"];
+const recall = (candidate, reference) =>
+  rougeN(candidate, reference, { beta: Infinity });
+
+jackKnife(references, candidate, (reference, systemSummary) =>
+  recall(systemSummary, reference),
+); // => 5/12, the mean of recall scores 1/2 and 1/3
+```
+
+The adapter matters for asymmetric scorers such as recall. Passing `recall` directly in this example reverses the comparison and returns `1`. The existing argument order is unchanged; `jackKnife` does not infer which strings are references.
 
 ## TypeScript
 

--- a/README.md
+++ b/README.md
@@ -187,13 +187,13 @@ The procedure in [Lin (2004), Section 2.1](https://aclanthology.org/W04-1013.pdf
 import { n as rougeN, jackKnife } from "js-rouge";
 
 const candidate = "a";
-const references = ["a b", "a c d"];
+const references = ["a b", "a c d", "a b c d e"];
 const recall = (candidate, reference) =>
   rougeN(candidate, reference, { beta: Infinity });
 
 jackKnife(references, candidate, (reference, systemSummary) =>
   recall(systemSummary, reference),
-); // => 5/12, the mean of recall scores 1/2 and 1/3
+); // => 4/9, the mean of leave-one-out maxima 1/3, 1/2, and 1/2
 ```
 
 The adapter matters for asymmetric scorers such as recall. Passing `recall` directly in this example reverses the comparison and returns `1`. The existing argument order is unchanged; `jackKnife` does not infer which strings are references.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -429,17 +429,12 @@ export function arithmeticMean(input: number[]): number {
 }
 
 /**
- * Evaluates the jackknife resampling result for a set of
- * candidate summaries vs. a reference summary.
+ * Scores each candidate against a fixed reference, then applies test to the
+ * leave-one-out maxima (arithmetic mean by default). Requires at least two candidates.
+ * Calls func(candidate, ref) once per candidate.
  *
- * Calls func(candidate, ref) once per candidate, takes the maximum score
- * after omitting each candidate in turn, and applies test to those maxima.
- * At least two candidates are required.
- *
- * To keep one candidate fixed and resample multiple references instead, use
+ * For reference resampling, preserve scorer argument order with
  * jackKnife(references, candidate, (reference, summary) => scorer(summary, reference)).
- * This adapter matters for asymmetric scorers such as recall; argument order
- * is not inferred or reversed automatically.
  *
  * @method jackKnife
  * @param  {Array<string>}  cands      An array of candidate summaries to be evaluated

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -432,6 +432,15 @@ export function arithmeticMean(input: number[]): number {
  * Evaluates the jackknife resampling result for a set of
  * candidate summaries vs. a reference summary.
  *
+ * Calls func(candidate, ref) once per candidate, takes the maximum score
+ * after omitting each candidate in turn, and applies test to those maxima.
+ * At least two candidates are required.
+ *
+ * To keep one candidate fixed and resample multiple references instead, use
+ * jackKnife(references, candidate, (reference, summary) => scorer(summary, reference)).
+ * This adapter matters for asymmetric scorers such as recall; argument order
+ * is not inferred or reversed automatically.
+ *
  * @method jackKnife
  * @param  {Array<string>}  cands      An array of candidate summaries to be evaluated
  * @param  {string}         ref        The reference summary to be evaluated against

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -724,6 +724,25 @@ describe('Utility Functions', () => {
     test('should return the correct result using alternative test', () => {
       expect(jk(cands, ref, evalFunc, statTest)).toBe(31);
     });
+
+    test('should adapt multiple references without reversing an asymmetric scorer', () => {
+      const candidate = 'a';
+      const references = ['a b', 'a c d'];
+      const recall = jest.fn((summary: string, reference: string): number =>
+        rouge.n(summary, reference, { beta: Number.POSITIVE_INFINITY }),
+      );
+
+      expect(
+        jk(references, candidate, (reference, summary) => recall(summary, reference)),
+      ).toBeCloseTo(5 / 12);
+      expect(recall.mock.calls).toEqual([
+        ['a', 'a b'],
+        ['a', 'a c d'],
+      ]);
+
+      // Direct callbacks retain the documented candidate-first orientation.
+      expect(jk(references, candidate, recall)).toBe(1);
+    });
   });
 
   describe('fMeasure', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -735,11 +735,7 @@ describe('Utility Functions', () => {
       expect(
         jk(references, candidate, (reference, summary) => recall(summary, reference)),
       ).toBeCloseTo(4 / 9, 15);
-      expect(recall.mock.calls).toEqual([
-        ['a', 'a b'],
-        ['a', 'a c d'],
-        ['a', 'a b c d e'],
-      ]);
+      expect(recall.mock.calls).toEqual(references.map((reference) => [candidate, reference]));
 
       // Direct callbacks retain the documented candidate-first orientation.
       expect(jk(references, candidate, recall)).toBe(1);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -727,17 +727,18 @@ describe('Utility Functions', () => {
 
     test('should adapt multiple references without reversing an asymmetric scorer', () => {
       const candidate = 'a';
-      const references = ['a b', 'a c d'];
+      const references = ['a b', 'a c d', 'a b c d e'];
       const recall = jest.fn((summary: string, reference: string): number =>
         rouge.n(summary, reference, { beta: Number.POSITIVE_INFINITY }),
       );
 
       expect(
         jk(references, candidate, (reference, summary) => recall(summary, reference)),
-      ).toBeCloseTo(5 / 12);
+      ).toBeCloseTo(4 / 9, 15);
       expect(recall.mock.calls).toEqual([
         ['a', 'a b'],
         ['a', 'a c d'],
+        ['a', 'a b c d e'],
       ]);
 
       // Direct callbacks retain the documented candidate-first orientation.


### PR DESCRIPTION
## Scope

Independent documentation/contract PR against `main`; it can merge separately from the runtime-fix stack (#122–#125). No runtime behavior or public signatures change.

## Changes

Clarify the existing candidate-array/one-reference callback order and leave-one-out maximum/statistic behavior in README and JSDoc. Distinguish it from the fixed-candidate/multiple-reference procedure in [Lin (2004), Section 2.1](https://aclanthology.org/W04-1013.pdf).

Show an argument-reversing adapter without silently changing the API. The review improvement uses three references with recalls `1/2`, `1/3`, and `1/5`: leave-one-out maxima are `1/3`, `1/2`, and `1/2`, whose mean is `4/9`. Unlike a two-reference example, this distinguishes jackknife maxima from a simple mean of all pairwise scores. Passing recall directly reverses the comparison and returns `1`.

Extend the existing asymmetric-scorer regression to cover the third reference, exact callback arguments, and a tight score tolerance. No additional test file or runtime abstraction is needed.

The additional pass shortens the JSDoc without removing any contract detail and builds expected callback arguments from the existing reference fixture. It removes nine lines; the runtime implementation and three-reference README example are unchanged.

## Verification

- All 402 Jest tests pass after refreshing against the merged runtime fixes.
- Strict local Biome checks, README formatting, CJS/ESM/declaration builds, and `git diff --check` pass.
- The documented three-reference adapter returns `4/9`, and the reversed callback returns `1`, against both built module formats.
- This branch also combines cleanly with the final runtime stack in a local integration branch; all 402 combined tests pass. No GitHub PRs were merged.

Local checks use already-installed tooling because registry policy blocks a clean install of newly published Biome 2.5.10. The manifest and lockfile are unchanged. Normal GitHub CI checks the pinned toolchain on Node 18, 20, 22, and 24.

## Current-head checks

Verified `54fb2eff63557d4e41567813d956a9c1f5feaabb` against `main` at `f660f7733cf25a957ee08f27d4aceacf560a8947`: all 402 tests, builds, and strict local lint pass. [Node 18/20/22/24 CI](https://github.com/promptfoo/js-rouge/actions/runs/32591112080) and [Codex code/security reviews](https://github.com/promptfoo/js-rouge/pull/126#issuecomment-5377821071) completed on this exact head, with zero unresolved review threads.
