### PR TITLE
fix: validate factorial inputs

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -496,7 +496,8 @@ function factorial(x: number): number {
   }
 
   let result = 1;
-  for (let factor = 2; factor <= x; factor++) {
+  // Preserve the floating-point multiplication order of the former recursive implementation.
+  for (let factor = x; factor >= 2; factor--) {
     result *= factor;
   }
   return result;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -481,33 +481,34 @@ function memoize<T, R>(func: (arg: T) => R, Store: new () => Map<T, R> = Map): (
 }
 
 /**
- * Computes the factorial of a number.
+ * Computes the factorial of an integer from 0 through 170.
  *
- * This function uses a tail-recursive call to avoid
- * blowing the stack when computing inputs with a large
- * recursion depth.
+ * Values above 170 are rejected because their factorials overflow
+ * JavaScript's finite number range.
  *
- * @method factRec
- * @param  {number} x     The number for which the factorial is to be computed
- * @param  {number} acc   The starting value for the computation. Defaults to 1.
- * @return {number}       The factorial result
+ * @method factorial
+ * @param  {number} x     The integer for which the factorial is to be computed
+ * @return {number}       The finite factorial result
  */
-function factRec(x: number, acc = 1): number {
-  if (x < 0) {
-    throw new RangeError('Input must be a positive number');
+function factorial(x: number): number {
+  if (!Number.isInteger(x) || x < 0 || x > 170) {
+    throw new RangeError('Input must be an integer between 0 and 170');
   }
-  return x < 2 ? acc : factRec(x - 1, x * acc);
+
+  let result = 1;
+  for (let factor = 2; factor <= x; factor++) {
+    result *= factor;
+  }
+  return result;
 }
 
 /**
  * Memoized factorial function.
  *
- * **Memory Note**: Results are cached indefinitely. In typical ROUGE usage,
- * factorial is called with small values (≤20) so memory impact is negligible.
- * The cache size is bounded by the range of valid factorial inputs that don't
- * overflow JavaScript's number type (approximately n ≤ 170).
+ * Accepts only finite, non-negative integers through 170. Results are cached
+ * indefinitely, so the cache contains at most 171 entries.
  */
-export const fact = memoize(factRec);
+export const fact = memoize(factorial);
 
 /**
  * Returns the skip bigrams for an array of word tokens.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -450,47 +450,16 @@ export function charIsUpperCase(input: string): boolean {
 }
 
 /**
- * Memoizes a function using a Map
- *
- * **Memory Warning**: The cache is unbounded and will grow indefinitely for unique inputs.
- * In long-running processes with many unique inputs, consider using a bounded cache
- * implementation (e.g., LRU cache) or periodically clearing the memoized function.
- *
- * @method memoize
- * @param  {Function} func    The function to be memoized
- * @param  {Function} Store   The data store constructor. Defaults to the ES6-inbuilt Map function.
- *                            A store should implement `has`, `get`, and `set` methods.
- * @return {Function}         A closure of the memoization cache and the original function
- */
-function memoize<T, R>(func: (arg: T) => R, Store: new () => Map<T, R> = Map): (arg: T) => R {
-  return (() => {
-    const cache = new Store();
-
-    return (n: T) => {
-      if (cache.has(n)) {
-        const cachedResult = cache.get(n);
-        if (cachedResult !== undefined) {
-          return cachedResult;
-        }
-      }
-      const result = func(n);
-      cache.set(n, result);
-      return result;
-    };
-  })();
-}
-
-/**
  * Computes the factorial of an integer from 0 through 170.
  *
  * Values above 170 are rejected because their factorials overflow
  * JavaScript's finite number range.
  *
- * @method factorial
+ * @method fact
  * @param  {number} x     The integer for which the factorial is to be computed
  * @return {number}       The finite factorial result
  */
-function factorial(x: number): number {
+export function fact(x: number): number {
   if (!Number.isInteger(x) || x < 0 || x > 170) {
     throw new RangeError('Input must be an integer between 0 and 170');
   }
@@ -502,14 +471,6 @@ function factorial(x: number): number {
   }
   return result;
 }
-
-/**
- * Memoized factorial function.
- *
- * Accepts only finite, non-negative integers through 170. Results are cached
- * indefinitely, so the cache contains at most 171 entries.
- */
-export const fact = memoize(factorial);
 
 /**
  * Returns the skip bigrams for an array of word tokens.

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -49,8 +49,11 @@ describe('Utility Functions', () => {
     test('should return 2432902008176640000 for 20! using cache', () => {
       expect(fact(20)).toBe(2_432_902_008_176_640_000);
     });
+    test('should preserve the legacy multiplication order for 98!', () => {
+      expect(fact(98)).toBe(9.426_890_448_883_248e153);
+    });
     test('should return a finite result for the maximum supported input', () => {
-      expect(fact(170)).toBe(7.257_415_615_307_994e306);
+      expect(fact(170)).toBe(7.257_415_615_308_004e306);
     });
   });
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -19,24 +19,17 @@ describe('Utility Functions', () => {
   describe('fact', () => {
     const { fact } = rouge;
 
-    test.each([
-      -1,
-      -1.5,
-      1.5,
-      171,
-      10_000,
-      Number.NaN,
-      Number.POSITIVE_INFINITY,
-      Number.NEGATIVE_INFINITY,
-    ])('should throw RangeError for invalid input %p', (input) => {
-      expect(() => fact(input)).toThrow(RangeError);
-    });
+    test.each([-1, 1.5, 171, Number.NaN, Number.POSITIVE_INFINITY])(
+      'should throw RangeError for invalid input %p',
+      (input) => {
+        expect(() => fact(input)).toThrow(RangeError);
+      },
+    );
 
     test.each([
       [0, 1],
       [1, 1],
       [5, 120],
-      [10, 3_628_800],
       [20, 2_432_902_008_176_640_000],
       [98, 9.426_890_448_883_248e153],
       [170, 7.257_415_615_308_004e306],

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -19,16 +19,12 @@ describe('Utility Functions', () => {
   describe('fact', () => {
     const { fact } = rouge;
 
-    test.each([
-      -1,
-      -1.5,
-      1.5,
-      Number.NaN,
-      Number.POSITIVE_INFINITY,
-      Number.NEGATIVE_INFINITY,
-    ])('should throw RangeError for invalid input %p', (input) => {
-      expect(() => fact(input)).toThrow(RangeError);
-    });
+    test.each([-1, -1.5, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+      'should throw RangeError for invalid input %p',
+      (input) => {
+        expect(() => fact(input)).toThrow(RangeError);
+      },
+    );
 
     test.each([171, 10_000])('should reject unsupported input %i before computation', (input) => {
       expect(() => fact(input)).toThrow(RangeError);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -19,8 +19,19 @@ describe('Utility Functions', () => {
   describe('fact', () => {
     const { fact } = rouge;
 
-    test('should throw RangeError for -1!', () => {
-      expect(() => fact(-1)).toThrow(RangeError);
+    test.each([
+      -1,
+      -1.5,
+      1.5,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+    ])('should throw RangeError for invalid input %p', (input) => {
+      expect(() => fact(input)).toThrow(RangeError);
+    });
+
+    test.each([171, 10_000])('should reject unsupported input %i before computation', (input) => {
+      expect(() => fact(input)).toThrow(RangeError);
     });
 
     test('should return 1 for 0!', () => {
@@ -41,6 +52,9 @@ describe('Utility Functions', () => {
     });
     test('should return 2432902008176640000 for 20! using cache', () => {
       expect(fact(20)).toBe(2_432_902_008_176_640_000);
+    });
+    test('should return a finite result for the maximum supported input', () => {
+      expect(fact(170)).toBe(7.257_415_615_307_994e306);
     });
   });
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -19,41 +19,29 @@ describe('Utility Functions', () => {
   describe('fact', () => {
     const { fact } = rouge;
 
-    test.each([-1, -1.5, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
-      'should throw RangeError for invalid input %p',
-      (input) => {
-        expect(() => fact(input)).toThrow(RangeError);
-      },
-    );
-
-    test.each([171, 10_000])('should reject unsupported input %i before computation', (input) => {
+    test.each([
+      -1,
+      -1.5,
+      1.5,
+      171,
+      10_000,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+    ])('should throw RangeError for invalid input %p', (input) => {
       expect(() => fact(input)).toThrow(RangeError);
     });
 
-    test('should return 1 for 0!', () => {
-      expect(fact(0)).toBe(1);
-    });
-    test('should return 1 for 1!', () => {
-      expect(fact(1)).toBe(1);
-    });
-
-    test('should return 120 for 5!', () => {
-      expect(fact(5)).toBe(120);
-    });
-    test('should return 3628800 for 10!', () => {
-      expect(fact(10)).toBe(3_628_800);
-    });
-    test('should return 2432902008176640000 for 20!', () => {
-      expect(fact(20)).toBe(2_432_902_008_176_640_000);
-    });
-    test('should return 2432902008176640000 for 20! using cache', () => {
-      expect(fact(20)).toBe(2_432_902_008_176_640_000);
-    });
-    test('should preserve the legacy multiplication order for 98!', () => {
-      expect(fact(98)).toBe(9.426_890_448_883_248e153);
-    });
-    test('should return a finite result for the maximum supported input', () => {
-      expect(fact(170)).toBe(7.257_415_615_308_004e306);
+    test.each([
+      [0, 1],
+      [1, 1],
+      [5, 120],
+      [10, 3_628_800],
+      [20, 2_432_902_008_176_640_000],
+      [98, 9.426_890_448_883_248e153],
+      [170, 7.257_415_615_308_004e306],
+    ])('should return %p for %i!', (input, expected) => {
+      expect(fact(input)).toBe(expected);
     });
   });
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -40,7 +40,7 @@ describe('Utility Functions', () => {
       [20, 2_432_902_008_176_640_000],
       [98, 9.426_890_448_883_248e153],
       [170, 7.257_415_615_308_004e306],
-    ])('should return %p for %i!', (input, expected) => {
+    ])('should compute %i!', (input, expected) => {
       expect(fact(input)).toBe(expected);
     });
   });


### PR DESCRIPTION
## Summary

- validate factorial inputs as integers from 0 through 170
- reject invalid or overflowing inputs with `RangeError`
- compute the bounded result directly with iteration, without recursion, memoization, or global cache state
- cover invalid domains and exact numeric boundaries

## Behavior change

`fact()` now rejects fractional, non-finite, negative, and overflow-producing inputs instead of returning invalid results or recursing until the call stack is exhausted.

## Simplification pass

- kept the implementation as one validation guard and one descending loop; a shared validator would be a one-use abstraction
- removed test rows that repeated the same guard or loop path while retaining negative, fractional, non-finite, overflow, and exact boundary coverage
- reduced the pass by 7 net lines (6 additions, 13 deletions)

## Validation

- `npm test -- --runInBand` (406 tests)
- `npm run type-check`
- Biome 2.5.10 strict check
- combined eight-PR stack: 497 tests, type-check, format checks, build, and packed-package smoke
