### PR TITLE
fix: make custom ROUGE-L matching position-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Omitted options and fields explicitly set to `undefined` use the documented defa
 | `lcs`           | function | built-in      | Value-returning LCS function         |
 | `lcsIndices`    | function | `undefined`   | Position-aware LCS function          |
 
+`lcs` and `lcsIndices` are mutually exclusive. Specifying both throws `RangeError`.
+
 ### ROUGE-S Options
 
 | Option          | Type     | Default       | Description                          |

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ rougeL(candidate, reference); // => 0.75
 
 The exported `lcs(a, b)` utility still returns token values. For position-aware customization, use `lcsIndices`: the callback receives candidate and reference sentence-token arrays and returns the exact, strictly increasing reference indices selected by the match. The selected reference tokens must form a subsequence of the candidate.
 
-The legacy `lcs` callback remains supported when its ordered token subsequence identifies exactly one sequence of reference positions. When repeated reference tokens make those positions ambiguous, `l()` throws `RangeError` instead of guessing; use `lcsIndices` to provide the intended alignment. The built-in implementation retains the exact reference positions from its LCS alignment.
+The value-returning `lcs` callback remains supported and aligns its ordered token subsequence to successive reference occurrences from left to right. This preserves the existing callback behavior when repeated reference tokens admit more than one alignment. Use `lcsIndices` to provide a different exact alignment. The built-in implementation retains the exact reference positions from its LCS alignment.
 
 These corrections change ROUGE-L scores for repeated words and multi-sentence summaries. Rerun evaluation baselines when comparing versions.
 
@@ -145,7 +145,7 @@ Omitted options and fields explicitly set to `undefined` use the documented defa
 | `caseSensitive` | boolean  | `true`        | Whether comparison is case-sensitive |
 | `tokenizer`     | function | Penn Treebank | Custom tokenizer function            |
 | `segmenter`     | function | built-in      | Custom sentence segmenter            |
-| `lcs`           | function | built-in      | Legacy value-returning LCS function  |
+| `lcs`           | function | built-in      | Value-returning LCS function         |
 | `lcsIndices`    | function | `undefined`   | Position-aware LCS function          |
 
 ### ROUGE-S Options

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ rougeL(candidate, reference); // => 0.75
 
 `l()` computes summary-level union LCS (called `rougeLsum` in Google's ROUGE package). It unions matched reference-token positions across candidate sentences and clips credit to the candidate's token counts. Sentence tokenization supplies both the matches and their denominators. Case-insensitive comparison preserves sentence boundaries by applying case folding after segmentation.
 
-The exported `lcs(a, b)` utility still returns token values. A custom `lcs` callback must return an ordered token subsequence; its values are aligned to successive reference occurrences from left to right. The built-in implementation retains the exact reference positions from its LCS alignment.
+The exported `lcs(a, b)` utility still returns token values. For position-aware customization, use `lcsIndices`: the callback receives candidate and reference sentence-token arrays and returns the exact, strictly increasing reference indices selected by the match. The selected reference tokens must form a subsequence of the candidate.
+
+The legacy `lcs` callback remains supported when its ordered token subsequence identifies exactly one sequence of reference positions. When repeated reference tokens make those positions ambiguous, `l()` throws `RangeError` instead of guessing; use `lcsIndices` to provide the intended alignment. The built-in implementation retains the exact reference positions from its LCS alignment.
 
 These corrections change ROUGE-L scores for repeated words and multi-sentence summaries. Rerun evaluation baselines when comparing versions.
 
@@ -143,7 +145,8 @@ Omitted options and fields explicitly set to `undefined` use the documented defa
 | `caseSensitive` | boolean  | `true`        | Whether comparison is case-sensitive |
 | `tokenizer`     | function | Penn Treebank | Custom tokenizer function            |
 | `segmenter`     | function | built-in      | Custom sentence segmenter            |
-| `lcs`           | function | built-in      | Custom LCS function                  |
+| `lcs`           | function | built-in      | Legacy value-returning LCS function  |
+| `lcsIndices`    | function | `undefined`   | Position-aware LCS function          |
 
 ### ROUGE-S Options
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,7 @@ rougeL(candidate, reference); // => 0.75
 
 `l()` computes summary-level union LCS (called `rougeLsum` in Google's ROUGE package). It unions matched reference-token positions across candidate sentences and clips credit to the candidate's token counts. Sentence tokenization supplies both the matches and their denominators. Case-insensitive comparison preserves sentence boundaries by applying case folding after segmentation.
 
-The exported `lcs(a, b)` utility still returns token values. For position-aware customization, use `lcsIndices`: the callback receives candidate and reference sentence-token arrays and returns the exact, strictly increasing reference indices selected by the match. The selected reference tokens must form a subsequence of the candidate.
-
-The value-returning `lcs` callback remains supported and aligns its ordered token subsequence to successive reference occurrences from left to right. This preserves the existing callback behavior when repeated reference tokens admit more than one alignment. Use `lcsIndices` to provide a different exact alignment. The built-in implementation retains the exact reference positions from its LCS alignment.
+The exported `lcs(a, b)` utility still returns token values. The value-returning `lcs` callback remains supported and aligns its ordered subsequence to successive reference occurrences from left to right, preserving legacy behavior for repeated tokens. For an exact alignment, use `lcsIndices`: it receives candidate and reference sentence-token arrays and returns strictly increasing reference indices whose selected tokens form a subsequence of the candidate. The built-in implementation retains exact reference positions.
 
 These corrections change ROUGE-L scores for repeated words and multi-sentence summaries. Rerun evaluation baselines when comparing versions.
 

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -38,17 +38,9 @@ export interface RougeLOptions {
   beta?: number;
   /** Whether comparison is case-sensitive (default: true) */
   caseSensitive?: boolean;
-  /**
-   * Custom LCS function returning an ordered token subsequence.
-   *
-   * Returned values are aligned to successive reference occurrences from left to
-   * right. Use `lcsIndices` to select exact positions when the reference repeats tokens.
-   */
+  /** Custom LCS returning values aligned to reference occurrences from left to right. */
   lcs?: (a: string[], b: string[]) => string[];
-  /**
-   * Custom LCS function returning exact, strictly increasing reference indices.
-   * Cannot be specified with `lcs`; providing both throws `RangeError`.
-   */
+  /** Custom LCS returning exact, strictly increasing reference indices; cannot be combined with `lcs`. */
   lcsIndices?: (candidate: string[], reference: string[]) => number[];
   /** Custom sentence segmenter */
   segmenter?: (input: string) => string[];

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -327,32 +327,23 @@ function validateCustomLcsIndices(
     throw new RangeError('Custom lcsIndices must return an array of reference token indices');
   }
 
-  const indices: number[] = [];
-  const tokens: string[] = [];
   let previous = -1;
   for (const index of result) {
-    if (
-      typeof index !== 'number' ||
-      !Number.isInteger(index) ||
-      index < 0 ||
-      index >= reference.length ||
-      index <= previous
-    ) {
+    if (!Number.isInteger(index) || index < 0 || index >= reference.length || index <= previous) {
       throw new RangeError(
         'Custom lcsIndices must return strictly increasing integer indices within the reference',
       );
     }
-    indices.push(index);
-    tokens.push(reference[index]);
     previous = index;
   }
 
-  if (!isSubsequence(tokens, candidate)) {
+  const selected = result.map((index) => reference[index]);
+  if (!isSubsequence(selected, candidate)) {
     throw new RangeError(
       'Custom lcsIndices must select reference tokens that form a subsequence of the candidate',
     );
   }
-  return indices;
+  return result;
 }
 
 function alignReferenceIndices(
@@ -364,20 +355,16 @@ function alignReferenceIndices(
     throw new RangeError('Custom lcs must return an array of token strings');
   }
 
-  const tokens: string[] = [];
-  for (const token of result) {
-    if (typeof token !== 'string') {
-      throw new RangeError('Custom lcs must return an array of token strings');
-    }
-    tokens.push(token);
+  if (!result.every((token) => typeof token === 'string')) {
+    throw new RangeError('Custom lcs must return an array of token strings');
   }
-  if (!isSubsequence(tokens, candidate)) {
+  if (!isSubsequence(result, candidate)) {
     throw new RangeError('Custom lcs must return a common subsequence of candidate and reference');
   }
 
   const indices: number[] = [];
   let next = 0;
-  for (const token of tokens) {
+  for (const token of result) {
     const index = reference.indexOf(token, next);
     if (index === -1) {
       throw new RangeError(

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -315,7 +315,17 @@ function matchedReferenceIndices(
     return builtInLcsIndices(candidate, reference);
   }
 
-  return alignReferenceIndices(candidate, reference, getLcs(candidate, reference));
+  // Preserve the value-only callback's legacy best-effort alignment.
+  const indices: number[] = [];
+  let next = 0;
+  for (const token of getLcs(candidate, reference)) {
+    const index = reference.indexOf(token, next);
+    if (index !== -1) {
+      indices.push(index);
+      next = index + 1;
+    }
+  }
+  return indices;
 }
 
 function validateCustomLcsIndices(
@@ -328,68 +338,21 @@ function validateCustomLcsIndices(
   }
 
   let previous = -1;
+  let nextCandidate = 0;
   for (const index of result) {
     if (!Number.isInteger(index) || index < 0 || index >= reference.length || index <= previous) {
       throw new RangeError(
         'Custom lcsIndices must return strictly increasing integer indices within the reference',
       );
     }
-    previous = index;
-  }
-
-  const selected = result.map((index) => reference[index]);
-  if (!isSubsequence(selected, candidate)) {
-    throw new RangeError(
-      'Custom lcsIndices must select reference tokens that form a subsequence of the candidate',
-    );
-  }
-  return result;
-}
-
-function alignReferenceIndices(
-  candidate: string[],
-  reference: string[],
-  result: string[],
-): number[] {
-  if (!Array.isArray(result)) {
-    throw new RangeError('Custom lcs must return an array of token strings');
-  }
-
-  if (!result.every((token) => typeof token === 'string')) {
-    throw new RangeError('Custom lcs must return an array of token strings');
-  }
-  if (!isSubsequence(result, candidate)) {
-    throw new RangeError('Custom lcs must return a common subsequence of candidate and reference');
-  }
-
-  const indices: number[] = [];
-  let next = 0;
-  for (const token of result) {
-    const index = reference.indexOf(token, next);
-    if (index === -1) {
+    const candidateIndex = candidate.indexOf(reference[index], nextCandidate);
+    if (candidateIndex === -1) {
       throw new RangeError(
-        'Custom lcs must return a common subsequence of candidate and reference',
+        'Custom lcsIndices must select reference tokens that form a subsequence of the candidate',
       );
     }
-    indices.push(index);
-    next = index + 1;
+    previous = index;
+    nextCandidate = candidateIndex + 1;
   }
-  return indices;
-}
-
-function isSubsequence(tokens: string[], sequence: string[]): boolean {
-  if (tokens.length === 0) {
-    return true;
-  }
-
-  let tokenIndex = 0;
-  for (const token of sequence) {
-    if (token === tokens[tokenIndex]) {
-      tokenIndex++;
-      if (tokenIndex === tokens.length) {
-        return true;
-      }
-    }
-  }
-  return false;
+  return result;
 }

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -1,4 +1,4 @@
-import { lcsIndices } from './lcs';
+import { lcsIndices as builtInLcsIndices } from './lcs';
 import * as utils from './utils';
 import { validateBeta, validateMaxSkip, validateNGramSize } from './validation';
 
@@ -38,8 +38,17 @@ export interface RougeLOptions {
   beta?: number;
   /** Whether comparison is case-sensitive (default: true) */
   caseSensitive?: boolean;
-  /** Custom LCS function returning an ordered token subsequence */
+  /**
+   * Custom LCS function returning an ordered token subsequence.
+   *
+   * Returned values must identify a unique sequence of reference positions. Use
+   * `lcsIndices` when repeated reference tokens make that alignment ambiguous.
+   *
+   * @deprecated Prefer `lcsIndices`, which preserves reference positions directly.
+   */
   lcs?: (a: string[], b: string[]) => string[];
+  /** Custom LCS function returning exact, strictly increasing reference indices */
+  lcsIndices?: (candidate: string[], reference: string[]) => number[];
   /** Custom sentence segmenter */
   segmenter?: (input: string) => string[];
   /** Custom string tokenizer */
@@ -209,12 +218,14 @@ export function s(cand: string, ref: string, opts?: RougeSOptions): number {
  * 	beta: 1.0                           // The beta value used for the f-measure
  * 	caseSensitive: true                 // Whether comparison is case-sensitive
  * 	lcs: <inbuilt function>             // The longest common subsequence function
+ * 	lcsIndices: undefined                // A position-aware custom LCS function
  * 	segmenter: <inbuilt function>,      // The sentence segmenter
  * 	tokenizer: <inbuilt function>       // The string tokenizer
  * }
  * ```
  *
  * `lcs` has a type signature of ((Array<string>, Array<string>) => Array<string>)
+ * `lcsIndices` has a type signature of ((Array<string>, Array<string>) => Array<number>)
  * `segmenter` has a type signature of ((string) => Array<string)
  * `tokenizer` has a type signature of ((string) => Array<string)
  *
@@ -236,9 +247,13 @@ export function l(cand: string, ref: string, opts?: RougeLOptions): number {
     beta = 1.0,
     caseSensitive = true,
     lcs: getLcs = utils.lcs,
+    lcsIndices: getLcsIndices,
     segmenter = utils.sentenceSegment,
     tokenizer = utils.treeBankTokenize,
   } = opts ?? {};
+  if (opts?.lcs !== undefined && getLcsIndices !== undefined) {
+    throw new RangeError('ROUGE-L options cannot specify both lcs and lcsIndices');
+  }
   validateBeta(beta);
 
   const tokenizeSentence = (sentence: string): string[] =>
@@ -264,7 +279,7 @@ export function l(cand: string, ref: string, opts?: RougeLOptions): number {
   for (const reference of refSents) {
     const union = new Set<number>();
     for (const candidate of candSents) {
-      for (const index of matchedReferenceIndices(candidate, reference, getLcs)) {
+      for (const index of matchedReferenceIndices(candidate, reference, getLcs, getLcsIndices)) {
         union.add(index);
       }
     }
@@ -290,20 +305,114 @@ function matchedReferenceIndices(
   candidate: string[],
   reference: string[],
   getLcs: (a: string[], b: string[]) => string[],
+  getLcsIndices?: (candidate: string[], reference: string[]) => number[],
 ): number[] {
+  if (getLcsIndices !== undefined) {
+    return validateCustomLcsIndices(candidate, reference, getLcsIndices(candidate, reference));
+  }
   if (getLcs === utils.lcs) {
-    return lcsIndices(candidate, reference);
+    return builtInLcsIndices(candidate, reference);
   }
 
-  // The public callback returns values, so align them to successive reference occurrences.
+  return alignUniqueReferenceIndices(candidate, reference, getLcs(candidate, reference));
+}
+
+function validateCustomLcsIndices(
+  candidate: string[],
+  reference: string[],
+  result: number[],
+): number[] {
+  if (!Array.isArray(result)) {
+    throw new RangeError('Custom lcsIndices must return an array of reference token indices');
+  }
+
   const indices: number[] = [];
-  let next = 0;
-  for (const token of getLcs(candidate, reference)) {
-    const index = reference.indexOf(token, next);
-    if (index !== -1) {
-      indices.push(index);
-      next = index + 1;
+  const tokens: string[] = [];
+  let previous = -1;
+  for (const index of result) {
+    if (
+      typeof index !== 'number' ||
+      !Number.isInteger(index) ||
+      index < 0 ||
+      index >= reference.length ||
+      index <= previous
+    ) {
+      throw new RangeError(
+        'Custom lcsIndices must return strictly increasing integer indices within the reference',
+      );
     }
+    indices.push(index);
+    tokens.push(reference[index]);
+    previous = index;
+  }
+
+  if (!isSubsequence(tokens, candidate)) {
+    throw new RangeError(
+      'Custom lcsIndices must select reference tokens that form a subsequence of the candidate',
+    );
   }
   return indices;
+}
+
+function alignUniqueReferenceIndices(
+  candidate: string[],
+  reference: string[],
+  result: string[],
+): number[] {
+  if (!Array.isArray(result)) {
+    throw new RangeError('Custom lcs must return an array of token strings');
+  }
+
+  const tokens: string[] = [];
+  for (const token of result) {
+    if (typeof token !== 'string') {
+      throw new RangeError('Custom lcs must return an array of token strings');
+    }
+    tokens.push(token);
+  }
+  if (!isSubsequence(tokens, candidate)) {
+    throw new RangeError('Custom lcs must return a common subsequence of candidate and reference');
+  }
+
+  const earliest: number[] = [];
+  let next = 0;
+  for (const token of tokens) {
+    const index = reference.indexOf(token, next);
+    if (index === -1) {
+      throw new RangeError(
+        'Custom lcs must return a common subsequence of candidate and reference',
+      );
+    }
+    earliest.push(index);
+    next = index + 1;
+  }
+
+  const latest = new Array<number>(tokens.length);
+  let before = reference.length;
+  for (let i = tokens.length - 1; i >= 0; i--) {
+    const index = reference.lastIndexOf(tokens[i], before - 1);
+    latest[i] = index;
+    before = index;
+  }
+  for (let i = 0; i < earliest.length; i++) {
+    if (earliest[i] !== latest[i]) {
+      throw new RangeError(
+        'Custom lcs returned tokens with ambiguous reference positions; use lcsIndices to return exact reference indices',
+      );
+    }
+  }
+  return earliest;
+}
+
+function isSubsequence(tokens: string[], sequence: string[]): boolean {
+  let tokenIndex = 0;
+  for (const token of sequence) {
+    if (token === tokens[tokenIndex]) {
+      tokenIndex++;
+      if (tokenIndex === tokens.length) {
+        return true;
+      }
+    }
+  }
+  return tokens.length === 0;
 }

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -45,7 +45,10 @@ export interface RougeLOptions {
    * right. Use `lcsIndices` to select exact positions when the reference repeats tokens.
    */
   lcs?: (a: string[], b: string[]) => string[];
-  /** Custom LCS function returning exact, strictly increasing reference indices */
+  /**
+   * Custom LCS function returning exact, strictly increasing reference indices.
+   * Cannot be specified with `lcs`; providing both throws `RangeError`.
+   */
   lcsIndices?: (candidate: string[], reference: string[]) => number[];
   /** Custom sentence segmenter */
   segmenter?: (input: string) => string[];

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -391,6 +391,10 @@ function alignReferenceIndices(
 }
 
 function isSubsequence(tokens: string[], sequence: string[]): boolean {
+  if (tokens.length === 0) {
+    return true;
+  }
+
   let tokenIndex = 0;
   for (const token of sequence) {
     if (token === tokens[tokenIndex]) {
@@ -400,5 +404,5 @@ function isSubsequence(tokens: string[], sequence: string[]): boolean {
       }
     }
   }
-  return tokens.length === 0;
+  return false;
 }

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -41,10 +41,8 @@ export interface RougeLOptions {
   /**
    * Custom LCS function returning an ordered token subsequence.
    *
-   * Returned values must identify a unique sequence of reference positions. Use
-   * `lcsIndices` when repeated reference tokens make that alignment ambiguous.
-   *
-   * @deprecated Prefer `lcsIndices`, which preserves reference positions directly.
+   * Returned values are aligned to successive reference occurrences from left to
+   * right. Use `lcsIndices` to select exact positions when the reference repeats tokens.
    */
   lcs?: (a: string[], b: string[]) => string[];
   /** Custom LCS function returning exact, strictly increasing reference indices */
@@ -314,7 +312,7 @@ function matchedReferenceIndices(
     return builtInLcsIndices(candidate, reference);
   }
 
-  return alignUniqueReferenceIndices(candidate, reference, getLcs(candidate, reference));
+  return alignReferenceIndices(candidate, reference, getLcs(candidate, reference));
 }
 
 function validateCustomLcsIndices(
@@ -354,7 +352,7 @@ function validateCustomLcsIndices(
   return indices;
 }
 
-function alignUniqueReferenceIndices(
+function alignReferenceIndices(
   candidate: string[],
   reference: string[],
   result: string[],
@@ -374,7 +372,7 @@ function alignUniqueReferenceIndices(
     throw new RangeError('Custom lcs must return a common subsequence of candidate and reference');
   }
 
-  const earliest: number[] = [];
+  const indices: number[] = [];
   let next = 0;
   for (const token of tokens) {
     const index = reference.indexOf(token, next);
@@ -383,25 +381,10 @@ function alignUniqueReferenceIndices(
         'Custom lcs must return a common subsequence of candidate and reference',
       );
     }
-    earliest.push(index);
+    indices.push(index);
     next = index + 1;
   }
-
-  const latest = new Array<number>(tokens.length);
-  let before = reference.length;
-  for (let i = tokens.length - 1; i >= 0; i--) {
-    const index = reference.lastIndexOf(tokens[i], before - 1);
-    latest[i] = index;
-    before = index;
-  }
-  for (let i = 0; i < earliest.length; i++) {
-    if (earliest[i] !== latest[i]) {
-      throw new RangeError(
-        'Custom lcs returned tokens with ambiguous reference positions; use lcsIndices to return exact reference indices',
-      );
-    }
-  }
-  return earliest;
+  return indices;
 }
 
 function isSubsequence(tokens: string[], sequence: string[]): boolean {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1487,6 +1487,49 @@ describe('Core Functions', () => {
       expect(l('a a a', 'a a', { lcs: customLcs })).toBeCloseTo(4 / 5);
     });
 
+    test('should reject ambiguous reference positions from a value-only LCS callback', () => {
+      const customLcs = (a: string[], b: string[]): string[] => rouge.lcs(a, b);
+      expect(() => l('a\nb a', 'a b a', { lcs: customLcs })).toThrow(
+        /ambiguous reference positions.*lcsIndices/,
+      );
+    });
+
+    test('should use exact reference positions from a custom LCS-index callback', () => {
+      const customLcsIndices = (candidate: string[]): number[] =>
+        candidate.length === 1 ? [0] : [1, 2];
+      expect(l('a\nb a', 'a b a')).toBeCloseTo(2 / 3);
+      expect(l('a\nb a', 'a b a', { lcsIndices: customLcsIndices })).toBe(1);
+    });
+
+    test('should reject specifying both custom LCS callback forms', () => {
+      expect(() =>
+        l('a', 'a', {
+          lcs: () => ['a'],
+          lcsIndices: () => [0],
+        }),
+      ).toThrow(/cannot specify both lcs and lcsIndices/);
+    });
+
+    test.each([
+      [-1],
+      [2],
+      [0.5],
+      [0, 0],
+      [1, 0],
+    ])('should reject malformed custom LCS indices: %j', (indices) => {
+      expect(() => l('a b', 'a b', { lcsIndices: () => indices })).toThrow(RangeError);
+    });
+
+    test('should reject custom LCS indices whose tokens are not a candidate subsequence', () => {
+      expect(() => l('a', 'a b', { lcsIndices: () => [1] })).toThrow(
+        /subsequence of the candidate/,
+      );
+    });
+
+    test('should reject values that are not a common subsequence from a custom LCS callback', () => {
+      expect(() => l('a b', 'a b', { lcs: () => ['b', 'a'] })).toThrow(/common subsequence/);
+    });
+
     test('should return zero when custom tokenization removes every token', () => {
       expect(l('a', 'b', { tokenizer: () => [] })).toBe(0);
     });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1538,6 +1538,24 @@ describe('Core Functions', () => {
       expect(() => l('a b', 'a b', { lcs: () => ['b', 'a'] })).toThrow(/common subsequence/);
     });
 
+    test('should not rescan candidate tokens for an empty custom LCS result', () => {
+      let candidateIterations = 0;
+      const candidateTokens = new Proxy(['a', 'b'], {
+        get(target, property, receiver) {
+          if (property === Symbol.iterator) {
+            candidateIterations++;
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      });
+      const tokenizer = (input: string): string[] =>
+        input === 'candidate' ? candidateTokens : ['reference'];
+      const segmenter = (input: string): string[] => [input];
+
+      expect(l('candidate', 'reference', { lcs: () => [], tokenizer, segmenter })).toBe(0);
+      expect(candidateIterations).toBe(1);
+    });
+
     test('should return zero when custom tokenization removes every token', () => {
       expect(l('a', 'b', { tokenizer: () => [] })).toBe(0);
     });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1494,9 +1494,9 @@ describe('Core Functions', () => {
 
     test('should use exact reference positions from a custom LCS-index callback', () => {
       const customLcsIndices = (candidate: string[]): number[] =>
-        candidate.length === 1 ? [2] : [1, 2];
+        candidate.length === 1 ? [0] : [1, 2];
       expect(l('a\nb a', 'a b a')).toBeCloseTo(2 / 3);
-      expect(l('a\nb a', 'a b a', { lcsIndices: customLcsIndices })).toBeCloseTo(2 / 3);
+      expect(l('a\nb a', 'a b a', { lcsIndices: customLcsIndices })).toBe(1);
     });
 
     test('should reject specifying both custom LCS callback forms', () => {
@@ -1515,14 +1515,13 @@ describe('Core Functions', () => {
       );
     });
 
-    const malformedIndexResults = [
+    test.each([
       { name: 'negative out-of-range index', indices: [-1] },
       { name: 'upper out-of-range index', indices: [2] },
       { name: 'fractional index', indices: [0.5] },
       { name: 'duplicate indices', indices: [0, 0] },
       { name: 'descending indices', indices: [1, 0] },
-    ];
-    test.each(malformedIndexResults)('should reject $name', ({ indices }) => {
+    ])('should reject $name', ({ indices }) => {
       expect(() => l('a b', 'a b', { lcsIndices: () => indices })).toThrow(
         /strictly increasing integer indices within the reference/,
       );

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1554,22 +1554,8 @@ describe('Core Functions', () => {
       expect(() => l('a b', 'a c', { lcs: () => ['b'] })).toThrow(/common subsequence/);
     });
 
-    test('should not rescan candidate tokens for an empty custom LCS result', () => {
-      let candidateIterations = 0;
-      const candidateTokens = new Proxy(['a', 'b'], {
-        get(target, property, receiver) {
-          if (property === Symbol.iterator) {
-            candidateIterations++;
-          }
-          return Reflect.get(target, property, receiver);
-        },
-      });
-      const tokenizer = (input: string): string[] =>
-        input === 'candidate' ? candidateTokens : ['reference'];
-      const segmenter = (input: string): string[] => [input];
-
-      expect(l('candidate', 'reference', { lcs: () => [], tokenizer, segmenter })).toBe(0);
-      expect(candidateIterations).toBe(1);
+    test('should accept an empty custom LCS result', () => {
+      expect(l('candidate', 'reference', { lcs: () => [] })).toBe(0);
     });
 
     test('should return zero when custom tokenization removes every token', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1487,11 +1487,9 @@ describe('Core Functions', () => {
       expect(l('a a a', 'a a', { lcs: customLcs })).toBeCloseTo(4 / 5);
     });
 
-    test('should reject ambiguous reference positions from a value-only LCS callback', () => {
+    test('should preserve left-to-right alignment for value-only LCS callbacks', () => {
       const customLcs = (a: string[], b: string[]): string[] => rouge.lcs(a, b);
-      expect(() => l('a\nb a', 'a b a', { lcs: customLcs })).toThrow(
-        /ambiguous reference positions.*lcsIndices/,
-      );
+      expect(l('a\nb a', 'a b a', { lcs: customLcs })).toBe(1);
     });
 
     test('should use exact reference positions from a custom LCS-index callback', () => {
@@ -1510,14 +1508,24 @@ describe('Core Functions', () => {
       ).toThrow(/cannot specify both lcs and lcsIndices/);
     });
 
-    test.each([
-      [-1],
-      [2],
-      [0.5],
-      [0, 0],
-      [1, 0],
-    ])('should reject malformed custom LCS indices: %j', (indices) => {
-      expect(() => l('a b', 'a b', { lcsIndices: () => indices })).toThrow(RangeError);
+    test('should reject a non-array custom LCS-index result', () => {
+      const customLcsIndices = (): number[] => 'not an array' as unknown as number[];
+      expect(() => l('a b', 'a b', { lcsIndices: customLcsIndices })).toThrow(
+        /must return an array/,
+      );
+    });
+
+    const malformedIndexResults = [
+      { name: 'negative out-of-range index', indices: [-1] },
+      { name: 'upper out-of-range index', indices: [2] },
+      { name: 'fractional index', indices: [0.5] },
+      { name: 'duplicate indices', indices: [0, 0] },
+      { name: 'descending indices', indices: [1, 0] },
+    ];
+    test.each(malformedIndexResults)('should reject $name', ({ indices }) => {
+      expect(() => l('a b', 'a b', { lcsIndices: () => indices })).toThrow(
+        /strictly increasing integer indices within the reference/,
+      );
     });
 
     test('should reject custom LCS indices whose tokens are not a candidate subsequence', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1494,9 +1494,9 @@ describe('Core Functions', () => {
 
     test('should use exact reference positions from a custom LCS-index callback', () => {
       const customLcsIndices = (candidate: string[]): number[] =>
-        candidate.length === 1 ? [0] : [1, 2];
+        candidate.length === 1 ? [2] : [1, 2];
       expect(l('a\nb a', 'a b a')).toBeCloseTo(2 / 3);
-      expect(l('a\nb a', 'a b a', { lcsIndices: customLcsIndices })).toBe(1);
+      expect(l('a\nb a', 'a b a', { lcsIndices: customLcsIndices })).toBeCloseTo(2 / 3);
     });
 
     test('should reject specifying both custom LCS callback forms', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1515,6 +1515,18 @@ describe('Core Functions', () => {
       );
     });
 
+    test('should reject a non-array custom LCS result', () => {
+      const customLcs = (): string[] => 'not an array' as unknown as string[];
+      expect(() => l('a b', 'a b', { lcs: customLcs })).toThrow(/must return an array/);
+    });
+
+    test('should reject non-string values from a custom LCS callback', () => {
+      const customLcs = (): string[] => [0] as unknown as string[];
+      expect(() => l('a b', 'a b', { lcs: customLcs })).toThrow(
+        /must return an array of token strings/,
+      );
+    });
+
     const malformedIndexResults = [
       { name: 'negative out-of-range index', indices: [-1] },
       { name: 'upper out-of-range index', indices: [2] },
@@ -1536,6 +1548,10 @@ describe('Core Functions', () => {
 
     test('should reject values that are not a common subsequence from a custom LCS callback', () => {
       expect(() => l('a b', 'a b', { lcs: () => ['b', 'a'] })).toThrow(/common subsequence/);
+    });
+
+    test('should reject custom LCS values that are absent from the reference', () => {
+      expect(() => l('a b', 'a c', { lcs: () => ['b'] })).toThrow(/common subsequence/);
     });
 
     test('should not rescan candidate tokens for an empty custom LCS result', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1515,18 +1515,6 @@ describe('Core Functions', () => {
       );
     });
 
-    test('should reject a non-array custom LCS result', () => {
-      const customLcs = (): string[] => 'not an array' as unknown as string[];
-      expect(() => l('a b', 'a b', { lcs: customLcs })).toThrow(/must return an array/);
-    });
-
-    test('should reject non-string values from a custom LCS callback', () => {
-      const customLcs = (): string[] => [0] as unknown as string[];
-      expect(() => l('a b', 'a b', { lcs: customLcs })).toThrow(
-        /must return an array of token strings/,
-      );
-    });
-
     const malformedIndexResults = [
       { name: 'negative out-of-range index', indices: [-1] },
       { name: 'upper out-of-range index', indices: [2] },
@@ -1546,12 +1534,8 @@ describe('Core Functions', () => {
       );
     });
 
-    test('should reject values that are not a common subsequence from a custom LCS callback', () => {
-      expect(() => l('a b', 'a b', { lcs: () => ['b', 'a'] })).toThrow(/common subsequence/);
-    });
-
-    test('should reject custom LCS values that are absent from the reference', () => {
-      expect(() => l('a b', 'a c', { lcs: () => ['b'] })).toThrow(/common subsequence/);
+    test('should preserve best-effort alignment for legacy value-only callbacks', () => {
+      expect(l('a b', 'a c', { lcs: () => ['a', 'missing'] })).toBeCloseTo(1 / 2);
     });
 
     test('should accept an empty custom LCS result', () => {


### PR DESCRIPTION
## Summary

- add a position-aware `lcsIndices` hook that returns exact reference-token indices
- validate custom indices for bounds, ordering, and candidate subsequence membership
- preserve the published best-effort behavior of the legacy value-returning `lcs` hook
- keep the callback forms mutually exclusive and avoid rescanning empty matches
- remove duplicated array copies and implementation-coupled callback tests

## Why

Value-only callbacks cannot disambiguate repeated reference tokens. The new hook lets callers preserve the exact alignment needed by summary-level union LCS without changing existing callback behavior in a patch release.

## Simplification pass

- retained separate value and index callback paths because their missing-token semantics differ and a flag-driven helper would obscure that contract
- corrected the exact-position regression so the custom indices choose a genuinely different repeated-token alignment
- collapsed overlapping documentation and inlined a one-use malformed-case table
- reduced the pass by 11 net lines (7 additions, 18 deletions)

## Validation

- `npm test -- --runInBand` (414 tests)
- `npm run type-check`
- Biome 2.5.10 strict check
- Prettier check for `README.md`
- combined eight-PR stack: 497 tests, type-check, format checks, build, and packed-package smoke
