### PR TITLE
fix: bound LCS auxiliary memory

### DIFF
--- a/src/lcs.ts
+++ b/src/lcs.ts
@@ -1,33 +1,106 @@
-/** Returns the positions in b matched by a longest common subsequence of a and b. */
-export function lcsIndices(a: string[], b: string[]): number[] {
-  if (a.length === 0 || b.length === 0) {
-    return [];
+/** Return LCS lengths for every prefix of b using linear auxiliary memory. */
+function prefixLengths(
+  a: string[],
+  aStart: number,
+  aEnd: number,
+  b: string[],
+  bStart: number,
+  bEnd: number,
+): Uint32Array {
+  const width = bEnd - bStart;
+  let previous = new Uint32Array(width + 1);
+  let current = new Uint32Array(width + 1);
+
+  for (let i = aStart; i < aEnd; i++) {
+    current[0] = 0;
+    for (let j = 1; j <= width; j++) {
+      current[j] =
+        a[i] === b[bStart + j - 1] ? previous[j - 1] + 1 : Math.max(previous[j], current[j - 1]);
+    }
+    [previous, current] = [current, previous];
+  }
+  return previous;
+}
+
+/**
+ * Find where the legacy backtracking path first reaches the middle row.
+ * Origins are propagated with the same diagonal/up/left choices as the full
+ * matrix, so duplicate-token tie choices remain observable-identical.
+ */
+function findSplit(
+  a: string[],
+  aStart: number,
+  aMiddle: number,
+  aEnd: number,
+  b: string[],
+  bStart: number,
+  bEnd: number,
+): number {
+  const width = bEnd - bStart;
+  let previousLengths: Uint32Array = prefixLengths(a, aStart, aMiddle, b, bStart, bEnd);
+  let currentLengths: Uint32Array = new Uint32Array(width + 1);
+  let previousOrigins: Uint32Array = new Uint32Array(width + 1);
+  let currentOrigins: Uint32Array = new Uint32Array(width + 1);
+  for (let j = 0; j <= width; j++) {
+    previousOrigins[j] = j;
   }
 
-  const dp: number[][] = new Array(a.length + 1).fill(0).map(() => new Array(b.length + 1).fill(0));
-  for (let i = 1; i <= a.length; i++) {
-    for (let j = 1; j <= b.length; j++) {
-      if (a[i - 1] === b[j - 1]) {
-        dp[i][j] = dp[i - 1][j - 1] + 1;
+  for (let i = aMiddle; i < aEnd; i++) {
+    currentLengths[0] = 0;
+    currentOrigins[0] = 0;
+    for (let j = 1; j <= width; j++) {
+      if (a[i] === b[bStart + j - 1]) {
+        currentLengths[j] = previousLengths[j - 1] + 1;
+        currentOrigins[j] = previousOrigins[j - 1];
+      } else if (previousLengths[j] > currentLengths[j - 1]) {
+        currentLengths[j] = previousLengths[j];
+        currentOrigins[j] = previousOrigins[j];
       } else {
-        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+        currentLengths[j] = currentLengths[j - 1];
+        currentOrigins[j] = currentOrigins[j - 1];
       }
     }
+    [previousLengths, currentLengths] = [currentLengths, previousLengths];
+    [previousOrigins, currentOrigins] = [currentOrigins, previousOrigins];
+  }
+  return previousOrigins[width];
+}
+
+/**
+ * Divide-and-conquer reconstruction with the same tie preference as the former
+ * full-matrix backtracking and linear auxiliary memory.
+ */
+function collectLcsIndices(
+  a: string[],
+  aStart: number,
+  aEnd: number,
+  b: string[],
+  bStart: number,
+  bEnd: number,
+  indices: number[],
+): void {
+  if (aStart === aEnd || bStart === bEnd) {
+    return;
+  }
+  if (aEnd - aStart === 1) {
+    for (let j = bEnd - 1; j >= bStart; j--) {
+      if (a[aStart] === b[j]) {
+        indices.push(j);
+        return;
+      }
+    }
+    return;
   }
 
+  const aMiddle = aStart + Math.floor((aEnd - aStart) / 2);
+  const bMiddle = bStart + findSplit(a, aStart, aMiddle, aEnd, b, bStart, bEnd);
+  collectLcsIndices(a, aStart, aMiddle, b, bStart, bMiddle, indices);
+  collectLcsIndices(a, aMiddle, aEnd, b, bMiddle, bEnd, indices);
+}
+
+/** Returns the positions in b matched by a longest common subsequence of a and b. */
+export function lcsIndices(a: string[], b: string[]): number[] {
   const indices: number[] = [];
-  let i = a.length;
-  let j = b.length;
-  while (i > 0 && j > 0) {
-    if (a[i - 1] === b[j - 1]) {
-      indices.push(j - 1);
-      i--;
-      j--;
-    } else if (dp[i - 1][j] > dp[i][j - 1]) {
-      i--;
-    } else {
-      j--;
-    }
-  }
-  return indices.reverse();
+  collectLcsIndices(a, 0, a.length, b, 0, b.length, indices);
+  return indices;
 }

--- a/src/lcs.ts
+++ b/src/lcs.ts
@@ -12,7 +12,6 @@ function prefixLengths(
   let current = new Uint32Array(width + 1);
 
   for (let i = aStart; i < aEnd; i++) {
-    current[0] = 0;
     for (let j = 1; j <= width; j++) {
       current[j] =
         a[i] === b[bStart + j - 1] ? previous[j - 1] + 1 : Math.max(previous[j], current[j - 1]);
@@ -37,17 +36,15 @@ function findSplit(
   bEnd: number,
 ): number {
   const width = bEnd - bStart;
-  let previousLengths: Uint32Array = prefixLengths(a, aStart, aMiddle, b, bStart, bEnd);
+  let previousLengths = prefixLengths(a, aStart, aMiddle, b, bStart, bEnd);
   let currentLengths: Uint32Array = new Uint32Array(width + 1);
-  let previousOrigins: Uint32Array = new Uint32Array(width + 1);
-  let currentOrigins: Uint32Array = new Uint32Array(width + 1);
+  let previousOrigins = new Uint32Array(width + 1);
+  let currentOrigins = new Uint32Array(width + 1);
   for (let j = 0; j <= width; j++) {
     previousOrigins[j] = j;
   }
 
   for (let i = aMiddle; i < aEnd; i++) {
-    currentLengths[0] = 0;
-    currentOrigins[0] = 0;
     for (let j = 1; j <= width; j++) {
       if (a[i] === b[bStart + j - 1]) {
         currentLengths[j] = previousLengths[j - 1] + 1;

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import { buildSync } from 'esbuild';
+import { lcsIndices } from '../src/lcs';
 import * as rouge from '../src/rouge';
 
 const bracketPairs = [
@@ -143,6 +144,12 @@ describe('Utility Functions', () => {
     test('should preserve its choice when multiple longest subsequences exist', () => {
       expect(lcs(['a', 'b'], ['b', 'a'])).toEqual(['b']);
     });
+    test('should preserve reference-position choices when duplicate tokens tie', () => {
+      expect(lcsIndices(['a'], ['a', 'a'])).toEqual([1]);
+      expect(lcsIndices(['a', 'b'], ['b', 'a'])).toEqual([0]);
+      expect(lcsIndices(['a', 'a'], ['a', 'a', 'a'])).toEqual([1, 2]);
+      expect(lcsIndices(['a', 'b'], ['a', 'a'])).toEqual([0]);
+    });
     test('should return ["w1", "w3", "w5"] for ["w1", "w2", "w3", "w4", "w5"] and ["w1", "w3", "w8", "w9", "w5"]', () => {
       expect(lcs(['w1', 'w2', 'w3', 'w4', 'w5'], ['w1', 'w3', 'w8', 'w9', 'w5'])).toEqual([
         'w1',
@@ -150,6 +157,35 @@ describe('Utility Functions', () => {
         'w5',
       ]);
     });
+
+    test('should process long token sequences within a small heap', () => {
+      const bundled = buildSync({
+        entryPoints: [join(__dirname, '../src/rouge.ts')],
+        bundle: true,
+        platform: 'node',
+        target: 'node18',
+        write: false,
+      }).outputFiles[0].text;
+      const script = `${bundled}
+          const tokens = Array.from({ length: 4000 }, (_, index) => \`token-\${index}\`);
+          const result = module.exports.lcs(tokens, tokens);
+          if (result.length !== tokens.length || result[0] !== tokens[0] || result.at(-1) !== tokens.at(-1)) {
+            throw new Error('LCS content changed');
+          }
+          process.stdout.write('ok');
+        `;
+      const child = spawnSync(process.execPath, ['--max-old-space-size=64'], {
+        input: script,
+        encoding: 'utf8',
+        timeout: 30_000,
+      });
+      expect(child.error).toBeUndefined();
+      expect({ status: child.status, stderr: child.stderr }).toEqual({
+        status: 0,
+        stderr: '',
+      });
+      expect(child.stdout).toBe('ok');
+    }, 30_000);
   });
 
   describe('nGram', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -16,6 +16,36 @@ const invalidNGramSizes = [...nonFiniteNumbers, -1, 0, 1.5];
 const invalidMaxSkips = [Number.NaN, Number.NEGATIVE_INFINITY, -1, 0.5, 1.5];
 const invalidBetas = [Number.NaN, Number.NEGATIVE_INFINITY, -1];
 
+function legacyLcsIndices(a: string[], b: string[]): number[] {
+  const lengths = Array.from({ length: a.length + 1 }, () =>
+    new Array<number>(b.length + 1).fill(0),
+  );
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) {
+      lengths[i][j] =
+        a[i - 1] === b[j - 1]
+          ? lengths[i - 1][j - 1] + 1
+          : Math.max(lengths[i - 1][j], lengths[i][j - 1]);
+    }
+  }
+
+  const indices: number[] = [];
+  let i = a.length;
+  let j = b.length;
+  while (i > 0 && j > 0) {
+    if (a[i - 1] === b[j - 1]) {
+      indices.push(j - 1);
+      i--;
+      j--;
+    } else if (lengths[i - 1][j] > lengths[i][j - 1]) {
+      i--;
+    } else {
+      j--;
+    }
+  }
+  return indices.reverse();
+}
+
 describe('Utility Functions', () => {
   describe('fact', () => {
     const { fact } = rouge;
@@ -144,11 +174,19 @@ describe('Utility Functions', () => {
     test('should preserve its choice when multiple longest subsequences exist', () => {
       expect(lcs(['a', 'b'], ['b', 'a'])).toEqual(['b']);
     });
-    test('should preserve reference-position choices when duplicate tokens tie', () => {
-      expect(lcsIndices(['a'], ['a', 'a'])).toEqual([1]);
-      expect(lcsIndices(['a', 'b'], ['b', 'a'])).toEqual([0]);
-      expect(lcsIndices(['a', 'a'], ['a', 'a', 'a'])).toEqual([1, 2]);
-      expect(lcsIndices(['a', 'b'], ['a', 'a'])).toEqual([0]);
+    test('should preserve legacy reference-position choices', () => {
+      const sequences: string[][] = [[]];
+      for (let length = 1; length <= 5; length++) {
+        for (let bits = 0; bits < 2 ** length; bits++) {
+          sequences.push(Array.from({ length }, (_, index) => ((bits >> index) & 1 ? 'b' : 'a')));
+        }
+      }
+
+      for (const candidate of sequences) {
+        for (const reference of sequences) {
+          expect(lcsIndices(candidate, reference)).toEqual(legacyLcsIndices(candidate, reference));
+        }
+      }
     });
     test('should return ["w1", "w3", "w5"] for ["w1", "w2", "w3", "w4", "w5"] and ["w1", "w3", "w8", "w9", "w5"]', () => {
       expect(lcs(['w1', 'w2', 'w3', 'w4', 'w5'], ['w1', 'w3', 'w8', 'w9', 'w5'])).toEqual([


### PR DESCRIPTION
## Summary

- replace the boxed `O(mn)` LCS matrix with a divide-and-conquer implementation using linear auxiliary memory
- preserve the existing alignment and tie-breaking exactly, including repeated-token reference positions
- compare the implementation against a test-local legacy matrix oracle for all 3,969 binary sequence pairs of lengths 0 through 5
- retain a 4,000-by-4,000 heap-constrained stress test

## Why

The previous matrix can terminate Node through heap exhaustion on plausible long summaries. This addresses audit finding A2 without changing the public `lcs()` result or ROUGE-L matching semantics.

## Simplification pass

- removed redundant typed-array index-zero resets and inferable local annotations
- retained one explicit row annotation because TypeScript 7 otherwise narrows its buffer incompatibly during row swaps
- retained the split helper and range parameters because they separate two different recurrences and avoid slice allocations
- reduced the pass by 3 net lines (3 additions, 6 deletions)

## Validation

- exhaustive legacy-oracle comparison for tie behavior
- 4,000-token child process under a 64 MB heap
- `npm test -- --runInBand` (404 tests)
- `npm run type-check`
- Biome 2.5.10 strict check
- combined eight-PR stack: 497 tests, type-check, format checks, build, and packed-package smoke
