### PR TITLE
fix: bound built-in ROUGE-S memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ Omitted options and fields explicitly set to `undefined` use the documented defa
 
 ROUGE-N and ROUGE-S count repeated matching grams up to the smaller of their frequencies in the candidate and reference. Correcting earlier versions' set-based counting changes scores for repeated grams; rerun evaluation baselines when comparing versions.
 
+Built-in ROUGE-S scoring counts skip-bigram frequencies without allocating the full pair arrays. Calling the exported `skipBigram()` utility or supplying a custom `skipBigram` callback still materializes the callback's returned array.
+
 Built-in scoring preserves token boundaries even when custom tokenizers return tokens containing spaces, quotes, or separators. For example, `["new york", "city"]` and `["new", "york city"]` no longer count as the same bigram. The exported `nGram()` and `skipBigram()` utilities retain their readable, space-joined output strings; those strings are not collision-free identifiers for arbitrary token arrays. Custom gram generators still receive the original tokens and their returned strings are used as identities, so those callbacks remain responsible for any encoding they need.
 
 ### Limitations

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -64,6 +64,7 @@ function countMatchingGrams(candidate: string[], reference: string[]): number {
 }
 
 interface SharedTokenPositions {
+  token: string;
   candidate: number[];
   reference: number[];
 }
@@ -82,28 +83,38 @@ function tokenPositions(tokens: string[]): Map<string, number[]> {
   return positions;
 }
 
-/** Count ordered position pairs whose index distance is at most maxSkip. */
-function countSkipPairs(first: number[], second: number[], maxSkip: number): number {
+/** Count ordered position pairs for an unbounded skip window. */
+function countUnboundedSkipPairs(first: number[], second: number[]): number {
   let firstValid = 0;
-  let afterLastValid = 0;
   let pairs = 0;
 
   for (const firstPosition of first) {
     while (firstValid < second.length && second[firstValid] <= firstPosition) {
       firstValid++;
     }
-    if (afterLastValid < firstValid) {
-      afterLastValid = firstValid;
-    }
-
-    const lastPosition =
-      maxSkip === Number.POSITIVE_INFINITY ? Number.POSITIVE_INFINITY : firstPosition + maxSkip;
-    while (afterLastValid < second.length && second[afterLastValid] <= lastPosition) {
-      afterLastValid++;
-    }
-    pairs += afterLastValid - firstValid;
+    pairs += second.length - firstValid;
   }
   return pairs;
+}
+
+/** Count finite-window followers for one first-token value without retaining all pair types. */
+function countFollowingSharedTokens(
+  tokens: string[],
+  firstPositions: number[],
+  sharedTokens: Set<string>,
+  maxSkip: number,
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const firstPosition of firstPositions) {
+    const lastPosition = Math.min(firstPosition + maxSkip, tokens.length - 1);
+    for (let secondPosition = firstPosition + 1; secondPosition <= lastPosition; secondPosition++) {
+      const token = tokens[secondPosition];
+      if (sharedTokens.has(token)) {
+        counts.set(token, (counts.get(token) ?? 0) + 1);
+      }
+    }
+  }
+  return counts;
 }
 
 /** Count clipped built-in skip-bigram matches without materializing pair strings. */
@@ -120,6 +131,7 @@ function countMatchingSkipBigrams(
     const referenceTokenPositions = referencePositions.get(token);
     if (referenceTokenPositions) {
       shared.push({
+        token,
         candidate: candidateTokenPositions,
         reference: referenceTokenPositions,
       });
@@ -127,11 +139,33 @@ function countMatchingSkipBigrams(
   }
 
   let matches = 0;
+  if (maxSkip !== Number.POSITIVE_INFINITY) {
+    const sharedTokens = new Set(shared.map(({ token }) => token));
+    for (const first of shared) {
+      const candidateCounts = countFollowingSharedTokens(
+        candidate,
+        first.candidate,
+        sharedTokens,
+        maxSkip,
+      );
+      const referenceCounts = countFollowingSharedTokens(
+        reference,
+        first.reference,
+        sharedTokens,
+        maxSkip,
+      );
+      for (const [secondToken, candidateCount] of candidateCounts) {
+        matches += Math.min(candidateCount, referenceCounts.get(secondToken) ?? 0);
+      }
+    }
+    return matches;
+  }
+
   for (const first of shared) {
     for (const second of shared) {
-      const candidateCount = countSkipPairs(first.candidate, second.candidate, maxSkip);
+      const candidateCount = countUnboundedSkipPairs(first.candidate, second.candidate);
       if (candidateCount > 0) {
-        const referenceCount = countSkipPairs(first.reference, second.reference, maxSkip);
+        const referenceCount = countUnboundedSkipPairs(first.reference, second.reference);
         matches += Math.min(candidateCount, referenceCount);
       }
     }
@@ -280,6 +314,9 @@ export function s(cand: string, ref: string, opts?: RougeSOptions): number {
   const refTokens = tokenizeSummary(ref, caseSensitive, tokenizer);
   if (refTokens.length < 2) {
     throw new RangeError('Input must have at least two words');
+  }
+  if (maxSkip === 0) {
+    return 0;
   }
 
   const skip2 = countMatchingSkipBigrams(candTokens, refTokens, maxSkip);

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -64,7 +64,6 @@ function countMatchingGrams(candidate: string[], reference: string[]): number {
 }
 
 interface SharedTokenPositions {
-  token: string;
   candidate: number[];
   reference: number[];
 }
@@ -101,7 +100,7 @@ function countUnboundedSkipPairs(first: number[], second: number[]): number {
 function countFollowingSharedTokens(
   tokens: string[],
   firstPositions: number[],
-  sharedTokens: Set<string>,
+  sharedPositions: ReadonlyMap<string, number[]>,
   maxSkip: number,
 ): Map<string, number> {
   const counts = new Map<string, number>();
@@ -109,7 +108,7 @@ function countFollowingSharedTokens(
     const lastPosition = Math.min(firstPosition + maxSkip, tokens.length - 1);
     for (let secondPosition = firstPosition + 1; secondPosition <= lastPosition; secondPosition++) {
       const token = tokens[secondPosition];
-      if (sharedTokens.has(token)) {
+      if (sharedPositions.has(token)) {
         counts.set(token, (counts.get(token) ?? 0) + 1);
       }
     }
@@ -131,7 +130,6 @@ function countMatchingSkipBigrams(
     const referenceTokenPositions = referencePositions.get(token);
     if (referenceTokenPositions) {
       shared.push({
-        token,
         candidate: candidateTokenPositions,
         reference: referenceTokenPositions,
       });
@@ -140,18 +138,17 @@ function countMatchingSkipBigrams(
 
   let matches = 0;
   if (maxSkip !== Number.POSITIVE_INFINITY) {
-    const sharedTokens = new Set(shared.map(({ token }) => token));
     for (const first of shared) {
       const candidateCounts = countFollowingSharedTokens(
         candidate,
         first.candidate,
-        sharedTokens,
+        referencePositions,
         maxSkip,
       );
       const referenceCounts = countFollowingSharedTokens(
         reference,
         first.reference,
-        sharedTokens,
+        candidatePositions,
         maxSkip,
       );
       for (const [secondToken, candidateCount] of candidateCounts) {

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -63,6 +63,87 @@ function countMatchingGrams(candidate: string[], reference: string[]): number {
   return matches;
 }
 
+interface SharedTokenPositions {
+  candidate: number[];
+  reference: number[];
+}
+
+function tokenPositions(tokens: string[]): Map<string, number[]> {
+  const positions = new Map<string, number[]>();
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index];
+    const existing = positions.get(token);
+    if (existing) {
+      existing.push(index);
+    } else {
+      positions.set(token, [index]);
+    }
+  }
+  return positions;
+}
+
+/** Count ordered position pairs whose index distance is at most maxSkip. */
+function countSkipPairs(first: number[], second: number[], maxSkip: number): number {
+  let firstValid = 0;
+  let afterLastValid = 0;
+  let pairs = 0;
+
+  for (const firstPosition of first) {
+    while (firstValid < second.length && second[firstValid] <= firstPosition) {
+      firstValid++;
+    }
+    if (afterLastValid < firstValid) {
+      afterLastValid = firstValid;
+    }
+
+    const lastPosition =
+      maxSkip === Number.POSITIVE_INFINITY ? Number.POSITIVE_INFINITY : firstPosition + maxSkip;
+    while (afterLastValid < second.length && second[afterLastValid] <= lastPosition) {
+      afterLastValid++;
+    }
+    pairs += afterLastValid - firstValid;
+  }
+  return pairs;
+}
+
+/** Count clipped built-in skip-bigram matches without materializing pair strings. */
+function countMatchingSkipBigrams(
+  candidate: string[],
+  reference: string[],
+  maxSkip: number,
+): number {
+  const candidatePositions = tokenPositions(candidate);
+  const referencePositions = tokenPositions(reference);
+  const shared: SharedTokenPositions[] = [];
+
+  for (const [token, candidateTokenPositions] of candidatePositions) {
+    const referenceTokenPositions = referencePositions.get(token);
+    if (referenceTokenPositions) {
+      shared.push({
+        candidate: candidateTokenPositions,
+        reference: referenceTokenPositions,
+      });
+    }
+  }
+
+  let matches = 0;
+  for (const first of shared) {
+    for (const second of shared) {
+      const candidateCount = countSkipPairs(first.candidate, second.candidate, maxSkip);
+      if (candidateCount > 0) {
+        const referenceCount = countSkipPairs(first.reference, second.reference, maxSkip);
+        matches += Math.min(candidateCount, referenceCount);
+      }
+    }
+  }
+  return matches;
+}
+
+function skipBigramCount(tokenCount: number, maxSkip: number): number {
+  const distance = Math.min(maxSkip, tokenCount - 1);
+  return distance * tokenCount - (distance * (distance + 1)) / 2;
+}
+
 /** The built-in tokenizer expects sentences; custom tokenizers receive whole summaries. */
 function tokenizeSummary(
   input: string,
@@ -182,20 +263,31 @@ export function s(cand: string, ref: string, opts?: RougeSOptions): number {
   validateMaxSkip(maxSkip);
   validateBeta(beta);
 
-  const getGrams = (input: string): string[] => {
-    const tokens = tokenizeSummary(input, caseSensitive, tokenizer);
-    return skipBigram(skipBigram === utils.skipBigram ? encodeTokens(tokens) : tokens, maxSkip);
-  };
-  const candGrams = getGrams(cand);
-  const refGrams = getGrams(ref);
+  if (skipBigram !== utils.skipBigram) {
+    const candGrams = skipBigram(tokenizeSummary(cand, caseSensitive, tokenizer), maxSkip);
+    const refGrams = skipBigram(tokenizeSummary(ref, caseSensitive, tokenizer), maxSkip);
+    const skip2 = countMatchingGrams(candGrams, refGrams);
+    if (skip2 === 0) {
+      return 0;
+    }
+    return utils.fMeasure(skip2 / candGrams.length, skip2 / refGrams.length, beta);
+  }
 
-  const skip2 = countMatchingGrams(candGrams, refGrams);
+  const candTokens = tokenizeSummary(cand, caseSensitive, tokenizer);
+  if (candTokens.length < 2) {
+    throw new RangeError('Input must have at least two words');
+  }
+  const refTokens = tokenizeSummary(ref, caseSensitive, tokenizer);
+  if (refTokens.length < 2) {
+    throw new RangeError('Input must have at least two words');
+  }
 
+  const skip2 = countMatchingSkipBigrams(candTokens, refTokens, maxSkip);
   if (skip2 === 0) {
     return 0;
   }
-  const skip2Recall = skip2 / refGrams.length;
-  const skip2Prec = skip2 / candGrams.length;
+  const skip2Recall = skip2 / skipBigramCount(refTokens.length, maxSkip);
+  const skip2Prec = skip2 / skipBigramCount(candTokens.length, maxSkip);
 
   return utils.fMeasure(skip2Prec, skip2Recall, beta);
 }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1446,6 +1446,37 @@ describe('Core Functions', () => {
       expect(child.stdout).toBe('ok');
     }, 30_000);
 
+    test('should score finite windows without scanning every distinct token pair', () => {
+      const bundled = buildSync({
+        entryPoints: [join(__dirname, '../src/rouge.ts')],
+        bundle: true,
+        platform: 'node',
+        target: 'node18',
+        write: false,
+      }).outputFiles[0].text;
+      const script = `${bundled}
+          const summary = Array.from({ length: 30000 }, (_, index) => \`token\${index}\`).join(' ');
+          if (module.exports.s(summary, summary, { maxSkip: 0 }) !== 0) {
+            throw new Error('zero-window score changed');
+          }
+          if (module.exports.s(summary, summary, { maxSkip: 1 }) !== 1) {
+            throw new Error('finite-window score changed');
+          }
+          process.stdout.write('ok');
+        `;
+      const child = spawnSync(process.execPath, [], {
+        input: script,
+        encoding: 'utf8',
+        timeout: 3000,
+      });
+      expect(child.error).toBeUndefined();
+      expect({ status: child.status, stderr: child.stderr }).toEqual({
+        status: 0,
+        stderr: '',
+      });
+      expect(child.stdout).toBe('ok');
+    }, 10_000);
+
     test('should respect maxSkip option', () => {
       // With maxSkip=1, only adjacent pairs are considered
       // cand: 'police kill the gunman' -> adjacent pairs: 'police kill', 'kill the', 'the gunman'

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -15,6 +15,29 @@ const invalidNGramSizes = [...nonFiniteNumbers, -1, 0, 1.5];
 const invalidMaxSkips = [Number.NaN, Number.NEGATIVE_INFINITY, -1, 0.5, 1.5];
 const invalidBetas = [Number.NaN, Number.NEGATIVE_INFINITY, -1];
 
+function expectBundledScriptToPass(script: string, timeout: number, nodeArgs: string[] = []): void {
+  const bundled = buildSync({
+    entryPoints: [join(__dirname, '../src/rouge.ts')],
+    bundle: true,
+    platform: 'node',
+    target: 'node18',
+    write: false,
+  }).outputFiles[0].text;
+  const child = spawnSync(process.execPath, nodeArgs, {
+    input: `${bundled}\n${script}`,
+    encoding: 'utf8',
+    timeout,
+  });
+  if (child.error) {
+    throw child.error;
+  }
+  if (child.status !== 0 || child.stderr !== '' || child.stdout !== 'ok') {
+    throw new Error(
+      `Bundled script failed: ${JSON.stringify({ status: child.status, stderr: child.stderr, stdout: child.stdout })}`,
+    );
+  }
+}
+
 describe('Utility Functions', () => {
   describe('fact', () => {
     const { fact } = rouge;
@@ -618,14 +641,8 @@ describe('Utility Functions', () => {
       const TIMEOUT_MS = 500;
 
       test('should segment abbreviation chains within a small heap', () => {
-        const bundled = buildSync({
-          entryPoints: [join(__dirname, '../src/rouge.ts')],
-          bundle: true,
-          platform: 'node',
-          target: 'node18',
-          write: false,
-        }).outputFiles[0].text;
-        const script = `${bundled}
+        expectBundledScriptToPass(
+          `
           for (const [fragment, normalized] of [['Dr. ', 'Dr. '], ['e.g. ', 'e.g. '], ['Dr.\\n', 'Dr. ']]) {
             const summary = fragment.repeat(5000) + 'End.';
             const sentences = module.exports.sentenceSegment(summary);
@@ -637,15 +654,10 @@ describe('Utility Functions', () => {
             }
           }
           process.stdout.write('ok');
-        `;
-        const child = spawnSync(process.execPath, ['--max-old-space-size=64'], {
-          input: script,
-          encoding: 'utf8',
-          timeout: 15_000,
-        });
-        expect(child.error).toBeUndefined();
-        expect({ status: child.status, stderr: child.stderr }).toEqual({ status: 0, stderr: '' });
-        expect(child.stdout).toBe('ok');
+        `,
+          15_000,
+          ['--max-old-space-size=64'],
+        );
       });
 
       test('should handle long strings without sentence terminators quickly', () => {
@@ -1398,11 +1410,11 @@ describe('Core Functions', () => {
       }
 
       for (const candidate of sequences) {
+        const candidateJson = JSON.stringify(candidate);
         for (const reference of sequences) {
+          const referenceJson = JSON.stringify(reference);
           for (const maxSkip of [0, 1, 2, Number.POSITIVE_INFINITY]) {
             for (const beta of [0, 1, Number.POSITIVE_INFINITY]) {
-              const candidateJson = JSON.stringify(candidate);
-              const referenceJson = JSON.stringify(reference);
               expect(s(candidateJson, referenceJson, { tokenizer, maxSkip, beta })).toBeCloseTo(
                 s(candidateJson, referenceJson, {
                   tokenizer,
@@ -1419,42 +1431,22 @@ describe('Core Functions', () => {
     });
 
     test('should score long summaries within a small heap', () => {
-      const bundled = buildSync({
-        entryPoints: [join(__dirname, '../src/rouge.ts')],
-        bundle: true,
-        platform: 'node',
-        target: 'node18',
-        write: false,
-      }).outputFiles[0].text;
-      const script = `${bundled}
+      expectBundledScriptToPass(
+        `
           const summary = Array.from({ length: 5000 }, () => 'a').join(' ');
           if (module.exports.s(summary, summary) !== 1) {
             throw new Error('ROUGE-S score changed');
           }
           process.stdout.write('ok');
-        `;
-      const child = spawnSync(process.execPath, ['--max-old-space-size=64'], {
-        input: script,
-        encoding: 'utf8',
-        timeout: 30_000,
-      });
-      expect(child.error).toBeUndefined();
-      expect({ status: child.status, stderr: child.stderr }).toEqual({
-        status: 0,
-        stderr: '',
-      });
-      expect(child.stdout).toBe('ok');
+        `,
+        30_000,
+        ['--max-old-space-size=64'],
+      );
     }, 30_000);
 
     test('should score finite windows without scanning every distinct token pair', () => {
-      const bundled = buildSync({
-        entryPoints: [join(__dirname, '../src/rouge.ts')],
-        bundle: true,
-        platform: 'node',
-        target: 'node18',
-        write: false,
-      }).outputFiles[0].text;
-      const script = `${bundled}
+      expectBundledScriptToPass(
+        `
           const summary = Array.from({ length: 30000 }, (_, index) => \`token\${index}\`).join(' ');
           if (module.exports.s(summary, summary, { maxSkip: 0 }) !== 0) {
             throw new Error('zero-window score changed');
@@ -1463,18 +1455,9 @@ describe('Core Functions', () => {
             throw new Error('finite-window score changed');
           }
           process.stdout.write('ok');
-        `;
-      const child = spawnSync(process.execPath, [], {
-        input: script,
-        encoding: 'utf8',
-        timeout: 3000,
-      });
-      expect(child.error).toBeUndefined();
-      expect({ status: child.status, stderr: child.stderr }).toEqual({
-        status: 0,
-        stderr: '',
-      });
-      expect(child.stdout).toBe('ok');
+        `,
+        3000,
+      );
     }, 10_000);
 
     test('should respect maxSkip option', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1334,6 +1334,20 @@ describe('Core Functions', () => {
     test('should throw RangeError for empty ref', () => {
       expect(() => s(cands[0], '', undefined as any)).toThrow(RangeError);
     });
+    test('should throw RangeError for a candidate with fewer than two tokens', () => {
+      expect(() => s('one', 'one two')).toThrow(RangeError);
+    });
+    test('should throw RangeError for a reference with fewer than two tokens', () => {
+      expect(() => s('one two', 'one')).toThrow(RangeError);
+    });
+    test('should let custom generators define short-token behavior', () => {
+      const skipBigram = jest.fn((): string[] => ['custom gram']);
+      expect(s('one', 'one', { skipBigram })).toBe(1);
+      expect(skipBigram.mock.calls).toEqual([
+        [['one'], Number.POSITIVE_INFINITY],
+        [['one'], Number.POSITIVE_INFINITY],
+      ]);
+    });
 
     test('should return 0 for summaries with zero overlap', () => {
       expect(s('banana yoghurt', ref, undefined as any)).toBe(0);
@@ -1368,6 +1382,69 @@ describe('Core Functions', () => {
     test('should preserve the zero-window behavior', () => {
       expect(s('a b', 'a b', { maxSkip: 0 })).toBe(0);
     });
+
+    test('should match materialized skip-bigram scoring exhaustively', () => {
+      const tokenizer = (input: string): string[] => JSON.parse(input);
+      const materialized = (tokens: string[], maxSkip?: number): string[] =>
+        rouge.skipBigram(
+          tokens.map((token) => JSON.stringify(token)),
+          maxSkip,
+        );
+      const sequences: string[][] = [];
+      for (let length = 2; length <= 4; length++) {
+        for (let value = 0; value < 2 ** length; value++) {
+          sequences.push(Array.from({ length }, (_, index) => (value & (1 << index) ? 'a' : 'b')));
+        }
+      }
+
+      for (const candidate of sequences) {
+        for (const reference of sequences) {
+          for (const maxSkip of [0, 1, 2, Number.POSITIVE_INFINITY]) {
+            for (const beta of [0, 1, Number.POSITIVE_INFINITY]) {
+              const candidateJson = JSON.stringify(candidate);
+              const referenceJson = JSON.stringify(reference);
+              expect(s(candidateJson, referenceJson, { tokenizer, maxSkip, beta })).toBeCloseTo(
+                s(candidateJson, referenceJson, {
+                  tokenizer,
+                  maxSkip,
+                  beta,
+                  skipBigram: materialized,
+                }),
+                12,
+              );
+            }
+          }
+        }
+      }
+    });
+
+    test('should score long summaries within a small heap', () => {
+      const bundled = buildSync({
+        entryPoints: [join(__dirname, '../src/rouge.ts')],
+        bundle: true,
+        platform: 'node',
+        target: 'node18',
+        write: false,
+      }).outputFiles[0].text;
+      const script = `${bundled}
+          const summary = Array.from({ length: 5000 }, () => 'a').join(' ');
+          if (module.exports.s(summary, summary) !== 1) {
+            throw new Error('ROUGE-S score changed');
+          }
+          process.stdout.write('ok');
+        `;
+      const child = spawnSync(process.execPath, ['--max-old-space-size=64'], {
+        input: script,
+        encoding: 'utf8',
+        timeout: 30_000,
+      });
+      expect(child.error).toBeUndefined();
+      expect({ status: child.status, stderr: child.stderr }).toEqual({
+        status: 0,
+        stderr: '',
+      });
+      expect(child.stdout).toBe('ok');
+    }, 30_000);
 
     test('should respect maxSkip option', () => {
       // With maxSkip=1, only adjacent pairs are considered


### PR DESCRIPTION
## Summary

- count built-in skip-bigram matches from token-position lists instead of materializing quadratic arrays of encoded strings
- compute finite windows by visiting only eligible position pairs, with an immediate built-in zero-window return
- compute built-in denominators directly while retaining clipped multiplicity and `maxSkip` behavior
- keep custom generators and the public `skipBigram()` utility on their existing materialized-array contract
- retain separate bounded and unbounded counting paths because they enforce different performance bounds

## Why

The default all-pairs ROUGE-S path previously allocated `O(n^2)` skip-bigram strings and could abort Node with an out-of-memory failure. The first position-based replacement also scanned the Cartesian product of token values for bounded windows. This addresses audit finding A1 while keeping finite-window work proportional to eligible position pairs and preserving the extension API.

## Simplification pass

- reused the opposite summary's position map for membership checks, removing copied token names and a derived `Set`
- extracted the three repeated bundle/child-process assertions into one test helper while leaving heap and timeout limits at each call site
- retained separate finite and unbounded counters because combining them would add mode flags or weaken the complexity bound
- reduced the pass by 20 net lines (46 additions, 66 deletions)

## Validation

- 9,408 exhaustive comparisons against the previous materialized scorer
- 5,000-token all-pairs test under a 64 MB heap
- 30,000-distinct-token finite- and zero-window regression
- `npm test -- --runInBand` (408 tests)
- `npm run type-check`
- Biome 2.5.10 strict check
- combined eight-PR stack: 497 tests, type-check, format checks, build, and packed-package smoke
