### PR TITLE
fix: harden utility contracts and resampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ These preprocessing corrections can change scores for multi-sentence summaries, 
 
 Omitted options and fields explicitly set to `undefined` use the documented defaults. Explicit `false`, `0`, and `Infinity` values are preserved where supported.
 
-`n` must be a positive safe integer. `maxSkip` must be a non-negative integer or positive `Infinity`. `beta` must be a non-negative finite number or positive `Infinity`; `NaN` is never valid. Invalid numeric options throw `RangeError` before tokenization or a zero-overlap return, including with custom gram generators. The public `nGram`, `skipBigram`, and `fMeasure` utilities enforce the same numeric contracts, and `fMeasure` requires finite precision and recall in `[0, 1]`. Large finite beta values produce finite scores.
+`n` must be a positive safe integer. `maxSkip` must be a non-negative integer or positive `Infinity`. `beta` must be a non-negative finite number or positive `Infinity`; `NaN` is never valid. Invalid numeric options throw `RangeError` before tokenization or a zero-overlap return, including with custom gram generators. The public `nGram`, `skipBigram`, and `fMeasure` utilities enforce the same numeric contracts, and `fMeasure` requires finite precision and recall in `[0, 1]`. Large finite beta values produce finite scores. The built-in `nGram()` rejects padded requests that would materialize more than one million padding-induced token positions; custom generators are unaffected.
 
 ### ROUGE-N Options
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ These preprocessing corrections can change scores for multi-sentence summaries, 
 
 Omitted options and fields explicitly set to `undefined` use the documented defaults. Explicit `false`, `0`, and `Infinity` values are preserved where supported.
 
-`n` must be a positive integer. `maxSkip` must be a non-negative integer or positive `Infinity`. `beta` must be a non-negative finite number or positive `Infinity`; `NaN` is never valid. Invalid numeric options throw `RangeError` before tokenization or a zero-overlap return, including with custom gram generators. The public `nGram`, `skipBigram`, and `fMeasure` utilities enforce the same numeric contracts, and `fMeasure` requires finite precision and recall in `[0, 1]`. Large finite beta values produce finite scores.
+`n` must be a positive safe integer. `maxSkip` must be a non-negative integer or positive `Infinity`. `beta` must be a non-negative finite number or positive `Infinity`; `NaN` is never valid. Invalid numeric options throw `RangeError` before tokenization or a zero-overlap return, including with custom gram generators. The public `nGram`, `skipBigram`, and `fMeasure` utilities enforce the same numeric contracts, and `fMeasure` requires finite precision and recall in `[0, 1]`. Large finite beta values produce finite scores.
 
 ### ROUGE-N Options
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -567,6 +567,13 @@ export function nGram(tokens: string[], n = 2, pad: Partial<NGramOptions> = {}):
       val: pad.val ?? NGRAM_DEFAULT_OPTS.val,
     };
 
+    const paddingSize = n - 1;
+    const paddedLength =
+      tokens.length + (config.start ? paddingSize : 0) + (config.end ? paddingSize : 0);
+    if (paddedLength < n) {
+      throw new RangeError('ngram size cannot be larger than the number of tokens available');
+    }
+
     // Clone the input token array to avoid mutating the source data
     workingTokens = tokens.slice();
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -558,10 +558,6 @@ export const NGRAM_DEFAULT_OPTS: NGramOptions = {
 export function nGram(tokens: string[], n = 2, pad: Partial<NGramOptions> = {}): string[] {
   validateNGramSize(n);
 
-  if (tokens.length < n) {
-    throw new RangeError('ngram size cannot be larger than the number of tokens available');
-  }
-
   let workingTokens = tokens;
 
   if (Object.keys(pad).length > 0) {
@@ -586,6 +582,10 @@ export function nGram(tokens: string[], n = 2, pad: Partial<NGramOptions> = {}):
     }
   }
 
+  if (workingTokens.length < n) {
+    throw new RangeError('ngram size cannot be larger than the number of tokens available');
+  }
+
   const acc: string[] = [];
   for (let idx = 0; idx < workingTokens.length - n + 1; idx++) {
     acc.push(workingTokens.slice(idx, idx + n).join(' '));
@@ -603,10 +603,14 @@ export function nGram(tokens: string[], n = 2, pad: Partial<NGramOptions> = {}):
  * @return {number}         The number of ways in which 2 items can be chosen from `val`
  */
 export function comb2(val: number): number {
-  if (val < 2) {
-    throw new RangeError('Input must be greater than 2');
+  if (!Number.isSafeInteger(val) || val < 2) {
+    throw new RangeError('Input must be a safe integer greater than or equal to 2');
   }
-  return 0.5 * val * (val - 1);
+  const result = (val * (val - 1)) / 2;
+  if (!Number.isSafeInteger(result)) {
+    throw new RangeError('Result exceeds Number.MAX_SAFE_INTEGER');
+  }
+  return result;
 }
 
 /**
@@ -652,15 +656,18 @@ export function jackKnife(
 
   const pairs: number[] = cands.map((c) => func(c, ref));
 
-  const acc: number[] = [];
+  const prefixMax = new Array<number>(pairs.length + 1);
+  const suffixMax = new Array<number>(pairs.length + 1);
+  prefixMax[0] = Number.NEGATIVE_INFINITY;
+  suffixMax[pairs.length] = Number.NEGATIVE_INFINITY;
   for (let idx = 0; idx < pairs.length; idx++) {
-    // Clone the array and remove one element
-    const leaveOneOut = pairs.slice(0);
-    leaveOneOut.splice(idx, 1);
-
-    acc.push(Math.max(...leaveOneOut));
+    prefixMax[idx + 1] = Math.max(prefixMax[idx], pairs[idx]);
+  }
+  for (let idx = pairs.length - 1; idx >= 0; idx--) {
+    suffixMax[idx] = Math.max(suffixMax[idx + 1], pairs[idx]);
   }
 
+  const acc = pairs.map((_, idx) => Math.max(prefixMax[idx], suffixMax[idx + 1]));
   return test(acc);
 }
 
@@ -672,7 +679,7 @@ export function jackKnife(
  * F_β = ((1 + β²) × P × R) / (β² × P + R)
  *
  * Beta controls the tradeoff between precision and recall:
- * - beta = 0: Pure precision (F₀ = P)
+ * - beta = 0: Pure precision when recall is positive; zero when recall is zero
  * - beta = 1: F1 score (harmonic mean, equal weight)
  * - beta = 2: F2 score (weighs recall twice as much as precision)
  * - beta = Infinity: Pure recall

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -558,24 +558,19 @@ export const NGRAM_DEFAULT_OPTS: NGramOptions = {
 export function nGram(tokens: string[], n = 2, pad: Partial<NGramOptions> = {}): string[] {
   validateNGramSize(n);
 
-  const config = {
-    start: pad.start ?? NGRAM_DEFAULT_OPTS.start,
-    end: pad.end ?? NGRAM_DEFAULT_OPTS.end,
-    val: pad.val ?? NGRAM_DEFAULT_OPTS.val,
-  };
+  const start = pad.start ?? NGRAM_DEFAULT_OPTS.start;
+  const end = pad.end ?? NGRAM_DEFAULT_OPTS.end;
+  const value = pad.val ?? NGRAM_DEFAULT_OPTS.val;
   const paddingSize = n - 1;
-  const paddedLength =
-    tokens.length + (config.start ? paddingSize : 0) + (config.end ? paddingSize : 0);
+  const paddedLength = tokens.length + (start ? paddingSize : 0) + (end ? paddingSize : 0);
   if (paddedLength < n) {
     throw new RangeError('ngram size cannot be larger than the number of tokens available');
   }
 
-  const startPadding = config.start ? new Array<string>(paddingSize).fill(config.val) : [];
-  const endPadding = config.end ? new Array<string>(paddingSize).fill(config.val) : [];
+  const startPadding = start ? new Array<string>(paddingSize).fill(value) : [];
+  const endPadding = end ? new Array<string>(paddingSize).fill(value) : [];
   const workingTokens =
-    startPadding.length === 0 && endPadding.length === 0
-      ? tokens
-      : startPadding.concat(tokens, endPadding);
+    paddedLength === tokens.length ? tokens : startPadding.concat(tokens, endPadding);
 
   const acc: string[] = [];
   for (let idx = 0; idx < workingTokens.length - n + 1; idx++) {
@@ -645,21 +640,22 @@ export function jackKnife(
     throw new RangeError('Candidate array must contain more than one element');
   }
 
-  const pairs: number[] = cands.map((c) => func(c, ref));
+  const scores = cands.map((candidate) => func(candidate, ref));
 
-  const prefixMax = new Array<number>(pairs.length + 1);
-  const suffixMax = new Array<number>(pairs.length + 1);
-  prefixMax[0] = Number.NEGATIVE_INFINITY;
-  suffixMax[pairs.length] = Number.NEGATIVE_INFINITY;
-  for (let idx = 0; idx < pairs.length; idx++) {
-    prefixMax[idx + 1] = Math.max(prefixMax[idx], pairs[idx]);
-  }
-  for (let idx = pairs.length - 1; idx >= 0; idx--) {
-    suffixMax[idx] = Math.max(suffixMax[idx + 1], pairs[idx]);
+  const suffixMax = new Array<number>(scores.length + 1);
+  suffixMax[scores.length] = Number.NEGATIVE_INFINITY;
+  for (let idx = scores.length - 1; idx >= 0; idx--) {
+    suffixMax[idx] = Math.max(suffixMax[idx + 1], scores[idx]);
   }
 
-  const acc = pairs.map((_, idx) => Math.max(prefixMax[idx], suffixMax[idx + 1]));
-  return test(acc);
+  const leaveOneOutMaxima = new Array<number>(scores.length);
+  let prefixMax = Number.NEGATIVE_INFINITY;
+  for (let idx = 0; idx < scores.length; idx++) {
+    leaveOneOutMaxima[idx] = Math.max(prefixMax, suffixMax[idx + 1]);
+    prefixMax = Math.max(prefixMax, scores[idx]);
+  }
+
+  return test(leaveOneOutMaxima);
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -546,6 +546,8 @@ export const NGRAM_DEFAULT_OPTS: NGramOptions = {
   val: '<S>',
 };
 
+const MAX_NGRAM_PADDING_WORK = 1_000_000;
+
 /**
  * Returns n-grams for an array of word tokens.
  *
@@ -562,18 +564,30 @@ export function nGram(tokens: string[], n = 2, pad: Partial<NGramOptions> = {}):
   const end = pad.end ?? NGRAM_DEFAULT_OPTS.end;
   const value = pad.val ?? NGRAM_DEFAULT_OPTS.val;
   const paddingSize = n - 1;
-  const paddedLength = tokens.length + (start ? paddingSize : 0) + (end ? paddingSize : 0);
+  const startPaddingSize = start ? paddingSize : 0;
+  const endPaddingSize = end ? paddingSize : 0;
+  const paddingLength = startPaddingSize + endPaddingSize;
+  const paddedLength = tokens.length + paddingLength;
   if (paddedLength < n) {
     throw new RangeError('ngram size cannot be larger than the number of tokens available');
   }
 
-  const startPadding = start ? new Array<string>(paddingSize).fill(value) : [];
-  const endPadding = end ? new Array<string>(paddingSize).fill(value) : [];
-  const workingTokens =
-    paddedLength === tokens.length ? tokens : startPadding.concat(tokens, endPadding);
+  const gramCount = paddedLength - n + 1;
+  const unpaddedGramCount = Math.max(tokens.length - n + 1, 0);
+  const paddingWork = paddingLength + n * (gramCount - unpaddedGramCount);
+  if (
+    paddingLength > 0 &&
+    (!Number.isSafeInteger(paddingWork) || paddingWork > MAX_NGRAM_PADDING_WORK)
+  ) {
+    throw new RangeError('Padded n-gram generation exceeds the materialization limit');
+  }
+
+  const startPadding = new Array<string>(startPaddingSize).fill(value);
+  const endPadding = new Array<string>(endPaddingSize).fill(value);
+  const workingTokens = paddingLength === 0 ? tokens : startPadding.concat(tokens, endPadding);
 
   const acc: string[] = [];
-  for (let idx = 0; idx < workingTokens.length - n + 1; idx++) {
+  for (let idx = 0; idx < gramCount; idx++) {
     acc.push(workingTokens.slice(idx, idx + n).join(' '));
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -558,40 +558,24 @@ export const NGRAM_DEFAULT_OPTS: NGramOptions = {
 export function nGram(tokens: string[], n = 2, pad: Partial<NGramOptions> = {}): string[] {
   validateNGramSize(n);
 
-  let workingTokens = tokens;
-
-  if (Object.keys(pad).length > 0) {
-    const config = {
-      start: pad.start ?? NGRAM_DEFAULT_OPTS.start,
-      end: pad.end ?? NGRAM_DEFAULT_OPTS.end,
-      val: pad.val ?? NGRAM_DEFAULT_OPTS.val,
-    };
-
-    const paddingSize = n - 1;
-    const paddedLength =
-      tokens.length + (config.start ? paddingSize : 0) + (config.end ? paddingSize : 0);
-    if (paddedLength < n) {
-      throw new RangeError('ngram size cannot be larger than the number of tokens available');
-    }
-
-    // Clone the input token array to avoid mutating the source data
-    workingTokens = tokens.slice();
-
-    if (config.start) {
-      for (let i = 0; i < n - 1; i++) {
-        workingTokens.unshift(config.val);
-      }
-    }
-    if (config.end) {
-      for (let i = 0; i < n - 1; i++) {
-        workingTokens.push(config.val);
-      }
-    }
-  }
-
-  if (workingTokens.length < n) {
+  const config = {
+    start: pad.start ?? NGRAM_DEFAULT_OPTS.start,
+    end: pad.end ?? NGRAM_DEFAULT_OPTS.end,
+    val: pad.val ?? NGRAM_DEFAULT_OPTS.val,
+  };
+  const paddingSize = n - 1;
+  const paddedLength =
+    tokens.length + (config.start ? paddingSize : 0) + (config.end ? paddingSize : 0);
+  if (paddedLength < n) {
     throw new RangeError('ngram size cannot be larger than the number of tokens available');
   }
+
+  const startPadding = config.start ? new Array<string>(paddingSize).fill(config.val) : [];
+  const endPadding = config.end ? new Array<string>(paddingSize).fill(config.val) : [];
+  const workingTokens =
+    startPadding.length === 0 && endPadding.length === 0
+      ? tokens
+      : startPadding.concat(tokens, endPadding);
 
   const acc: string[] = [];
   for (let idx = 0; idx < workingTokens.length - n + 1; idx++) {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,7 +1,7 @@
 /** Shared numeric contracts for the scorers and their public utilities. */
 export function validateNGramSize(n: number): void {
-  if (!Number.isInteger(n) || n < 1) {
-    throw new RangeError('ngram size must be a positive integer');
+  if (!Number.isSafeInteger(n) || n < 1) {
+    throw new RangeError('ngram size must be a positive safe integer');
   }
 }
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -251,20 +251,20 @@ describe('Utility Functions', () => {
       expect(() => nGram(['a'], 3, { start: false, end: false })).toThrow(RangeError);
     });
 
-    test.each([
-      1_000_000_000,
-      2 ** 54,
-    ])('should reject impossible padding size %s before materializing it', (size) => {
-      const unshift = jest.spyOn(Array.prototype, 'unshift').mockImplementation((): number => {
-        throw new Error('padding should not be materialized');
-      });
-      try {
-        expect(() => nGram([], size, { start: true })).toThrow(RangeError);
-        expect(unshift).not.toHaveBeenCalled();
-      } finally {
-        unshift.mockRestore();
-      }
-    });
+    test.each([1_000_000_000, 2 ** 54])(
+      'should reject impossible padding size %s before materializing it',
+      (size) => {
+        const unshift = jest.spyOn(Array.prototype, 'unshift').mockImplementation((): number => {
+          throw new Error('padding should not be materialized');
+        });
+        try {
+          expect(() => nGram([], size, { start: true })).toThrow(RangeError);
+          expect(unshift).not.toHaveBeenCalled();
+        } finally {
+          unshift.mockRestore();
+        }
+      },
+    );
   });
 
   describe('skipBigram', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -250,6 +250,18 @@ describe('Utility Functions', () => {
       expect(() => nGram([], 2, { start: true })).toThrow(RangeError);
       expect(() => nGram(['a'], 3, { start: false, end: false })).toThrow(RangeError);
     });
+
+    test('should reject impossible large padding before materializing it', () => {
+      const unshift = jest.spyOn(Array.prototype, 'unshift').mockImplementation((): number => {
+        throw new Error('padding should not be materialized');
+      });
+      try {
+        expect(() => nGram([], 1_000_000_000, { start: true })).toThrow(RangeError);
+        expect(unshift).not.toHaveBeenCalled();
+      } finally {
+        unshift.mockRestore();
+      }
+    });
   });
 
   describe('skipBigram', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -50,6 +50,13 @@ describe('Utility Functions', () => {
     test('should throw RangeError for C(1,2)', () => {
       expect(() => comb2(1)).toThrow(RangeError);
     });
+    test.each([...nonFiniteNumbers, 2.5])('should reject invalid item count %s', (value) => {
+      expect(() => comb2(value)).toThrow(RangeError);
+    });
+    test('should reject results that exceed the safe integer range', () => {
+      expect(() => comb2(134_217_729)).toThrow(RangeError);
+      expect(() => comb2(Number.MAX_SAFE_INTEGER)).toThrow(RangeError);
+    });
 
     test('should return 1 for C(2,2)', () => {
       expect(comb2(2)).toBe(1);
@@ -59,6 +66,9 @@ describe('Utility Functions', () => {
     });
     test('should return 499500 for C(1000,2)', () => {
       expect(comb2(1000)).toBe(499_500);
+    });
+    test('should return the largest safe boundary result', () => {
+      expect(comb2(134_217_728)).toBe(9_007_199_187_632_128);
     });
   });
 
@@ -226,6 +236,19 @@ describe('Utility Functions', () => {
         'c d',
       ]);
       expect(nGram(data, 2, { start: undefined, end: undefined })).toEqual(nGram(data, 2));
+    });
+
+    test('should apply requested padding before validating short inputs', () => {
+      const oneToken = ['a'];
+      expect(nGram(oneToken, 2, { start: true })).toEqual(['<S> a']);
+      expect(nGram(oneToken, 2, { end: true })).toEqual(['a <S>']);
+      expect(nGram([], 2, { start: true, end: true })).toEqual(['<S> <S>']);
+      expect(oneToken).toEqual(['a']);
+    });
+
+    test('should still reject short inputs when padding is insufficient', () => {
+      expect(() => nGram([], 2, { start: true })).toThrow(RangeError);
+      expect(() => nGram(['a'], 3, { start: false, end: false })).toThrow(RangeError);
     });
   });
 
@@ -910,6 +933,42 @@ describe('Utility Functions', () => {
     });
     test('should return the correct result using alternative test', () => {
       expect(jk(cands, ref, evalFunc, statTest)).toBe(31);
+    });
+
+    test('should preserve leave-one-out maxima and score each candidate once', () => {
+      const scorer = jest.fn((candidate: string): number => Number(candidate));
+      let distribution: number[] = [];
+      const statistic = (input: number[]): number => {
+        distribution = input;
+        return 0;
+      };
+
+      expect(jk(['4', '3', '2'], ref, scorer, statistic)).toBe(0);
+      expect(distribution).toEqual([3, 4, 4]);
+      expect(scorer.mock.calls).toEqual([
+        ['4', ref],
+        ['3', ref],
+        ['2', ref],
+      ]);
+    });
+
+    test('should preserve NaN propagation in leave-one-out maxima', () => {
+      let distribution: number[] = [];
+      jk(
+        ['nan', '3', '1'],
+        ref,
+        (candidate) => Number(candidate),
+        (input) => {
+          distribution = input;
+          return 0;
+        },
+      );
+      expect(distribution).toEqual([3, Number.NaN, Number.NaN]);
+    });
+
+    test('should handle large candidate sets without quadratic resampling', () => {
+      const candidates = Array.from({ length: 50_000 }, (_, index) => String(index));
+      expect(jk(candidates, ref, () => 1)).toBe(1);
     });
 
     test('should adapt multiple references without reversing an asymmetric scorer', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -11,7 +11,7 @@ const bracketPairs = [
 ] as const;
 const geographicAcronyms = ['U.S.', 'U.S.A.', 'E.U.'];
 const nonFiniteNumbers = [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY];
-const invalidNGramSizes = [...nonFiniteNumbers, -1, 0, 1.5];
+const invalidNGramSizes = [...nonFiniteNumbers, -1, 0, 1.5, 2 ** 54];
 const invalidMaxSkips = [Number.NaN, Number.NEGATIVE_INFINITY, -1, 0.5, 1.5];
 const invalidBetas = [Number.NaN, Number.NEGATIVE_INFINITY, -1];
 
@@ -251,12 +251,15 @@ describe('Utility Functions', () => {
       expect(() => nGram(['a'], 3, { start: false, end: false })).toThrow(RangeError);
     });
 
-    test('should reject impossible large padding before materializing it', () => {
+    test.each([
+      1_000_000_000,
+      2 ** 54,
+    ])('should reject impossible padding size %s before materializing it', (size) => {
       const unshift = jest.spyOn(Array.prototype, 'unshift').mockImplementation((): number => {
         throw new Error('padding should not be materialized');
       });
       try {
-        expect(() => nGram([], 1_000_000_000, { start: true })).toThrow(RangeError);
+        expect(() => nGram([], size, { start: true })).toThrow(RangeError);
         expect(unshift).not.toHaveBeenCalled();
       } finally {
         unshift.mockRestore();

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -253,6 +253,12 @@ describe('Utility Functions', () => {
     test('should reject impossible padding before allocation', () => {
       expect(() => nGram([], 1_000_000_000, { start: true })).toThrow(RangeError);
     });
+
+    test('should reject excessive two-sided padding before materialization', () => {
+      expect(() => nGram([], 1_000_000_000, { start: true, end: true })).toThrow(
+        /materialization limit/,
+      );
+    });
   });
 
   describe('skipBigram', () => {
@@ -1354,6 +1360,12 @@ describe('Core Functions', () => {
       const tokenizer = (text: string): string[] => text.split('');
       const nGram = (tokens: string[]): string[] => tokens;
       expect(n('aaa', 'aa', { tokenizer, nGram })).toBeCloseTo(4 / 5);
+    });
+
+    test('should not apply the built-in padding limit to custom ngram callbacks', () => {
+      const nGram = jest.fn((): string[] => ['match']);
+      expect(n('a', 'a', { n: 1_000_000_000, nGram })).toBe(1);
+      expect(nGram).toHaveBeenCalledTimes(2);
     });
 
     test('should correctly compute ROUGE-N score with custom beta', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -11,7 +11,8 @@ const bracketPairs = [
 ] as const;
 const geographicAcronyms = ['U.S.', 'U.S.A.', 'E.U.'];
 const nonFiniteNumbers = [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY];
-const invalidNGramSizes = [...nonFiniteNumbers, -1, 0, 1.5, 2 ** 54];
+const unsafeInteger = Number.MAX_SAFE_INTEGER + 1;
+const invalidNGramSizes = [...nonFiniteNumbers, -1, 0, 1.5, unsafeInteger];
 const invalidMaxSkips = [Number.NaN, Number.NEGATIVE_INFINITY, -1, 0.5, 1.5];
 const invalidBetas = [Number.NaN, Number.NEGATIVE_INFINITY, -1];
 
@@ -47,15 +48,14 @@ describe('Utility Functions', () => {
   describe('comb2', () => {
     const { comb2 } = rouge;
 
-    test('should throw RangeError for C(1,2)', () => {
-      expect(() => comb2(1)).toThrow(RangeError);
-    });
-    test.each([...nonFiniteNumbers, 2.5])('should reject invalid item count %s', (value) => {
-      expect(() => comb2(value)).toThrow(RangeError);
-    });
+    test.each([1, ...nonFiniteNumbers, 2.5, unsafeInteger])(
+      'should reject invalid item count %s',
+      (value) => {
+        expect(() => comb2(value)).toThrow(RangeError);
+      },
+    );
     test('should reject results that exceed the safe integer range', () => {
       expect(() => comb2(134_217_729)).toThrow(RangeError);
-      expect(() => comb2(Number.MAX_SAFE_INTEGER)).toThrow(RangeError);
     });
 
     test('should return 1 for C(2,2)', () => {
@@ -248,11 +248,10 @@ describe('Utility Functions', () => {
 
     test('should still reject short inputs when padding is insufficient', () => {
       expect(() => nGram([], 2, { start: true })).toThrow(RangeError);
-      expect(() => nGram(['a'], 3, { start: false, end: false })).toThrow(RangeError);
     });
 
-    test.each([1_000_000_000, 2 ** 54])('should reject impossible padding size %s', (size) => {
-      expect(() => nGram([], size, { start: true })).toThrow(RangeError);
+    test('should reject impossible padding before allocation', () => {
+      expect(() => nGram([], 1_000_000_000, { start: true })).toThrow(RangeError);
     });
   });
 
@@ -941,14 +940,10 @@ describe('Utility Functions', () => {
 
     test('should preserve leave-one-out maxima and score each candidate once', () => {
       const scorer = jest.fn((candidate: string): number => Number(candidate));
-      let distribution: number[] = [];
-      const statistic = (input: number[]): number => {
-        distribution = input;
-        return 0;
-      };
+      const statistic = jest.fn(() => 0);
 
       expect(jk(['4', '3', '2'], ref, scorer, statistic)).toBe(0);
-      expect(distribution).toEqual([3, 4, 4]);
+      expect(statistic).toHaveBeenCalledWith([3, 4, 4]);
       expect(scorer.mock.calls).toEqual([
         ['4', ref],
         ['3', ref],
@@ -957,17 +952,9 @@ describe('Utility Functions', () => {
     });
 
     test('should preserve NaN propagation in leave-one-out maxima', () => {
-      let distribution: number[] = [];
-      jk(
-        ['nan', '3', '1'],
-        ref,
-        (candidate) => Number(candidate),
-        (input) => {
-          distribution = input;
-          return 0;
-        },
-      );
-      expect(distribution).toEqual([3, Number.NaN, Number.NaN]);
+      const statistic = jest.fn(() => 0);
+      jk(['nan', '3', '1'], ref, (candidate) => Number(candidate), statistic);
+      expect(statistic).toHaveBeenCalledWith([3, Number.NaN, Number.NaN]);
     });
 
     test('should handle large candidate sets without quadratic resampling', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -251,20 +251,9 @@ describe('Utility Functions', () => {
       expect(() => nGram(['a'], 3, { start: false, end: false })).toThrow(RangeError);
     });
 
-    test.each([1_000_000_000, 2 ** 54])(
-      'should reject impossible padding size %s before materializing it',
-      (size) => {
-        const unshift = jest.spyOn(Array.prototype, 'unshift').mockImplementation((): number => {
-          throw new Error('padding should not be materialized');
-        });
-        try {
-          expect(() => nGram([], size, { start: true })).toThrow(RangeError);
-          expect(unshift).not.toHaveBeenCalled();
-        } finally {
-          unshift.mockRestore();
-        }
-      },
-    );
+    test.each([1_000_000_000, 2 ** 54])('should reject impossible padding size %s', (size) => {
+      expect(() => nGram([], size, { start: true })).toThrow(RangeError);
+    });
   });
 
   describe('skipBigram', () => {


### PR DESCRIPTION
## Summary

- reject fractional, non-finite, unsafe, and out-of-domain `comb2()` inputs while preserving the exact safe boundary
- require safe-integer n-gram sizes before padding arithmetic or allocation
- apply requested `nGram()` padding to the length contract while rejecting impossible padding before allocation
- reject built-in padded requests that would materialize more than one million padding-induced token positions
- reduce `jackKnife()` to one suffix-max array plus a rolling prefix maximum while preserving `NaN` behavior and scorer call counts
- correct the `fMeasure()` beta-zero documentation

## Why

These changes address audit findings A9, A10, A13, and A14: invalid legacy utility domains, unsafe n-gram arithmetic, incorrect padded-short grams, contradictory documentation, and avoidable quadratic resampling.

The padding-only limit also fixes a reproduced constrained-heap OOM. It measures the allocation work introduced by optional padding instead of imposing a blanket `n` limit, so unpadded calls and custom generators are unaffected.

## Simplification pass

- replaced the two-array jackknife with one suffix array and a rolling prefix; 55,980 exhaustive score arrays matched the prior algorithm, including infinities and `NaN`
- replaced the temporary n-gram configuration object with resolved locals and reused the computed gram count
- added one local arithmetic guard only after the two-sided padding OOM reproduction; safe-integer checking stops overflow before allocation
- the pure simplification removed 17 net lines; the justified OOM fix added 26, for a combined net increase of 9 lines

## Validation

- 55,980-array differential jackknife comparison
- 50,000-candidate jackknife stress regression
- 64 MB child-process proof that excessive two-sided padding now fails before allocation
- custom-generator preservation regression for a billion-sized `n`
- `npm test -- --runInBand` (419 tests)
- `npm run type-check`
- Biome 2.5.10 strict check
- Prettier check for `README.md`
- `npm run build`
- combined eight-PR stack: 497 tests, type-check, format checks, build, and packed-package smoke
