### PR TITLE
ci: harden Node and package compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
+      - run: npm run type-check
       - name: Biome CI check
         run: npx biome ci . --error-on-warnings
       - run: npm run build
@@ -51,6 +52,7 @@ jobs:
           test -f dist/rouge.js || (echo "Missing dist/rouge.js" && exit 1)
           test -f dist/rouge.mjs || (echo "Missing dist/rouge.mjs" && exit 1)
           test -f dist/rouge.d.ts || (echo "Missing dist/rouge.d.ts" && exit 1)
+      - run: npm run test:package
       - run: npm test
 
   ci-success:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,6 +76,8 @@ jobs:
           test -f dist/rouge.mjs || (echo "Missing dist/rouge.mjs" && exit 1)
           test -f dist/rouge.d.ts || (echo "Missing dist/rouge.d.ts" && exit 1)
           echo "Build artifacts verified successfully"
+      - name: Verify packed consumers
+        run: npm run test:package
       # Publishing uses npm's OIDC trusted publishers for authentication.
       # This requires npm 11.5.1+ (Node 24 includes npm 11.6.0) and the package
       # must be configured on npmjs.com to trust this GitHub repository/workflow.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,16 +68,6 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - name: Build package
-        run: npm run build
-      - name: Verify build artifacts
-        run: |
-          test -f dist/rouge.js || (echo "Missing dist/rouge.js" && exit 1)
-          test -f dist/rouge.mjs || (echo "Missing dist/rouge.mjs" && exit 1)
-          test -f dist/rouge.d.ts || (echo "Missing dist/rouge.d.ts" && exit 1)
-          echo "Build artifacts verified successfully"
-      - name: Verify packed consumers
-        run: npm run test:package
       # Publishing uses npm's OIDC trusted publishers for authentication.
       # This requires npm 11.5.1+ (Node 24 includes npm 11.6.0) and the package
       # must be configured on npmjs.com to trust this GitHub repository/workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,11 +136,11 @@ F_β = ((1 + β²) × P × R) / (β² × P + R)
 
 GitHub Actions runs on push/PR to main:
 
-1. Matrix test: Node 18, 20, 22
-2. Format check
-3. Lint check
-4. Build
-5. Test
+1. Matrix test: Node 18, 20, 22, 24
+2. Source and test type checks
+3. Format and lint checks
+4. Build and packed-package consumer smoke tests
+5. Unit tests with coverage thresholds
 
 All checks must pass before merge.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,19 @@
 
 ## [3.2.0](https://github.com/promptfoo/js-rouge/compare/js-rouge-v3.1.5...js-rouge-v3.2.0) (2026-01-05)
 
-
 ### Features
 
-* export TypeScript option types for ROUGE functions ([#63](https://github.com/promptfoo/js-rouge/issues/63)) ([cf203c9](https://github.com/promptfoo/js-rouge/commit/cf203c9bcf50dedcd25fa3b99528b19aa3db12fa))
-
+- export TypeScript option types for ROUGE functions ([#63](https://github.com/promptfoo/js-rouge/issues/63)) ([cf203c9](https://github.com/promptfoo/js-rouge/commit/cf203c9bcf50dedcd25fa3b99528b19aa3db12fa))
 
 ### Bug Fixes
 
-* apply F-beta formula for all non-negative beta values ([#51](https://github.com/promptfoo/js-rouge/issues/51)) ([44f2bf5](https://github.com/promptfoo/js-rouge/commit/44f2bf51e468420d7e50fc28fb25e34d7ffb8fa6))
-* correct off-by-one error in treeBankTokenize loop ([#50](https://github.com/promptfoo/js-rouge/issues/50)) ([1f74053](https://github.com/promptfoo/js-rouge/commit/1f74053a56259d687228dfb3f377285e7dd8f4c6))
-* correct ROUGE-L precision and recall calculation ([#52](https://github.com/promptfoo/js-rouge/issues/52)) ([0c91f4c](https://github.com/promptfoo/js-rouge/commit/0c91f4ccd9b44524f148bf747798c0e68e47961c))
-* remove duplicate 'sep' entry in ABBR_DATES ([#53](https://github.com/promptfoo/js-rouge/issues/53)) ([433a4b5](https://github.com/promptfoo/js-rouge/commit/433a4b5cccea38552e8322104615443cb818a589))
-* resolve CodeQL security alerts for ReDoS and workflow permissions ([#48](https://github.com/promptfoo/js-rouge/issues/48)) ([972808d](https://github.com/promptfoo/js-rouge/commit/972808d4b6f45e5f3cba99526d6c4423937c3c45))
-* resolve CodeQL security alerts for ReDoS vulnerabilities ([#59](https://github.com/promptfoo/js-rouge/issues/59)) ([ad6a930](https://github.com/promptfoo/js-rouge/commit/ad6a93044c2f40900a49cf2888f8e9d8fb1c7c38))
-* **security:** harden CI/CD pipeline and add security tooling ([#68](https://github.com/promptfoo/js-rouge/issues/68)) ([545044a](https://github.com/promptfoo/js-rouge/commit/545044ad14deb270421e65000a3061c0890b9084))
+- apply F-beta formula for all non-negative beta values ([#51](https://github.com/promptfoo/js-rouge/issues/51)) ([44f2bf5](https://github.com/promptfoo/js-rouge/commit/44f2bf51e468420d7e50fc28fb25e34d7ffb8fa6))
+- correct off-by-one error in treeBankTokenize loop ([#50](https://github.com/promptfoo/js-rouge/issues/50)) ([1f74053](https://github.com/promptfoo/js-rouge/commit/1f74053a56259d687228dfb3f377285e7dd8f4c6))
+- correct ROUGE-L precision and recall calculation ([#52](https://github.com/promptfoo/js-rouge/issues/52)) ([0c91f4c](https://github.com/promptfoo/js-rouge/commit/0c91f4ccd9b44524f148bf747798c0e68e47961c))
+- remove duplicate 'sep' entry in ABBR_DATES ([#53](https://github.com/promptfoo/js-rouge/issues/53)) ([433a4b5](https://github.com/promptfoo/js-rouge/commit/433a4b5cccea38552e8322104615443cb818a589))
+- resolve CodeQL security alerts for ReDoS and workflow permissions ([#48](https://github.com/promptfoo/js-rouge/issues/48)) ([972808d](https://github.com/promptfoo/js-rouge/commit/972808d4b6f45e5f3cba99526d6c4423937c3c45))
+- resolve CodeQL security alerts for ReDoS vulnerabilities ([#59](https://github.com/promptfoo/js-rouge/issues/59)) ([ad6a930](https://github.com/promptfoo/js-rouge/commit/ad6a93044c2f40900a49cf2888f8e9d8fb1c7c38))
+- **security:** harden CI/CD pipeline and add security tooling ([#68](https://github.com/promptfoo/js-rouge/issues/68)) ([545044a](https://github.com/promptfoo/js-rouge/commit/545044ad14deb270421e65000a3061c0890b9084))
 
 ## [3.1.5](https://github.com/promptfoo/js-rouge/compare/js-rouge-v3.1.0...js-rouge-v3.1.5) (2025-12-17)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Nevertheless, the [paper](http://www.aclweb.org/anthology/W04-1013) describing R
 
 This package is available on NPM:
 
-Node.js 18.14 or later is required.
+Node.js 18 or later is required.
 
 ```shell
 npm install js-rouge
@@ -268,6 +268,7 @@ Have a bug or a feature request? [Please open a new issue](https://github.com/pr
 ## Contributing
 
 Please submit all pull requests against the main branch. All code should pass Biome validation and tests.
+Developing and testing locally requires Node.js 18.14 or later because Jest 30 sets that floor; the published package supports Node.js 18.0 or later.
 
 The amount of data available for writing tests is unfortunately woefully inadequate. We've tried to be as thorough as possible, but that eliminates neither the possibility of nor existence of errors. The gold standard is the DUC data-set, but that too is form-walled and legal-release-walled, which is infuriating. If you have data in the form of a candidate summary, reference(s), and a verified ROUGE score you do not mind sharing, we would love to add that to the test harness.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Nevertheless, the [paper](http://www.aclweb.org/anthology/W04-1013) describing R
 
 This package is available on NPM:
 
+Node.js 18.14 or later is required.
+
 ```shell
 npm install js-rouge
 ```
@@ -222,7 +224,12 @@ const score: number = n("candidate text", "reference text", { n: 2 });
 Option interfaces are exported for typing your own functions and configurations:
 
 ```typescript
-import { n, RougeNOptions, RougeSOptions, RougeLOptions } from "js-rouge";
+import {
+  n,
+  type RougeNOptions,
+  type RougeSOptions,
+  type RougeLOptions,
+} from "js-rouge";
 
 // Type your options objects
 const opts: RougeNOptions = { n: 2, caseSensitive: false };
@@ -260,7 +267,7 @@ Have a bug or a feature request? [Please open a new issue](https://github.com/pr
 
 ## Contributing
 
-Please submit all pull requests against the main branch. All code should pass ESLint validation and tests.
+Please submit all pull requests against the main branch. All code should pass Biome validation and tests.
 
 The amount of data available for writing tests is unfortunately woefully inadequate. We've tried to be as thorough as possible, but that eliminates neither the possibility of nor existence of errors. The gold standard is the DUC data-set, but that too is form-walled and legal-release-walled, which is infuriating. If you have data in the form of a candidate summary, reference(s), and a verified ROUGE score you do not mind sharing, we would love to add that to the test harness.
 

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -29,6 +29,15 @@ export default {
   // A list of reporter names that Jest uses when writing coverage reports
   coverageReporters: ['json', 'text', 'lcov', 'clover'],
 
+  coverageThreshold: {
+    global: {
+      branches: 98,
+      functions: 100,
+      lines: 99,
+      statements: 99,
+    },
+  },
+
   // The maximum amount of workers used to run your tests
   maxWorkers: '50%',
 

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -12,13 +12,16 @@ export default {
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],
 
   // A list of paths to directories that Jest should use to search for files in
-  roots: ['<rootDir>/test'],
+  roots: ['<rootDir>/src', '<rootDir>/test'],
 
   // Automatically clear mock calls and instances between every test
   clearMocks: true,
 
   // Indicates whether the coverage information should be collected while executing the test
   collectCoverage: true,
+
+  // Include source modules even when no test imports them
+  collectCoverageFrom: ['src/**/*.ts'],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: 'coverage',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,16 +13,16 @@
         "@swc/core": "^1.15.5",
         "@swc/jest": "^0.2.39",
         "@types/jest": "^30.0.0",
+        "@types/node": "18.19.130",
         "esbuild": "^0.28.1",
         "husky": "^9.1.7",
         "jest": "^30.2.0",
-        "lint-staged": "^17.0.0",
+        "lint-staged": "15.5.2",
         "prettier": "3.9.6",
-        "rimraf": "^6.1.2",
         "typescript": "^7.0.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.14.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2094,13 +2094,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
-      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -3110,43 +3110,14 @@
       }
     },
     "node_modules/cli-truncate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
-      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "slice-ansi": "^8.0.0",
-        "string-width": "^8.2.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.1"
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -3155,35 +3126,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-truncate/node_modules/slice-ansi": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
-      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.3",
-        "is-fullwidth-code-point": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
+      "license": "MIT"
     },
     "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3305,6 +3267,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3335,13 +3314,13 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -4654,6 +4633,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -4662,58 +4654,193 @@
       "license": "MIT"
     },
     "node_modules/lint-staged": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.5.tgz",
-      "integrity": "sha512-d12yC+/e8RhBjZtaxZn71FyrgU/P5e+uAPifhCLwdosQZP/zamSdKRWDC30ocVIbzDKiFG1McHc/LUgB92GIPw==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
+      "integrity": "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "listr2": "^10.2.1",
-        "picomatch": "^4.0.4",
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "debug": "^4.4.0",
+        "execa": "^8.0.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.2.5",
+        "micromatch": "^4.0.8",
+        "pidtree": "^0.6.0",
         "string-argv": "^0.3.2",
-        "tinyexec": "^1.1.2"
+        "yaml": "^2.7.0"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
       },
       "engines": {
-        "node": ">=22.22.1"
+        "node": ">=18.12.0"
       },
       "funding": {
         "url": "https://opencollective.com/lint-staged"
-      },
-      "optionalDependencies": {
-        "yaml": "^2.8.4"
       }
     },
-    "node_modules/lint-staged/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+    "node_modules/lint-staged/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/lint-staged/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/listr2": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
-      "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
+    "node_modules/lint-staged/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cli-truncate": "^5.2.0",
-        "eventemitter3": "^5.0.4",
-        "log-update": "^6.1.0",
-        "rfdc": "^1.4.1",
-        "wrap-ansi": "^10.0.0"
+        "path-key": "^4.0.0"
       },
       "engines": {
-        "node": ">=22.13.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
+      "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/listr2/node_modules/ansi-styles": {
@@ -4729,36 +4856,44 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/listr2/node_modules/string-width": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/listr2/node_modules/wrap-ansi": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
-      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.3",
-        "string-width": "^8.2.0",
-        "strip-ansi": "^7.1.2"
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -4785,9 +4920,9 @@
       }
     },
     "node_modules/log-update/node_modules/ansi-escapes": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
-      "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4819,6 +4954,39 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
     },
     "node_modules/log-update/node_modules/string-width": {
       "version": "7.2.0",
@@ -4959,9 +5127,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5175,6 +5343,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.1.tgz",
+      "integrity": "sha512-e0F9AOF1JMrCfBsyJOwU9lNvQ0WtXTq0j/4jk0BQ5JSI9VAybPXmDpPRw/2FQ3e5d3ZFN1mLh7jW99m/jjaptw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/pirates": {
@@ -5397,110 +5578,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/rimraf": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
-      "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "glob": "^13.0.0",
-        "package-json-from-dist": "^1.0.1"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "path-scurry": "^2.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/lru-cache": {
-      "version": "11.2.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/path-scurry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -5561,17 +5638,17 @@
       }
     },
     "node_modules/slice-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
@@ -5591,16 +5668,13 @@
       }
     },
     "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.1"
-      },
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5906,16 +5980,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/tinyexec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -6003,9 +6067,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6254,7 +6318,6 @@
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "typescript": "^7.0.0"
       },
       "engines": {
-        "node": ">=18.14.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "biome lint .",
     "format": "biome format --write . && prettier --write \"**/*.md\"",
     "check": "biome check --write . && prettier --write \"**/*.md\"",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run build && npm run test:package",
     "prepare": "husky"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
   },
   "scripts": {
     "test": "jest",
+    "test:package": "node scripts/package-smoke.js",
     "build": "npm run clean && npm run build:js && npm run build:types",
-    "build:js": "esbuild src/rouge.ts --bundle --minify --sourcemap --platform=node --target=node18 --outfile=dist/rouge.js && esbuild src/rouge.ts --bundle --minify --sourcemap --platform=neutral --format=esm --outfile=dist/rouge.mjs",
+    "build:js": "esbuild src/rouge.ts --bundle --minify --sourcemap --platform=node --target=node18 --outfile=dist/rouge.js && esbuild src/rouge.ts --bundle --minify --sourcemap --platform=neutral --format=esm --target=node18 --outfile=dist/rouge.mjs",
     "build:types": "tsc -p tsconfig.json --emitDeclarationOnly --outDir dist",
-    "clean": "rimraf dist",
-    "type-check": "tsc --noEmit",
+    "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
+    "type-check": "tsc --noEmit && tsc -p tsconfig.test.json",
     "lint": "biome lint .",
     "format": "biome format --write . && prettier --write \"**/*.md\"",
     "check": "biome check --write . && prettier --write \"**/*.md\"",
@@ -49,19 +50,20 @@
     "@swc/core": "^1.15.5",
     "@swc/jest": "^0.2.39",
     "@types/jest": "^30.0.0",
+    "@types/node": "18.19.130",
     "esbuild": "^0.28.1",
     "husky": "^9.1.7",
     "jest": "^30.2.0",
-    "lint-staged": "^17.0.0",
+    "lint-staged": "15.5.2",
     "prettier": "3.9.6",
-    "rimraf": "^6.1.2",
     "typescript": "^7.0.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.14.0"
   },
   "files": [
     "dist",
+    "src",
     "README.md",
     "LICENSE"
   ],

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:js": "esbuild src/rouge.ts --bundle --minify --sourcemap --platform=node --target=node18 --outfile=dist/rouge.js && esbuild src/rouge.ts --bundle --minify --sourcemap --platform=neutral --format=esm --target=node18 --outfile=dist/rouge.mjs",
     "build:types": "tsc -p tsconfig.json --emitDeclarationOnly --outDir dist",
     "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
-    "type-check": "tsc --noEmit && tsc -p tsconfig.test.json",
+    "type-check": "tsc -p tsconfig.test.json",
     "lint": "biome lint .",
     "format": "biome format --write . && prettier --write \"**/*.md\"",
     "check": "biome check --write . && prettier --write \"**/*.md\"",
@@ -59,7 +59,7 @@
     "typescript": "^7.0.0"
   },
   "engines": {
-    "node": ">=18.14.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "dist",

--- a/scripts/package-smoke.js
+++ b/scripts/package-smoke.js
@@ -15,17 +15,18 @@ const { dirname, join, resolve } = require('node:path');
 const repositoryRoot = resolve(__dirname, '..');
 const temporaryRoot = mkdtempSync(join(tmpdir(), 'js-rouge-package-'));
 const consumerRoot = join(temporaryRoot, 'consumer');
-const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const npmCli = process.env.npm_execpath;
 
 function run(command, args, cwd) {
   execFileSync(command, args, { cwd, stdio: 'inherit' });
 }
 
 try {
+  assert.ok(npmCli, 'Run the package smoke test through npm');
   assert.ok(existsSync(join(repositoryRoot, 'dist', 'rouge.js')), 'Build the package first');
   run(
-    npmCommand,
-    ['pack', '--ignore-scripts', '--pack-destination', temporaryRoot],
+    process.execPath,
+    [npmCli, 'pack', '--ignore-scripts', '--pack-destination', temporaryRoot],
     repositoryRoot,
   );
 
@@ -83,8 +84,16 @@ void score;
   );
 
   run(
-    npmCommand,
-    ['install', '--ignore-scripts', '--no-audit', '--no-fund', '--no-package-lock', tarball],
+    process.execPath,
+    [
+      npmCli,
+      'install',
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+      '--no-package-lock',
+      tarball,
+    ],
     consumerRoot,
   );
   run(process.execPath, ['commonjs.cjs'], consumerRoot);

--- a/scripts/package-smoke.js
+++ b/scripts/package-smoke.js
@@ -21,6 +21,14 @@ function run(command, args, cwd) {
   execFileSync(command, args, { cwd, stdio: 'inherit' });
 }
 
+function writeConsumerFile(file, contents) {
+  writeFileSync(join(consumerRoot, file), contents);
+}
+
+function writeConsumerJson(file, value) {
+  writeConsumerFile(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
 try {
   assert.ok(npmCli, 'Run the package smoke test through npm');
   assert.ok(existsSync(join(repositoryRoot, 'dist', 'rouge.js')), 'Build the package first');
@@ -35,53 +43,41 @@ try {
   const tarball = join(temporaryRoot, tarballs[0]);
 
   mkdirSync(consumerRoot);
-  writeFileSync(
-    join(consumerRoot, 'package.json'),
-    `${JSON.stringify({ name: 'js-rouge-smoke', private: true, type: 'module' }, null, 2)}\n`,
-  );
-  writeFileSync(
-    join(consumerRoot, 'commonjs.cjs'),
+  writeConsumerJson('package.json', { name: 'js-rouge-smoke', private: true, type: 'module' });
+  const runtimeAssertions = `assert.equal(n('a b', 'a b', { n: 2 }), 1);
+assert.equal(l('a b', 'a b'), 1);
+assert.equal(s('a b', 'a b'), 1);
+`;
+  writeConsumerFile(
+    'commonjs.cjs',
     `const assert = require('node:assert/strict');
 const { l, n, s } = require('js-rouge');
-assert.equal(n('a b', 'a b', { n: 2 }), 1);
-assert.equal(l('a b', 'a b'), 1);
-assert.equal(s('a b', 'a b'), 1);
-`,
+${runtimeAssertions}`,
   );
-  writeFileSync(
-    join(consumerRoot, 'module.mjs'),
+  writeConsumerFile(
+    'module.mjs',
     `import assert from 'node:assert/strict';
 import { l, n, s } from 'js-rouge';
-assert.equal(n('a b', 'a b', { n: 2 }), 1);
-assert.equal(l('a b', 'a b'), 1);
-assert.equal(s('a b', 'a b'), 1);
-`,
+${runtimeAssertions}`,
   );
-  writeFileSync(
-    join(consumerRoot, 'types.ts'),
+  writeConsumerFile(
+    'types.ts',
     `import { n, type RougeNOptions } from 'js-rouge';
 const options: RougeNOptions = { n: 2, caseSensitive: false };
 const score: number = n('a b', 'A B', options);
 void score;
 `,
   );
-  writeFileSync(
-    join(consumerRoot, 'tsconfig.json'),
-    `${JSON.stringify(
-      {
-        compilerOptions: {
-          module: 'NodeNext',
-          moduleResolution: 'NodeNext',
-          noEmit: true,
-          strict: true,
-          target: 'ES2022',
-        },
-        include: ['types.ts'],
-      },
-      null,
-      2,
-    )}\n`,
-  );
+  writeConsumerJson('tsconfig.json', {
+    compilerOptions: {
+      module: 'NodeNext',
+      moduleResolution: 'NodeNext',
+      noEmit: true,
+      strict: true,
+      target: 'ES2022',
+    },
+    include: ['types.ts'],
+  });
 
   run(
     process.execPath,

--- a/scripts/package-smoke.js
+++ b/scripts/package-smoke.js
@@ -1,0 +1,117 @@
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} = require('node:fs');
+const { tmpdir } = require('node:os');
+const { dirname, join, resolve } = require('node:path');
+
+const repositoryRoot = resolve(__dirname, '..');
+const temporaryRoot = mkdtempSync(join(tmpdir(), 'js-rouge-package-'));
+const consumerRoot = join(temporaryRoot, 'consumer');
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+function run(command, args, cwd) {
+  execFileSync(command, args, { cwd, stdio: 'inherit' });
+}
+
+try {
+  assert.ok(existsSync(join(repositoryRoot, 'dist', 'rouge.js')), 'Build the package first');
+  run(
+    npmCommand,
+    ['pack', '--ignore-scripts', '--pack-destination', temporaryRoot],
+    repositoryRoot,
+  );
+
+  const tarballs = readdirSync(temporaryRoot).filter((file) => file.endsWith('.tgz'));
+  assert.equal(tarballs.length, 1, 'npm pack should create exactly one tarball');
+  const tarball = join(temporaryRoot, tarballs[0]);
+
+  mkdirSync(consumerRoot);
+  writeFileSync(
+    join(consumerRoot, 'package.json'),
+    `${JSON.stringify({ name: 'js-rouge-smoke', private: true, type: 'module' }, null, 2)}\n`,
+  );
+  writeFileSync(
+    join(consumerRoot, 'commonjs.cjs'),
+    `const assert = require('node:assert/strict');
+const { l, n, s } = require('js-rouge');
+assert.equal(n('a b', 'a b', { n: 2 }), 1);
+assert.equal(l('a b', 'a b'), 1);
+assert.equal(s('a b', 'a b'), 1);
+`,
+  );
+  writeFileSync(
+    join(consumerRoot, 'module.mjs'),
+    `import assert from 'node:assert/strict';
+import { l, n, s } from 'js-rouge';
+assert.equal(n('a b', 'a b', { n: 2 }), 1);
+assert.equal(l('a b', 'a b'), 1);
+assert.equal(s('a b', 'a b'), 1);
+`,
+  );
+  writeFileSync(
+    join(consumerRoot, 'types.ts'),
+    `import { n, type RougeNOptions } from 'js-rouge';
+const options: RougeNOptions = { n: 2, caseSensitive: false };
+const score: number = n('a b', 'A B', options);
+void score;
+`,
+  );
+  writeFileSync(
+    join(consumerRoot, 'tsconfig.json'),
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          noEmit: true,
+          strict: true,
+          target: 'ES2022',
+        },
+        include: ['types.ts'],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  run(
+    npmCommand,
+    ['install', '--ignore-scripts', '--no-audit', '--no-fund', '--no-package-lock', tarball],
+    consumerRoot,
+  );
+  run(process.execPath, ['commonjs.cjs'], consumerRoot);
+  run(process.execPath, ['module.mjs'], consumerRoot);
+  run(
+    process.execPath,
+    [join(repositoryRoot, 'node_modules', 'typescript', 'bin', 'tsc'), '-p', consumerRoot],
+    repositoryRoot,
+  );
+
+  const installedRoot = join(consumerRoot, 'node_modules', 'js-rouge');
+  const installedPackage = JSON.parse(readFileSync(join(installedRoot, 'package.json'), 'utf8'));
+  assert.equal(installedPackage.dependencies, undefined, 'The package must remain dependency-free');
+
+  const declarationMaps = readdirSync(join(installedRoot, 'dist')).filter((file) =>
+    file.endsWith('.d.ts.map'),
+  );
+  assert.ok(declarationMaps.length > 0, 'The package should contain declaration maps');
+  for (const declarationMap of declarationMaps) {
+    const mapPath = join(installedRoot, 'dist', declarationMap);
+    const map = JSON.parse(readFileSync(mapPath, 'utf8'));
+    for (const source of map.sources) {
+      const sourcePath = resolve(dirname(mapPath), map.sourceRoot ?? '', source);
+      assert.ok(existsSync(sourcePath), `${declarationMap} should resolve ${source}`);
+      assert.ok(readFileSync(sourcePath, 'utf8').length > 0, `${source} should not be empty`);
+    }
+  }
+} finally {
+  rmSync(temporaryRoot, { force: true, recursive: true });
+}

--- a/scripts/package-smoke.js
+++ b/scripts/package-smoke.js
@@ -97,7 +97,9 @@ void score;
 
   const installedRoot = join(consumerRoot, 'node_modules', 'js-rouge');
   const installedPackage = JSON.parse(readFileSync(join(installedRoot, 'package.json'), 'utf8'));
-  assert.equal(installedPackage.dependencies, undefined, 'The package must remain dependency-free');
+  for (const field of ['dependencies', 'optionalDependencies', 'peerDependencies']) {
+    assert.equal(installedPackage[field], undefined, `The package must not declare ${field}`);
+  }
 
   const declarationMaps = readdirSync(join(installedRoot, 'dist')).filter((file) =>
     file.endsWith('.d.ts.map'),

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -5,7 +5,6 @@
     "declarationMap": false,
     "noEmit": true,
     "rootDir": ".",
-    "sourceMap": false,
     "types": ["jest", "node"]
   },
   "include": ["src/**/*.ts", "test/**/*.ts"],

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    "rootDir": ".",
+    "sourceMap": false,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- preserve the published runtime contract at Node `>=18.0.0` while documenting the Jest 30 development floor of Node 18.14
- add strict test-file type-checking and repository-wide coverage thresholds that include unimported source modules
- target Node 18 for both bundles and test Node 24 in CI
- add a packed-artifact smoke test covering CommonJS, ESM, strict TypeScript, zero runtime dependencies, and declaration-map source resolution
- invoke npm's JavaScript CLI through Node so the package smoke test works on Windows without shell quoting
- run build and package smoke from `prepublishOnly` so publication cannot bypass artifact validation
- ship the declaration sources referenced by published `.d.ts.map` files
- format the changelog with the locked Prettier 3.9.6 toolchain

## Why

This addresses audit findings A11 and A12. The development toolchain needs a more specific floor than the published runtime, and the published declaration maps previously pointed at source files omitted from the package.

The coverage configuration also had a concrete blind spot: global thresholds passed when a completely unimported file was added under `src`. Covering both source and test roots and collecting `src/**/*.ts` closes that gap.

## Simplification pass

- consolidated build and packed-artifact smoke into the npm publication lifecycle, then removed duplicate release-workflow steps
- shared consumer-file and runtime-assertion helpers in the package smoke script
- removed an inert test TypeScript source-map override
- reduced the pass by 12 net lines (36 additions, 48 deletions)

## Validation

- `npm run type-check` for source and tests
- `npm test -- --runInBand` (402 tests with coverage thresholds)
- temporary unimported-source probe appeared at 0% and failed the function threshold as intended
- Biome 2.5.10 strict check
- Prettier 3.9.6 check for all Markdown
- full `npm run prepublishOnly`: build, tarball, CJS/ESM, strict external TypeScript, declaration maps, and metadata checks
- verified every non-optional locked dependency accepts Node 18.14
- combined eight-PR stack: 497 tests, type-check, format checks, build, and packed-package smoke
