### PR TITLE
fix: bound unpadded n-gram materialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ These preprocessing corrections can change scores for multi-sentence summaries, 
 
 Omitted options and fields explicitly set to `undefined` use the documented defaults. Explicit `false`, `0`, and `Infinity` values are preserved where supported.
 
-`n` must be a positive safe integer. `maxSkip` must be a non-negative integer or positive `Infinity`. `beta` must be a non-negative finite number or positive `Infinity`; `NaN` is never valid. Invalid numeric options throw `RangeError` before tokenization or a zero-overlap return, including with custom gram generators. The public `nGram`, `skipBigram`, and `fMeasure` utilities enforce the same numeric contracts, and `fMeasure` requires finite precision and recall in `[0, 1]`. Large finite beta values produce finite scores. The built-in `nGram()` rejects requests that would materialize more than one million token positions, including padding; custom generators are unaffected.
+`n` must be a positive safe integer. `maxSkip` must be a non-negative integer or positive `Infinity`. `beta` must be a non-negative finite number or positive `Infinity`; `NaN` is never valid. Invalid numeric options throw `RangeError` before tokenization or a zero-overlap return, including with custom gram generators. The public `nGram`, `skipBigram`, and `fMeasure` utilities enforce the same numeric contracts, and `fMeasure` requires finite precision and recall in `[0, 1]`. Large finite beta values produce finite scores. The built-in `nGram()` bounds both token and character materialization, including padding; custom generators are unaffected.
 
 ### ROUGE-N Options
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ These preprocessing corrections can change scores for multi-sentence summaries, 
 
 Omitted options and fields explicitly set to `undefined` use the documented defaults. Explicit `false`, `0`, and `Infinity` values are preserved where supported.
 
-`n` must be a positive safe integer. `maxSkip` must be a non-negative integer or positive `Infinity`. `beta` must be a non-negative finite number or positive `Infinity`; `NaN` is never valid. Invalid numeric options throw `RangeError` before tokenization or a zero-overlap return, including with custom gram generators. The public `nGram`, `skipBigram`, and `fMeasure` utilities enforce the same numeric contracts, and `fMeasure` requires finite precision and recall in `[0, 1]`. Large finite beta values produce finite scores. The built-in `nGram()` rejects padded requests that would materialize more than one million padding-induced token positions; custom generators are unaffected.
+`n` must be a positive safe integer. `maxSkip` must be a non-negative integer or positive `Infinity`. `beta` must be a non-negative finite number or positive `Infinity`; `NaN` is never valid. Invalid numeric options throw `RangeError` before tokenization or a zero-overlap return, including with custom gram generators. The public `nGram`, `skipBigram`, and `fMeasure` utilities enforce the same numeric contracts, and `fMeasure` requires finite precision and recall in `[0, 1]`. Large finite beta values produce finite scores. The built-in `nGram()` rejects requests that would materialize more than one million token positions, including padding; custom generators are unaffected.
 
 ### ROUGE-N Options
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -604,11 +604,16 @@ export function nGram(tokens: string[], n = 2, pad: Partial<NGramOptions> = {}):
   }
 
   const gramCount = paddedLength - n + 1;
-  const materializationWork = paddingLength + n * gramCount;
-  if (
-    !Number.isSafeInteger(materializationWork) ||
-    materializationWork > MAX_NGRAM_MATERIALIZATION_WORK
-  ) {
+  let materializationWork = paddingLength + n * gramCount;
+  for (let i = 0; i < paddedLength && materializationWork <= MAX_NGRAM_MATERIALIZATION_WORK; i++) {
+    const token =
+      i < startPaddingSize || i >= startPaddingSize + tokens.length
+        ? value
+        : tokens[i - startPaddingSize];
+    materializationWork +=
+      Math.max(token.length - 1, 0) * Math.min(i + 1, n, gramCount, paddedLength - i);
+  }
+  if (materializationWork > MAX_NGRAM_MATERIALIZATION_WORK) {
     throw new RangeError('N-gram generation exceeds the materialization limit');
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -577,7 +577,7 @@ export const NGRAM_DEFAULT_OPTS: NGramOptions = {
   val: '<S>',
 };
 
-const MAX_NGRAM_PADDING_WORK = 1_000_000;
+const MAX_NGRAM_MATERIALIZATION_WORK = 1_000_000;
 
 /**
  * Returns n-grams for an array of word tokens.
@@ -604,13 +604,12 @@ export function nGram(tokens: string[], n = 2, pad: Partial<NGramOptions> = {}):
   }
 
   const gramCount = paddedLength - n + 1;
-  const unpaddedGramCount = Math.max(tokens.length - n + 1, 0);
-  const paddingWork = paddingLength + n * (gramCount - unpaddedGramCount);
+  const materializationWork = paddingLength + n * gramCount;
   if (
-    paddingLength > 0 &&
-    (!Number.isSafeInteger(paddingWork) || paddingWork > MAX_NGRAM_PADDING_WORK)
+    !Number.isSafeInteger(materializationWork) ||
+    materializationWork > MAX_NGRAM_MATERIALIZATION_WORK
   ) {
-    throw new RangeError('Padded n-gram generation exceeds the materialization limit');
+    throw new RangeError('N-gram generation exceeds the materialization limit');
   }
 
   const startPadding = new Array<string>(startPaddingSize).fill(value);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -350,6 +350,11 @@ describe('Utility Functions', () => {
         /materialization limit/,
       );
     });
+
+    test('should reject excessive unpadded n-gram materialization', () => {
+      const tokens = new Array<string>(2000).fill('a');
+      expect(() => nGram(tokens, 1000)).toThrow(/materialization limit/);
+    });
   });
 
   describe('skipBigram', () => {
@@ -1589,6 +1594,25 @@ describe('Core Functions', () => {
       expect(n('a', 'a', { n: 1_000_000_000, nGram })).toBe(1);
       expect(nGram).toHaveBeenCalledTimes(2);
     });
+
+    test('should reject excessive built-in n-grams within a small heap', () => {
+      expectBundledScriptToPass(
+        `
+          const summary = Array.from({ length: 6000 }, () => 'a').join(' ');
+          try {
+            module.exports.n(summary, summary, { n: 3000 });
+            throw new Error('excessive n-grams were accepted');
+          } catch (error) {
+            if (!(error instanceof RangeError) || !/materialization limit/.test(error.message)) {
+              throw error;
+            }
+          }
+          process.stdout.write('ok');
+        `,
+        30_000,
+        ['--max-old-space-size=64'],
+      );
+    }, 30_000);
 
     test('should correctly compute ROUGE-N score with custom beta', () => {
       // With beta=0, F-score equals precision

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1598,9 +1598,9 @@ describe('Core Functions', () => {
     test('should reject excessive built-in n-grams within a small heap', () => {
       expectBundledScriptToPass(
         `
-          const summary = Array.from({ length: 6000 }, () => 'a').join(' ');
+          const summary = Array(600).fill('x'.repeat(1024)).join(' ');
           try {
-            module.exports.n(summary, summary, { n: 3000 });
+            module.exports.n(summary, summary, { n: 300 });
             throw new Error('excessive n-grams were accepted');
           } catch (error) {
             if (!(error instanceof RangeError) || !/materialization limit/.test(error.message)) {


### PR DESCRIPTION
## Summary

- Bound built-in n-gram generation by both token positions and output character volume, including padding.
- Throw `RangeError` before unsafe allocations without changing custom gram generators.
- Reuse the existing constrained-heap test to cover the long-token crash.

## Verification

- `npm test -- --runInBand --silent --verbose=false` (499 tests).
- `npm run type-check`.
- `biome ci . --error-on-warnings`.
- `npm run prepublishOnly`, including CommonJS, ESM, and TypeScript package consumers.
- Confirmed that 600 one-kilobyte tokens with `n: 300` fail safely under a 64 MiB heap.
