### PR TITLE
fix: build clean packages and tolerate omitted dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
     "lint": "biome lint .",
     "format": "biome format --write . && prettier --write \"**/*.md\"",
     "check": "biome check --write . && prettier --write \"**/*.md\"",
+    "prepack": "npm run build",
     "prepublishOnly": "npm run build && npm run test:package",
-    "prepare": "husky"
+    "prepare": "node scripts/prepare.js"
   },
   "repository": {
     "type": "git",
@@ -63,6 +64,7 @@
   },
   "files": [
     "dist",
+    "scripts/prepare.js",
     "src",
     "README.md",
     "LICENSE"

--- a/scripts/package-smoke.js
+++ b/scripts/package-smoke.js
@@ -1,6 +1,7 @@
 const assert = require('node:assert/strict');
 const { execFileSync } = require('node:child_process');
 const {
+  copyFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -31,12 +32,8 @@ function writeConsumerJson(file, value) {
 
 try {
   assert.ok(npmCli, 'Run the package smoke test through npm');
-  assert.ok(existsSync(join(repositoryRoot, 'dist', 'rouge.js')), 'Build the package first');
-  run(
-    process.execPath,
-    [npmCli, 'pack', '--ignore-scripts', '--pack-destination', temporaryRoot],
-    repositoryRoot,
-  );
+  rmSync(join(repositoryRoot, 'dist'), { force: true, recursive: true });
+  run(process.execPath, [npmCli, 'pack', '--pack-destination', temporaryRoot], repositoryRoot);
 
   const tarballs = readdirSync(temporaryRoot).filter((file) => file.endsWith('.tgz'));
   assert.equal(tarballs.length, 1, 'npm pack should create exactly one tarball');
@@ -105,6 +102,13 @@ void score;
   for (const field of ['dependencies', 'optionalDependencies', 'peerDependencies']) {
     assert.equal(installedPackage[field], undefined, `The package must not declare ${field}`);
   }
+
+  const productionRoot = join(temporaryRoot, 'production');
+  mkdirSync(join(productionRoot, 'scripts'), { recursive: true });
+  for (const file of ['package.json', 'package-lock.json', 'scripts/prepare.js']) {
+    copyFileSync(join(repositoryRoot, file), join(productionRoot, file));
+  }
+  run(process.execPath, [npmCli, 'ci', '--omit=dev', '--no-audit', '--no-fund'], productionRoot);
 
   const declarationMaps = readdirSync(join(installedRoot, 'dist')).filter((file) =>
     file.endsWith('.d.ts.map'),

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -1,0 +1,15 @@
+const { spawnSync } = require('node:child_process');
+const { dirname, join } = require('node:path');
+
+let husky;
+try {
+  husky = require.resolve('husky');
+} catch (error) {
+  if (error.code === 'MODULE_NOT_FOUND') {
+    process.exit(0);
+  }
+  throw error;
+}
+
+const result = spawnSync(process.execPath, [join(dirname(husky), 'bin.js')], { stdio: 'inherit' });
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

- Build CommonJS, ESM, and declaration artifacts during npm's prepack lifecycle so clean source and Git installs include dist.
- Skip Husky installation when development dependencies are absent.
- Exercise a genuinely clean npm pack and a production-only npm ci in the package smoke test.

## Verification

- npm run test:package, including clean packing, installed ESM/CommonJS/TypeScript consumers, and npm ci --omit=dev
- npm test -- --runInBand --silent --verbose=false: 551 passed
- npm run type-check
- ./node_modules/.bin/biome ci . --error-on-warnings