### PR TITLE
fix: bound raw n-gram materialization before encoding

### DIFF
--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -1,6 +1,11 @@
 import { lcsIndices as builtInLcsIndices } from './lcs';
 import * as utils from './utils';
-import { validateBeta, validateMaxSkip, validateNGramSize } from './validation';
+import {
+  validateBeta,
+  validateMaxSkip,
+  validateNGramMaterialization,
+  validateNGramSize,
+} from './validation';
 
 export * from './utils';
 
@@ -242,7 +247,11 @@ export function n(cand: string, ref: string, opts?: RougeNOptions): number {
   const getGrams = (input: string): string[] => {
     const tokens = tokenizeSummary(input, caseSensitive, tokenizer);
     if (nGram === utils.nGram) {
-      return tokens.length < size ? [] : nGram(encodeTokens(tokens), size);
+      if (tokens.length < size) {
+        return [];
+      }
+      validateNGramMaterialization(tokens, size);
+      return nGram(encodeTokens(tokens), size);
     }
     return nGram(tokens, size);
   };

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -3,7 +3,7 @@ import * as utils from './utils';
 import {
   validateBeta,
   validateMaxSkip,
-  validateNGramMaterialization,
+  validateNGramScoringMaterialization,
   validateNGramSize,
 } from './validation';
 
@@ -244,19 +244,21 @@ export function n(cand: string, ref: string, opts?: RougeNOptions): number {
   validateNGramSize(size);
   validateBeta(beta);
 
-  const getGrams = (input: string): string[] => {
-    const tokens = tokenizeSummary(input, caseSensitive, tokenizer);
-    if (nGram === utils.nGram) {
-      if (tokens.length < size) {
-        return [];
-      }
-      validateNGramMaterialization(tokens, size, 0, 0, '', true);
-      return nGram(encodeTokens(tokens), size);
+  const candTokens = tokenizeSummary(cand, caseSensitive, tokenizer);
+  let candGrams: string[];
+  let refGrams: string[];
+  if (nGram === utils.nGram) {
+    const refTokens = tokenizeSummary(ref, caseSensitive, tokenizer);
+    if (candTokens.length < size || refTokens.length < size) {
+      return 0;
     }
-    return nGram(tokens, size);
-  };
-  const candGrams = getGrams(cand);
-  const refGrams = getGrams(ref);
+    validateNGramScoringMaterialization(candTokens, refTokens, size);
+    candGrams = nGram(encodeTokens(candTokens), size);
+    refGrams = nGram(encodeTokens(refTokens), size);
+  } else {
+    candGrams = nGram(candTokens, size);
+    refGrams = nGram(tokenizeSummary(ref, caseSensitive, tokenizer), size);
+  }
 
   const matches = countMatchingGrams(candGrams, refGrams);
 

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -250,7 +250,7 @@ export function n(cand: string, ref: string, opts?: RougeNOptions): number {
       if (tokens.length < size) {
         return [];
       }
-      validateNGramMaterialization(tokens, size);
+      validateNGramMaterialization(tokens, size, 0, 0, '', true);
       return nGram(encodeTokens(tokens), size);
     }
     return nGram(tokens, size);

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -3,6 +3,7 @@ import * as utils from './utils';
 import {
   validateBeta,
   validateMaxSkip,
+  validateNGramMaterialization,
   validateNGramScoringMaterialization,
   validateNGramSize,
 } from './validation';
@@ -248,11 +249,13 @@ export function n(cand: string, ref: string, opts?: RougeNOptions): number {
   let candGrams: string[];
   let refGrams: string[];
   if (nGram === utils.nGram) {
+    const candidateWork =
+      candTokens.length < size ? 0 : validateNGramMaterialization(candTokens, size, 0, 0, '', true);
     const refTokens = tokenizeSummary(ref, caseSensitive, tokenizer);
     if (candTokens.length < size || refTokens.length < size) {
       return 0;
     }
-    validateNGramScoringMaterialization(candTokens, refTokens, size);
+    validateNGramScoringMaterialization(candidateWork, refTokens, size);
     candGrams = nGram(encodeTokens(candTokens), size);
     refGrams = nGram(encodeTokens(refTokens), size);
   } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,11 @@
 import { GATE_EXCEPTIONS, GATE_SUBSTITUTIONS, TREEBANK_CONTRACTIONS } from './constants';
 import { lcsIndices } from './lcs';
-import { validateBeta, validateMaxSkip, validateNGramSize } from './validation';
+import {
+  validateBeta,
+  validateMaxSkip,
+  validateNGramMaterialization,
+  validateNGramSize,
+} from './validation';
 
 /**
  * Splits a sentence into an array of word tokens
@@ -590,8 +595,6 @@ export const NGRAM_DEFAULT_OPTS: NGramOptions = {
   val: '<S>',
 };
 
-const MAX_NGRAM_MATERIALIZATION_WORK = 1_000_000;
-
 /**
  * Returns n-grams for an array of word tokens.
  *
@@ -617,18 +620,7 @@ export function nGram(tokens: string[], n = 2, pad: Partial<NGramOptions> = {}):
   }
 
   const gramCount = paddedLength - n + 1;
-  let materializationWork = paddingLength + n * gramCount;
-  for (let i = 0; i < paddedLength && materializationWork <= MAX_NGRAM_MATERIALIZATION_WORK; i++) {
-    const token =
-      i < startPaddingSize || i >= startPaddingSize + tokens.length
-        ? value
-        : tokens[i - startPaddingSize];
-    materializationWork +=
-      Math.max(token.length - 1, 0) * Math.min(i + 1, n, gramCount, paddedLength - i);
-  }
-  if (materializationWork > MAX_NGRAM_MATERIALIZATION_WORK) {
-    throw new RangeError('N-gram generation exceeds the materialization limit');
-  }
+  validateNGramMaterialization(tokens, n, startPaddingSize, endPaddingSize, value);
 
   const startPadding = new Array<string>(startPaddingSize).fill(value);
   const endPadding = new Array<string>(endPaddingSize).fill(value);

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -50,7 +50,7 @@ export function validateNGramMaterialization(
   const paddingLength = startPaddingSize + endPaddingSize;
   const paddedLength = tokens.length + paddingLength;
   const gramCount = paddedLength - n + 1;
-  let work = paddingLength + gramCount * (2 * n - 1);
+  let work = paddingLength + gramCount * (2 * n - 1) + (encoded ? tokens.length : 0);
 
   for (let index = 0; index < paddedLength && work <= MAX_NGRAM_MATERIALIZATION_WORK; index++) {
     const token =

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -46,7 +46,7 @@ export function validateNGramMaterialization(
   endPaddingSize = 0,
   paddingValue = '',
   encoded = false,
-): void {
+): number {
   const paddingLength = startPaddingSize + endPaddingSize;
   const paddedLength = tokens.length + paddingLength;
   const gramCount = paddedLength - n + 1;
@@ -62,6 +62,20 @@ export function validateNGramMaterialization(
   }
 
   if (work > MAX_NGRAM_MATERIALIZATION_WORK) {
+    throw new RangeError('N-gram generation exceeds the materialization limit');
+  }
+  return work;
+}
+
+export function validateNGramScoringMaterialization(
+  candidate: string[],
+  reference: string[],
+  n: number,
+): void {
+  const candidateWork = validateNGramMaterialization(candidate, n, 0, 0, '', true);
+  const referenceWork = validateNGramMaterialization(reference, n, 0, 0, '', true);
+  const referenceGrams = reference.length - n + 1;
+  if (candidateWork + referenceWork + referenceGrams > MAX_NGRAM_MATERIALIZATION_WORK) {
     throw new RangeError('N-gram generation exceeds the materialization limit');
   }
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -68,11 +68,10 @@ export function validateNGramMaterialization(
 }
 
 export function validateNGramScoringMaterialization(
-  candidate: string[],
+  candidateWork: number,
   reference: string[],
   n: number,
 ): void {
-  const candidateWork = validateNGramMaterialization(candidate, n, 0, 0, '', true);
   const referenceWork = validateNGramMaterialization(reference, n, 0, 0, '', true);
   const referenceGrams = reference.length - n + 1;
   if (candidateWork + referenceWork + referenceGrams > MAX_NGRAM_MATERIALIZATION_WORK) {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -19,12 +19,33 @@ export function validateBeta(beta: number): void {
 
 const MAX_NGRAM_MATERIALIZATION_WORK = 1_000_000;
 
+function encodedTokenLength(token: string): number {
+  let length = token.length + 2;
+  for (let index = 0; index < token.length; index++) {
+    const code = token.charCodeAt(index);
+    if (code === 34 || code === 92) {
+      length++;
+    } else if (code < 32) {
+      length += code === 8 || code === 9 || code === 10 || code === 12 || code === 13 ? 1 : 5;
+    } else if (code >= 0xd8_00 && code <= 0xdf_ff) {
+      const following = token.charCodeAt(index + 1);
+      if (code <= 0xdb_ff && following >= 0xdc_00 && following <= 0xdf_ff) {
+        index++;
+      } else {
+        length += 5;
+      }
+    }
+  }
+  return length;
+}
+
 export function validateNGramMaterialization(
   tokens: string[],
   n: number,
   startPaddingSize = 0,
   endPaddingSize = 0,
   paddingValue = '',
+  encoded = false,
 ): void {
   const paddingLength = startPaddingSize + endPaddingSize;
   const paddedLength = tokens.length + paddingLength;
@@ -36,7 +57,8 @@ export function validateNGramMaterialization(
       index < startPaddingSize || index >= startPaddingSize + tokens.length
         ? paddingValue
         : (tokens[index - startPaddingSize] ?? '');
-    work += Math.max(token.length - 1, 0) * Math.min(index + 1, n, gramCount, paddedLength - index);
+    const length = encoded ? encodedTokenLength(token) : token.length;
+    work += Math.max(length - 1, 0) * Math.min(index + 1, n, gramCount, paddedLength - index);
   }
 
   if (work > MAX_NGRAM_MATERIALIZATION_WORK) {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -16,3 +16,30 @@ export function validateBeta(beta: number): void {
     throw new RangeError('beta must be a non-negative number or Infinity');
   }
 }
+
+const MAX_NGRAM_MATERIALIZATION_WORK = 1_000_000;
+
+export function validateNGramMaterialization(
+  tokens: string[],
+  n: number,
+  startPaddingSize = 0,
+  endPaddingSize = 0,
+  paddingValue = '',
+): void {
+  const paddingLength = startPaddingSize + endPaddingSize;
+  const paddedLength = tokens.length + paddingLength;
+  const gramCount = paddedLength - n + 1;
+  let work = paddingLength + gramCount * (2 * n - 1);
+
+  for (let index = 0; index < paddedLength && work <= MAX_NGRAM_MATERIALIZATION_WORK; index++) {
+    const token =
+      index < startPaddingSize || index >= startPaddingSize + tokens.length
+        ? paddingValue
+        : (tokens[index - startPaddingSize] ?? '');
+    work += Math.max(token.length - 1, 0) * Math.min(index + 1, n, gramCount, paddedLength - index);
+  }
+
+  if (work > MAX_NGRAM_MATERIALIZATION_WORK) {
+    throw new RangeError('N-gram generation exceeds the materialization limit');
+  }
+}

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1720,6 +1720,25 @@ describe('Core Functions', () => {
       }
     });
 
+    test.each(['a', '"', '\u0000', '\ud800'])(
+      'accounts for JSON token quoting and escapes before allocating: %j',
+      (token) => {
+        const tokenizer = (): string[] => new Array<string>(400_000).fill(token);
+        const stringify = jest.spyOn(JSON, 'stringify');
+        try {
+          expect(() => n('candidate', 'reference', { tokenizer })).toThrow(/materialization limit/);
+          expect(stringify).not.toHaveBeenCalled();
+        } finally {
+          stringify.mockRestore();
+        }
+      },
+    );
+
+    test('retains correctly encoded surrogate pairs under the limit', () => {
+      const tokenizer = (): string[] => ['\ud83d\ude00', '\t'];
+      expect(n('candidate', 'reference', { tokenizer })).toBe(1);
+    });
+
     test('should reject oversized token encoding within a small heap', () => {
       expectBundledScriptToPass(
         `
@@ -1728,6 +1747,25 @@ describe('Core Functions', () => {
           try {
             module.exports.n('candidate', 'reference', { tokenizer });
             throw new Error('oversized tokens were accepted');
+          } catch (error) {
+            if (!(error instanceof RangeError) || !/materialization limit/.test(error.message)) {
+              throw error;
+            }
+          }
+          process.stdout.write('ok');
+        `,
+        30_000,
+        ['--max-old-space-size=32'],
+      );
+    }, 30_000);
+
+    test('rejects large short-token arrays before JSON encoding under a small heap', () => {
+      expectBundledScriptToPass(
+        `
+          const tokenizer = () => new Array(800000).fill('a');
+          try {
+            module.exports.n('candidate', 'reference', { tokenizer });
+            throw new Error('Oversized token encoding was accepted');
           } catch (error) {
             if (!(error instanceof RangeError) || !/materialization limit/.test(error.message)) {
               throw error;

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1720,7 +1720,7 @@ describe('Core Functions', () => {
       }
     });
 
-    test.each(['a', '"', '\u0000', '\ud800'])(
+    test.each(['', 'a', '"', '\u0000', '\ud800'])(
       'accounts for JSON token quoting and escapes before allocating: %j',
       (token) => {
         const tokenizer = (): string[] => new Array<string>(400_000).fill(token);
@@ -1766,6 +1766,25 @@ describe('Core Functions', () => {
           try {
             module.exports.n('candidate', 'reference', { tokenizer });
             throw new Error('Oversized token encoding was accepted');
+          } catch (error) {
+            if (!(error instanceof RangeError) || !/materialization limit/.test(error.message)) {
+              throw error;
+            }
+          }
+          process.stdout.write('ok');
+        `,
+        30_000,
+        ['--max-old-space-size=32'],
+      );
+    }, 30_000);
+
+    test('rejects large empty-token arrays before allocating the encoding map', () => {
+      expectBundledScriptToPass(
+        `
+          const tokenizer = () => new Array(400000).fill('');
+          try {
+            module.exports.n('candidate', 'reference', { tokenizer });
+            throw new Error('Oversized encoding map was accepted');
           } catch (error) {
             if (!(error instanceof RangeError) || !/materialization limit/.test(error.message)) {
               throw error;

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1753,6 +1753,27 @@ describe('Core Functions', () => {
       }
     });
 
+    test('rejects an oversized candidate before tokenizing the reference', () => {
+      const tokenizer = jest.fn((input: string): string[] => {
+        if (input === 'candidate') {
+          return new Array<string>(400_000).fill('');
+        }
+        throw new Error('The reference tokenizer should not run');
+      });
+      expect(() => n('candidate', 'reference', { tokenizer })).toThrow(/materialization limit/);
+      expect(tokenizer).toHaveBeenCalledTimes(1);
+    });
+
+    test('snapshots reusable tokenizer buffers before tokenizing the reference', () => {
+      const buffer: string[] = [];
+      const tokenizer = (input: string): string[] => {
+        buffer.length = 0;
+        buffer.push(input);
+        return buffer;
+      };
+      expect(n('candidate', 'reference', { tokenizer })).toBe(0);
+    });
+
     test('should reject oversized token encoding within a small heap', () => {
       expectBundledScriptToPass(
         `

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1739,6 +1739,20 @@ describe('Core Functions', () => {
       expect(n('candidate', 'reference', { tokenizer })).toBe(1);
     });
 
+    test('budgets both summaries and distinct reference gram entries before encoding', () => {
+      const tokens = Array.from({ length: 120_000 }, (_, index) =>
+        String.fromCodePoint(0x1_00_00 + index),
+      );
+      const tokenizer = (): string[] => tokens;
+      const stringify = jest.spyOn(JSON, 'stringify');
+      try {
+        expect(() => n('candidate', 'reference', { tokenizer })).toThrow(/materialization limit/);
+        expect(stringify).not.toHaveBeenCalled();
+      } finally {
+        stringify.mockRestore();
+      }
+    });
+
     test('should reject oversized token encoding within a small heap', () => {
       expectBundledScriptToPass(
         `
@@ -1785,6 +1799,26 @@ describe('Core Functions', () => {
           try {
             module.exports.n('candidate', 'reference', { tokenizer });
             throw new Error('Oversized encoding map was accepted');
+          } catch (error) {
+            if (!(error instanceof RangeError) || !/materialization limit/.test(error.message)) {
+              throw error;
+            }
+          }
+          process.stdout.write('ok');
+        `,
+        30_000,
+        ['--max-old-space-size=32'],
+      );
+    }, 30_000);
+
+    test('rejects combined distinct-summary allocations within a constrained heap', () => {
+      expectBundledScriptToPass(
+        `
+          const tokens = Array.from({ length: 120000 }, (_, index) => String.fromCodePoint(0x10000 + index));
+          const tokenizer = () => tokens;
+          try {
+            module.exports.n('candidate', 'reference', { tokenizer });
+            throw new Error('Combined distinct-gram allocations were accepted');
           } catch (error) {
             if (!(error instanceof RangeError) || !/materialization limit/.test(error.message)) {
               throw error;

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -355,6 +355,18 @@ describe('Utility Functions', () => {
       const tokens = new Array<string>(2000).fill('a');
       expect(() => nGram(tokens, 1000)).toThrow(/materialization limit/);
     });
+
+    test('should include joining spaces in the materialization limit', () => {
+      expect(() => nGram(new Array<string>(1999).fill('a'), 1000)).toThrow(/materialization limit/);
+    });
+
+    test('should preserve sparse token arrays', () => {
+      expect(nGram(new Array<string>(2), 2)).toEqual([' ']);
+      const tokens = new Array<string>(3);
+      tokens[0] = 'a';
+      tokens[2] = 'c';
+      expect(nGram(tokens, 2)).toEqual(['a ', ' c']);
+    });
   });
 
   describe('skipBigram', () => {
@@ -1694,6 +1706,37 @@ describe('Core Functions', () => {
         `,
         30_000,
         ['--max-old-space-size=64'],
+      );
+    }, 30_000);
+
+    test('should reject oversized tokens before encoding them', () => {
+      const tokenizer = (): string[] => new Array<string>(3).fill('x'.repeat(1_000_001));
+      const stringify = jest.spyOn(JSON, 'stringify');
+      try {
+        expect(() => n('candidate', 'reference', { tokenizer })).toThrow(/materialization limit/);
+        expect(stringify).not.toHaveBeenCalled();
+      } finally {
+        stringify.mockRestore();
+      }
+    });
+
+    test('should reject oversized token encoding within a small heap', () => {
+      expectBundledScriptToPass(
+        `
+          const token = 'x'.repeat(1_000_001);
+          const tokenizer = () => Array(96).fill(token);
+          try {
+            module.exports.n('candidate', 'reference', { tokenizer });
+            throw new Error('oversized tokens were accepted');
+          } catch (error) {
+            if (!(error instanceof RangeError) || !/materialization limit/.test(error.message)) {
+              throw error;
+            }
+          }
+          process.stdout.write('ok');
+        `,
+        30_000,
+        ['--max-old-space-size=32'],
       );
     }, 30_000);
 


### PR DESCRIPTION
## Summary

- reject oversized raw ROUGE-N inputs before token encoding can exhaust memory
- account for padding, join separators, and sparse token arrays with one shared materialization guard
- preserve custom n-gram callbacks while covering a constrained 32 MB process

## Verification

- `npm test -- --runInBand --silent --verbose=false` (555 passing tests)
- `npm run type-check`
- `./node_modules/.bin/biome ci . --error-on-warnings`