### PR TITLE
fix: isolate reusable metric callback results

### DIFF
--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -27,7 +27,7 @@ export interface RougeSOptions {
   /** Maximum token index distance (1 includes adjacent words; default: Infinity) */
   maxSkip?: number;
   /** Custom skip-bigram generator function */
-  skipBigram?: (tokens: string[], maxSkip?: number) => string[];
+  skipBigram?: (tokens: string[], maxSkip: number) => string[];
   /** Custom string tokenizer */
   tokenizer?: (input: string) => string[];
 }
@@ -244,7 +244,7 @@ export function n(cand: string, ref: string, opts?: RougeNOptions): number {
     if (nGram === utils.nGram) {
       return tokens.length < size ? [] : nGram(encodeTokens(tokens), size);
     }
-    return nGram(tokens, size);
+    return [...nGram(tokens, size)];
   };
   const candGrams = getGrams(cand);
   const refGrams = getGrams(ref);
@@ -303,7 +303,7 @@ export function s(cand: string, ref: string, opts?: RougeSOptions): number {
   validateBeta(beta);
 
   if (skipBigram !== utils.skipBigram) {
-    const candGrams = skipBigram(tokenizeSummary(cand, caseSensitive, tokenizer), maxSkip);
+    const candGrams = [...skipBigram(tokenizeSummary(cand, caseSensitive, tokenizer), maxSkip)];
     const refGrams = skipBigram(tokenizeSummary(ref, caseSensitive, tokenizer), maxSkip);
     const skip2 = countMatchingGrams(candGrams, refGrams);
     if (skip2 === 0) {
@@ -378,8 +378,10 @@ export function l(cand: string, ref: string, opts?: RougeLOptions): number {
   }
   validateBeta(beta);
 
-  const tokenizeSentence = (sentence: string): string[] =>
-    tokenizer(caseSensitive ? sentence : sentence.toLowerCase());
+  const tokenizeSentence = (sentence: string): string[] => {
+    const tokens = tokenizer(caseSensitive ? sentence : sentence.toLowerCase());
+    return tokenizer === utils.treeBankTokenize ? tokens : [...tokens];
+  };
   const segmentSummary = (input: string): string[] =>
     segmenter === utils.sentenceSegment
       ? utils.sentenceSegment(input, { caseNeutral: !caseSensitive })

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1672,6 +1672,15 @@ describe('Core Functions', () => {
       expect(n('aaa', 'aa', { tokenizer, nGram })).toBeCloseTo(4 / 5);
     });
 
+    test('should snapshot reusable custom n-gram arrays', () => {
+      const scratch: string[] = [];
+      const nGram = (tokens: string[]): string[] => {
+        scratch.splice(0, scratch.length, ...tokens);
+        return scratch;
+      };
+      expect(n('alpha', 'beta', { nGram })).toBe(0);
+    });
+
     test('should not apply the built-in padding limit to custom ngram callbacks', () => {
       const nGram = jest.fn((): string[] => ['match']);
       expect(n('a', 'a', { n: 1_000_000_000, nGram })).toBe(1);
@@ -1746,6 +1755,15 @@ describe('Core Functions', () => {
 
     test('should return 0 for summaries with zero overlap', () => {
       expect(s('banana yoghurt', ref, undefined as any)).toBe(0);
+    });
+
+    test('should snapshot reusable custom skip-bigram arrays', () => {
+      const scratch: string[] = [];
+      const skipBigram = (tokens: string[], maxSkip: number): string[] => {
+        scratch.splice(0, scratch.length, tokens.slice(0, maxSkip + 1).join(' '));
+        return scratch;
+      };
+      expect(s('alpha one', 'beta two', { maxSkip: 1, skipBigram })).toBe(0);
     });
 
     test('should correctly compute ROUGE-S score for cand 1 with different opts', () => {
@@ -2017,6 +2035,15 @@ describe('Core Functions', () => {
 
     test('should return zero when custom tokenization removes every token', () => {
       expect(l('a', 'b', { tokenizer: () => [] })).toBe(0);
+    });
+
+    test('should snapshot reusable custom tokenizer arrays', () => {
+      const scratch: string[] = [];
+      const tokenizer = (input: string): string[] => {
+        scratch.splice(0, scratch.length, ...input.split(' '));
+        return scratch;
+      };
+      expect(l('alpha', 'beta', { tokenizer })).toBe(0);
     });
 
     test('should compute union LCS across all candidate sentences', () => {


### PR DESCRIPTION
## Summary

- snapshot reusable custom tokenizer, n-gram, and skip-bigram callback buffers before later invocations mutate them
- reflect the always-present skip window in the public TypeScript callback signature
- add regressions for all three ROUGE metrics and strict callback type checking

## Verification

- `npm test -- --runInBand --silent --verbose=false` (554 passing tests)
- `npm run type-check`
- `./node_modules/.bin/biome ci . --error-on-warnings`