### PR TITLE
fix: preserve lowercase continuations in neutral segmentation

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,7 +100,7 @@ const closingBracketReg = /[\])}>]/;
 const sentenceContinuationReg =
   /^(?:and|or|but|nor|for|yet|so|at|in|on|of|to|from|with|by|as|then|because|while|after|before|although|though|since|unless|until|when|where|whether|if|once|whereas)\b/i;
 const independentSentenceReg =
-  /^(?:in\s+(?:fact|time)\b|(?:after|because|while|before|although|though|since|unless|until|when|where|whether|if|once|whereas)\s+[^,.!?]{1,120},|(?:and|but|or|yet|so|then)\s+(?:(?:i|we|he|she|they|you|it)\b|(?:(?:the|a|an|my|our|their|his|her)\s+)?[\p{Letter}\p{Mark}'’-]+\s+(?:is|are|was|were|has|have|had|did|does|can|could|will|would|should|left|leave|leaves|went|came|said|stayed|arrived|agreed|rose|works|worked|runs|ran)\b))/iu;
+  /^(?:in\s+(?:fact|time)\b|\p{Letter}+\s+[^,.!?]{1,120},|(?:and|but|or|yet|so|then)\s+(?:(?:i|we|he|she|they|you|it)\b|(?:(?:the|a|an|my|our|their|his|her)\s+)?[\p{Letter}\p{Mark}'’-]+\s+(?:is|are|was|were|has|have|had|did|does|can|could|will|would|should|left|leave|leaves|went|came|said|stayed|arrived|agreed|rose|works|worked|runs|ran)\b))/iu;
 
 /** Keep merged fragments separate; boundary rules only need a suffix and word casing. */
 class SentenceBuffer {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,7 +100,7 @@ const closingBracketReg = /[\])}>]/;
 const sentenceContinuationReg =
   /^(?:and|or|but|nor|for|yet|so|at|in|on|of|to|from|with|by|as|then|because|while|after|before|although|though|since|unless|until|when|where|whether|if|once|whereas)\b/i;
 const independentSentenceReg =
-  /^(?:in\s+(?:fact|time)\b|(?:and|but|or|yet|so|then)\s+(?:(?:i|we|he|she|they|you|it)\b|(?:(?:the|a|an|my|our|their|his|her)\s+)?[\p{Letter}\p{Mark}'’-]+\s+(?:is|are|was|were|has|have|had|did|does|can|could|will|would|should|left|leave|leaves|went|came|said|stayed|arrived|agreed|rose|works|worked|runs|ran)\b))/iu;
+  /^(?:in\s+(?:fact|time)\b|(?:after|because|while|before|although|though|since|unless|until|when|where|whether|if|once|whereas)\s+[^,.!?]{1,120},|(?:and|but|or|yet|so|then)\s+(?:(?:i|we|he|she|they|you|it)\b|(?:(?:the|a|an|my|our|their|his|her)\s+)?[\p{Letter}\p{Mark}'’-]+\s+(?:is|are|was|were|has|have|had|did|does|can|could|will|would|should|left|leave|leaves|went|came|said|stayed|arrived|agreed|rose|works|worked|runs|ran)\b))/iu;
 
 /** Keep merged fragments separate; boundary rules only need a suffix and word casing. */
 class SentenceBuffer {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,7 +98,7 @@ const closingDelimiterReg = /[\])}>"']/;
 const openingBracketReg = /[([{<]/;
 const closingBracketReg = /[\])}>]/;
 const sentenceContinuationReg =
-  /^(?:and|or|but|nor|for|yet|so|at|in|on|of|to|from|with|by|as|then)\b/i;
+  /^(?:and|or|but|nor|for|yet|so|at|in|on|of|to|from|with|by|as|then|because|while|after|before|although|though|since|unless|until|when|where|whether|if|once|whereas)\b/i;
 
 /** Keep merged fragments separate; boundary rules only need a suffix and word casing. */
 class SentenceBuffer {
@@ -247,9 +247,7 @@ export function sentenceSegment(
         if (
           nextChunk &&
           (chunk.startsWithTitleCase ||
-            (caseNeutral &&
-              sentenceContinuationReg.test(nextChunk.trimStart()) &&
-              !strIsTitleCase(nextChunk)))
+            (caseNeutral && sentenceContinuationReg.test(nextChunk.trimStart())))
         ) {
           // Catch line breaks embedded within valid sentences
           // i.e. sentences that start with a capital letter
@@ -272,7 +270,7 @@ export function sentenceSegment(
         if (
           (caseNeutral
             ? startsWithCasedCharacter(nextChunk) &&
-              (!sentenceContinuationReg.test(nextChunk.trimStart()) || strIsTitleCase(nextChunk))
+              !sentenceContinuationReg.test(nextChunk.trimStart())
             : strIsTitleCase(nextChunk)) &&
           !excepReg.test(gateSuffix)
         ) {
@@ -458,8 +456,7 @@ function sentenceEnd(
   const gateSuffix = caseNeutral ? suffix.toLowerCase() : suffix;
   const nextCharacter = characterAt(input, next);
   const startsWithLetter = caseNeutral
-    ? isCasedCharacter(nextCharacter) &&
-      (!sentenceContinuationReg.test(input.slice(next)) || charIsUpperCase(nextCharacter))
+    ? isNeutralSentenceStart(input, end, next)
     : charIsUpperCase(nextCharacter);
   const startsWithNumber =
     /^\p{Number}$/u.test(nextCharacter) &&
@@ -474,6 +471,19 @@ function sentenceEnd(
     return -1;
   }
   return abbrvReg.test(gateSuffix) && excepReg.test(gateSuffix) ? -1 : end;
+}
+
+function isNeutralSentenceStart(input: string, previousEnd: number, next: number): boolean {
+  if (!isCasedCharacter(characterAt(input, next))) {
+    return false;
+  }
+
+  const continuation = input.slice(next);
+  return (
+    !sentenceContinuationReg.test(continuation) ||
+    /^in fact\b/i.test(continuation) ||
+    input.slice(previousEnd, next).includes('"')
+  );
 }
 
 function trimSpaces(input: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,7 +100,7 @@ const closingBracketReg = /[\])}>]/;
 const sentenceContinuationReg =
   /^(?:and|or|but|nor|for|yet|so|at|in|on|of|to|from|with|by|as|then|because|while|after|before|although|though|since|unless|until|when|where|whether|if|once|whereas)\b/i;
 const independentSentenceReg =
-  /^(?:in\s+(?:fact|time)\b|\p{Letter}+\s+[^,.!?]{1,120},|(?:and|but|or|yet|so|then)\s+(?:(?:i|we|he|she|they|you|it)\b|(?:(?:the|a|an|my|our|their|his|her)\s+)?[\p{Letter}\p{Mark}'’-]+\s+(?:is|are|was|were|has|have|had|did|does|can|could|will|would|should|left|leave|leaves|went|came|said|stayed|arrived|agreed|rose|works|worked|runs|ran)\b))/iu;
+  /^(?:in\s+(?:fact|time)\b|\p{Letter}+\s+[^,.!?]{1,120},|(?:and|but|or|yet|so|then)\s+(?:(?:i|we|he|she|they|you|it)\b|(?:(?:the|a|an|my|our|their|his|her)\s+)?(?!(?:more|later|moved)\b)[\p{Letter}\p{Mark}'’-]+\s+[\p{Letter}\p{Mark}'’-]+\b))/iu;
 
 /** Keep merged fragments separate; boundary rules only need a suffix and word casing. */
 class SentenceBuffer {
@@ -251,7 +251,7 @@ export function sentenceSegment(
           (chunk.startsWithTitleCase ||
             (caseNeutral &&
               sentenceContinuationReg.test(nextChunk.trimStart()) &&
-              /[.!?]["'\])}]\s*[\r\n]/.test(suffix)))
+              /[.!?]["'\])}>]\s*[\r\n]/.test(suffix)))
         ) {
           // Catch line breaks embedded within valid sentences
           // i.e. sentences that start with a capital letter

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,7 +100,7 @@ const closingBracketReg = /[\])}>]/;
 const sentenceContinuationReg =
   /^(?:and|or|but|nor|for|yet|so|at|in|on|of|to|from|with|by|as|then|because|while|after|before|although|though|since|unless|until|when|where|whether|if|once|whereas)\b/i;
 const independentSentenceReg =
-  /^(?:in\s+(?:fact|time)\b|(?:and|but|or|yet|so|then)\s+(?:i|we|he|she|they|you|it)\b)/i;
+  /^(?:in\s+(?:fact|time)\b|(?:and|but|or|yet|so|then)\s+(?:(?:i|we|he|she|they|you|it)\b|(?:(?:the|a|an|my|our|their|his|her)\s+)?[\p{Letter}\p{Mark}'’-]+\s+(?:is|are|was|were|has|have|had|did|does|can|could|will|would|should|left|leave|leaves|went|came|said|stayed|arrived|agreed|rose|works|worked|runs|ran)\b))/iu;
 
 /** Keep merged fragments separate; boundary rules only need a suffix and word casing. */
 class SentenceBuffer {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,6 +97,8 @@ const sentenceSuffixLength = Math.max(10, ...GATE_SUBSTITUTIONS.map((word) => wo
 const closingDelimiterReg = /[\])}>"']/;
 const openingBracketReg = /[([{<]/;
 const closingBracketReg = /[\])}>]/;
+const sentenceContinuationReg =
+  /^(?:and|or|but|nor|for|yet|so|at|in|on|of|to|from|with|by|as|then)\b/i;
 
 /** Keep merged fragments separate; boundary rules only need a suffix and word casing. */
 class SentenceBuffer {
@@ -261,7 +263,10 @@ export function sentenceSegment(
       } else if (chunks[idx + 1] && abbrvReg.test(gateSuffix)) {
         const nextChunk = chunks[idx + 1];
         if (
-          (caseNeutral ? startsWithCasedCharacter(nextChunk) : strIsTitleCase(nextChunk)) &&
+          (caseNeutral
+            ? startsWithCasedCharacter(nextChunk) &&
+              !sentenceContinuationReg.test(nextChunk.trimStart())
+            : strIsTitleCase(nextChunk)) &&
           !excepReg.test(gateSuffix)
         ) {
           // Catch abbreviations followed by a capital letter and treat as a boundary.
@@ -446,7 +451,7 @@ function sentenceEnd(
   const gateSuffix = caseNeutral ? suffix.toLowerCase() : suffix;
   const nextCharacter = characterAt(input, next);
   const startsWithLetter = caseNeutral
-    ? isCasedCharacter(nextCharacter)
+    ? isCasedCharacter(nextCharacter) && !sentenceContinuationReg.test(input.slice(next))
     : charIsUpperCase(nextCharacter);
   const startsWithNumber =
     /^\p{Number}$/u.test(nextCharacter) &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -99,6 +99,8 @@ const openingBracketReg = /[([{<]/;
 const closingBracketReg = /[\])}>]/;
 const sentenceContinuationReg =
   /^(?:and|or|but|nor|for|yet|so|at|in|on|of|to|from|with|by|as|then|because|while|after|before|although|though|since|unless|until|when|where|whether|if|once|whereas)\b/i;
+const independentSentenceReg =
+  /^(?:in\s+(?:fact|time)\b|(?:and|but|or|yet|so|then)\s+(?:i|we|he|she|they|you|it)\b)/i;
 
 /** Keep merged fragments separate; boundary rules only need a suffix and word casing. */
 class SentenceBuffer {
@@ -247,7 +249,9 @@ export function sentenceSegment(
         if (
           nextChunk &&
           (chunk.startsWithTitleCase ||
-            (caseNeutral && sentenceContinuationReg.test(nextChunk.trimStart())))
+            (caseNeutral &&
+              sentenceContinuationReg.test(nextChunk.trimStart()) &&
+              /[.!?]["'\])}]\s*[\r\n]/.test(suffix)))
         ) {
           // Catch line breaks embedded within valid sentences
           // i.e. sentences that start with a capital letter
@@ -270,7 +274,8 @@ export function sentenceSegment(
         if (
           (caseNeutral
             ? startsWithCasedCharacter(nextChunk) &&
-              !sentenceContinuationReg.test(nextChunk.trimStart())
+              (!sentenceContinuationReg.test(nextChunk.trimStart()) ||
+                independentSentenceReg.test(nextChunk.trimStart()))
             : strIsTitleCase(nextChunk)) &&
           !excepReg.test(gateSuffix)
         ) {
@@ -481,7 +486,7 @@ function isNeutralSentenceStart(input: string, previousEnd: number, next: number
   const continuation = input.slice(next);
   return (
     !sentenceContinuationReg.test(continuation) ||
-    /^in fact\b/i.test(continuation) ||
+    independentSentenceReg.test(continuation) ||
     input.slice(previousEnd, next).includes('"')
   );
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -243,11 +243,18 @@ export function sentenceSegment(
       const lastWord = suffix.match(/\S+$/)?.[0] ?? '';
 
       if (chunk.hasLineBreaks) {
-        if (chunks[idx + 1] && chunk.startsWithTitleCase) {
+        const nextChunk = chunks[idx + 1];
+        if (
+          nextChunk &&
+          (chunk.startsWithTitleCase ||
+            (caseNeutral &&
+              sentenceContinuationReg.test(nextChunk.trimStart()) &&
+              !strIsTitleCase(nextChunk)))
+        ) {
           // Catch line breaks embedded within valid sentences
           // i.e. sentences that start with a capital letter
           // and normalize every wrap before reprocessing the joined chunk.
-          chunk.append(` ${chunks[idx + 1]}`);
+          chunk.append(` ${nextChunk}`);
           chunk.normalizeWhitespace();
           pending = chunk;
         } else {
@@ -265,7 +272,7 @@ export function sentenceSegment(
         if (
           (caseNeutral
             ? startsWithCasedCharacter(nextChunk) &&
-              !sentenceContinuationReg.test(nextChunk.trimStart())
+              (!sentenceContinuationReg.test(nextChunk.trimStart()) || strIsTitleCase(nextChunk))
             : strIsTitleCase(nextChunk)) &&
           !excepReg.test(gateSuffix)
         ) {
@@ -451,7 +458,8 @@ function sentenceEnd(
   const gateSuffix = caseNeutral ? suffix.toLowerCase() : suffix;
   const nextCharacter = characterAt(input, next);
   const startsWithLetter = caseNeutral
-    ? isCasedCharacter(nextCharacter) && !sentenceContinuationReg.test(input.slice(next))
+    ? isCasedCharacter(nextCharacter) &&
+      (!sentenceContinuationReg.test(input.slice(next)) || charIsUpperCase(nextCharacter))
     : charIsUpperCase(nextCharacter);
   const startsWithNumber =
     /^\p{Number}$/u.test(nextCharacter) &&

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -461,6 +461,22 @@ describe('Utility Functions', () => {
       expect(segmentCaseNeutrally('"mt." next stop.')).toEqual(['"mt." next stop.']);
     });
 
+    test.each([
+      ['He answered "No." In fact, he left.', ['He answered "No."', 'In fact, he left.']],
+      ['She paused. "Then we begin."', ['She paused.', '"Then we begin."']],
+    ])('retains capitalized sentence starts after closing delimiters in %s', (input, expected) => {
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+    });
+
+    test.each(['\n', '\r\n', '\r'])(
+      'keeps lowercase quote continuations after uncased starts across %j',
+      (lineBreak) => {
+        expect(segmentCaseNeutrally(`2020 saw "hello."${lineBreak}then left.`)).toEqual([
+          '2020 saw "hello." then left.',
+        ]);
+      },
+    );
+
     test.each(['\u212a', '\u0130', 'I\u0307\u0323', 'I\u093e', 'I\u20dd', '\u{10400}\u0307'])(
       'should treat combining marks as part of a case-neutral initial: %s',
       (initial) => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -504,7 +504,16 @@ describe('Utility Functions', () => {
       'After that, John smiled.',
       'Because he was late, John hurried.',
       'While we waited, John arrived.',
-    ])('recognizes independent sentence-initial subordinators: %s', (continuation) => {
+      'At noon, John left.',
+      'On Monday, work resumed.',
+      'With little warning, it ended.',
+      'By noon, we returned.',
+      'From there, everyone left.',
+      'To begin, we agreed.',
+      'As expected, it worked.',
+      'In July, we moved.',
+      'For example, John laughed.',
+    ])('recognizes independent sentence-initial clauses: %s', (continuation) => {
       const input = `The list includes cats, dogs, etc. ${continuation}`;
       const expected = ['The list includes cats, dogs, etc.', continuation];
       expect(segmentCaseNeutrally(input)).toEqual(expected);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -438,6 +438,16 @@ describe('Utility Functions', () => {
       expect(segmentCaseNeutrally(input)).toEqual(expected);
     });
 
+    test.each([
+      'we need etc. and more animals.',
+      'at 8 a.m. and later we left.',
+      'i lived in calif. and moved east.',
+      'they worked at acme co. at noon.',
+      'she wrote "hello." then left.',
+    ])('keeps lowercase sentence continuations case-neutrally: %s', (input) => {
+      expect(segmentCaseNeutrally(input)).toEqual([input]);
+    });
+
     test('should match lowercase-equivalent Unicode abbreviations case-neutrally', () => {
       const mixedCase = 'Da\u212a.\nNext.';
       const lowerCase = mixedCase.toLowerCase();
@@ -1399,6 +1409,14 @@ describe('Core Functions', () => {
   );
 
   describe.each(metrics)('%s input handling', (_name, score) => {
+    test('does not change already-lowercase abbreviation scores in case-insensitive mode', () => {
+      const candidate = 'we need etc. and more animals.';
+      const reference = 'and more animals we need etc.';
+      expect(score(candidate, reference, { caseSensitive: false })).toBe(
+        score(candidate, reference),
+      );
+    });
+
     test.each(['\n', '\r\n', '\r'])('keeps wrapped quotes (%j)', (lineBreak) => {
       expect(score(`He said "Stop.${lineBreak}" Next.`, 'He said "Stop." Next.')).toBe(1);
       expect(score(`He said "Stop.${lineBreak}"`, 'He said "Stop."')).toBe(1);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -464,6 +464,8 @@ describe('Utility Functions', () => {
     test.each([
       ['He answered "No." In fact, he left.', ['He answered "No."', 'In fact, he left.']],
       ['He said "No." But I left.', ['He said "No."', 'But I left.']],
+      ['He said "No." But John left.', ['He said "No."', 'But John left.']],
+      ['He said "No." And the manager agreed.', ['He said "No."', 'And the manager agreed.']],
       ['He said "No." And we left.', ['He said "No."', 'And we left.']],
       ['He said "No." In time, we left.', ['He said "No."', 'In time, we left.']],
       ['She paused. "Then we begin."', ['She paused.', '"Then we begin."']],
@@ -483,6 +485,15 @@ describe('Utility Functions', () => {
     test('keeps independent abbreviation continuations invariant under case folding', () => {
       const input = 'Use etc. In fact, this is common.';
       const expected = ['Use etc.', 'In fact, this is common.'];
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+        expected.map((sentence) => sentence.toLowerCase()),
+      );
+    });
+
+    test('recognizes independent clauses with noun subjects after abbreviations', () => {
+      const input = 'Use etc. But John left.';
+      const expected = ['Use etc.', 'But John left.'];
       expect(segmentCaseNeutrally(input)).toEqual(expected);
       expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
         expected.map((sentence) => sentence.toLowerCase()),

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -500,6 +500,19 @@ describe('Utility Functions', () => {
       );
     });
 
+    test.each([
+      'After that, John smiled.',
+      'Because he was late, John hurried.',
+      'While we waited, John arrived.',
+    ])('recognizes independent sentence-initial subordinators: %s', (continuation) => {
+      const input = `The list includes cats, dogs, etc. ${continuation}`;
+      const expected = ['The list includes cats, dogs, etc.', continuation];
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+        expected.map((sentence) => sentence.toLowerCase()),
+      );
+    });
+
     test.each(['because', 'while', 'after', 'before', 'although', 'unless', 'until', 'when'])(
       'keeps subordinating continuation %s inside the sentence',
       (conjunction) => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -466,7 +466,24 @@ describe('Utility Functions', () => {
       ['She paused. "Then we begin."', ['She paused.', '"Then we begin."']],
     ])('retains capitalized sentence starts after closing delimiters in %s', (input, expected) => {
       expect(segmentCaseNeutrally(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+        expected.map((sentence) => sentence.toLowerCase()),
+      );
     });
+
+    test('keeps abbreviation continuations invariant under case folding', () => {
+      const input = 'Use etc. And more animals.';
+      expect(segmentCaseNeutrally(input)).toEqual([input]);
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([input.toLowerCase()]);
+    });
+
+    test.each(['because', 'while', 'after', 'before', 'although', 'unless', 'until', 'when'])(
+      'keeps subordinating continuation %s inside the sentence',
+      (conjunction) => {
+        const input = `we chose acme co. ${conjunction} it was reliable.`;
+        expect(segmentCaseNeutrally(input)).toEqual(ss(input));
+      },
+    );
 
     test.each(['\n', '\r\n', '\r'])(
       'keeps lowercase quote continuations after uncased starts across %j',

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -463,6 +463,9 @@ describe('Utility Functions', () => {
 
     test.each([
       ['He answered "No." In fact, he left.', ['He answered "No."', 'In fact, he left.']],
+      ['He said "No." But I left.', ['He said "No."', 'But I left.']],
+      ['He said "No." And we left.', ['He said "No."', 'And we left.']],
+      ['He said "No." In time, we left.', ['He said "No."', 'In time, we left.']],
       ['She paused. "Then we begin."', ['She paused.', '"Then we begin."']],
     ])('retains capitalized sentence starts after closing delimiters in %s', (input, expected) => {
       expect(segmentCaseNeutrally(input)).toEqual(expected);
@@ -475,6 +478,15 @@ describe('Utility Functions', () => {
       const input = 'Use etc. And more animals.';
       expect(segmentCaseNeutrally(input)).toEqual([input]);
       expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([input.toLowerCase()]);
+    });
+
+    test('keeps independent abbreviation continuations invariant under case folding', () => {
+      const input = 'Use etc. In fact, this is common.';
+      const expected = ['Use etc.', 'In fact, this is common.'];
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+        expected.map((sentence) => sentence.toLowerCase()),
+      );
     });
 
     test.each(['because', 'while', 'after', 'before', 'although', 'unless', 'until', 'when'])(
@@ -493,6 +505,13 @@ describe('Utility Functions', () => {
         ]);
       },
     );
+
+    test('retains line boundaries after numeric headings', () => {
+      expect(segmentCaseNeutrally('2020 report\nand sales rose.')).toEqual([
+        '2020 report',
+        'and sales rose.',
+      ]);
+    });
 
     test.each(['\u212a', '\u0130', 'I\u0307\u0323', 'I\u093e', 'I\u20dd', '\u{10400}\u0307'])(
       'should treat combining marks as part of a case-neutral initial: %s',

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -500,6 +500,18 @@ describe('Utility Functions', () => {
       );
     });
 
+    test.each(['smiled', 'laughed', 'danced', 'recovered', 'reads'])(
+      'recognizes independent noun-subject clauses without a verb whitelist: %s',
+      (verb) => {
+        const input = `Use etc. But John ${verb}.`;
+        const expected = ['Use etc.', `But John ${verb}.`];
+        expect(segmentCaseNeutrally(input)).toEqual(expected);
+        expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+          expected.map((sentence) => sentence.toLowerCase()),
+        );
+      },
+    );
+
     test.each([
       'After that, John smiled.',
       'Because he was late, John hurried.',
@@ -535,6 +547,9 @@ describe('Utility Functions', () => {
       (lineBreak) => {
         expect(segmentCaseNeutrally(`2020 saw "hello."${lineBreak}then left.`)).toEqual([
           '2020 saw "hello." then left.',
+        ]);
+        expect(segmentCaseNeutrally(`2020 saw <hello.>${lineBreak}then left.`)).toEqual([
+          '2020 saw <hello.> then left.',
         ]);
       },
     );


### PR DESCRIPTION
## Summary

- keep common conjunction and preposition continuations attached to abbreviations and quoted sentences when case information is unavailable
- preserve true lowercase sentence starts and existing page-number and exception behavior
- verify case-insensitive scoring remains equivalent across ROUGE-N, ROUGE-S, and ROUGE-L

## Verification

- `npm test -- --runInBand --silent --verbose=false` (559 passing tests)
- `npm run type-check`
- `./node_modules/.bin/biome ci . --error-on-warnings`
- `git diff --check`