### PR TITLE
fix: tokenize Unicode boundaries and decimal separators

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,14 +1,21 @@
+const unicodeWordCharacter =
+  '[\\p{Letter}\\p{Mark}\\p{Number}\\p{Connector_Punctuation}\\u200c\\u200d]';
+
+function contraction(pattern: string): RegExp {
+  return new RegExp(`(?<!${unicodeWordCharacter})${pattern}(?!${unicodeWordCharacter})`, 'giu');
+}
+
 export const TREEBANK_CONTRACTIONS: RegExp[] = [
-  /(?<![\p{Letter}\p{Mark}\p{Number}_])(can)(not)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
-  /(?<![\p{Letter}\p{Mark}\p{Number}_])(d)('ye)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
-  /(?<![\p{Letter}\p{Mark}\p{Number}_])(gim)(me)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
-  /(?<![\p{Letter}\p{Mark}\p{Number}_])(gon)(na)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
-  /(?<![\p{Letter}\p{Mark}\p{Number}_])(got)(ta)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
-  /(?<![\p{Letter}\p{Mark}\p{Number}_])(lem)(me)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
-  /(?<![\p{Letter}\p{Mark}\p{Number}_])(more)('n)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
-  /(?<![\p{Letter}\p{Mark}\p{Number}_])(wan)(na) /giu,
-  / ('t)(is)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
-  / ('t)(was)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
+  contraction('(can)(not)'),
+  contraction("(d)('ye)"),
+  contraction('(gim)(me)'),
+  contraction('(gon)(na)'),
+  contraction('(got)(ta)'),
+  contraction('(lem)(me)'),
+  contraction("(more)('n)"),
+  contraction('(wan)(na)(?= )'),
+  contraction("('t)(is)"),
+  contraction("('t)(was)"),
 ];
 
 export const HONORIFICS: string[] = [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,4 @@
-const unicodeWordCharacter =
-  '[\\p{Letter}\\p{Mark}\\p{Number}\\p{Connector_Punctuation}\\u200c\\u200d]';
+const unicodeWordCharacter = '[\\p{ID_Continue}\\u200c\\u200d]';
 
 function contraction(pattern: string): RegExp {
   return new RegExp(`(?<!${unicodeWordCharacter})${pattern}(?!${unicodeWordCharacter})`, 'giu');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,14 +1,14 @@
 export const TREEBANK_CONTRACTIONS: RegExp[] = [
-  /\b(can)(not)\b/gi,
-  /\b(d)('ye)\b/gi,
-  /\b(gim)(me)\b/gi,
-  /\b(gon)(na)\b/gi,
-  /\b(got)(ta)\b/gi,
-  /\b(lem)(me)\b/gi,
-  /\b(more)('n)\b/gi,
-  /\b(wan)(na) /gi,
-  / ('t)(is)\b/gi,
-  / ('t)(was)\b/gi,
+  /(?<![\p{Letter}\p{Mark}\p{Number}_])(can)(not)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
+  /(?<![\p{Letter}\p{Mark}\p{Number}_])(d)('ye)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
+  /(?<![\p{Letter}\p{Mark}\p{Number}_])(gim)(me)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
+  /(?<![\p{Letter}\p{Mark}\p{Number}_])(gon)(na)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
+  /(?<![\p{Letter}\p{Mark}\p{Number}_])(got)(ta)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
+  /(?<![\p{Letter}\p{Mark}\p{Number}_])(lem)(me)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
+  /(?<![\p{Letter}\p{Mark}\p{Number}_])(more)('n)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
+  /(?<![\p{Letter}\p{Mark}\p{Number}_])(wan)(na) /giu,
+  / ('t)(is)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
+  / ('t)(was)(?![\p{Letter}\p{Mark}\p{Number}_])/giu,
 ];
 
 export const HONORIFICS: string[] = [

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -222,10 +222,10 @@ function encodeTokens(tokens: string[]): string[] {
  * @return {number}                 The ROUGE-N F-score
  */
 export function n(cand: string, ref: string, opts?: RougeNOptions): number {
-  if (cand.trim().length === 0) {
+  if (cand.replace(/\u0085/g, '').trim().length === 0) {
     throw new RangeError('Candidate cannot be an empty string');
   }
-  if (ref.trim().length === 0) {
+  if (ref.replace(/\u0085/g, '').trim().length === 0) {
     throw new RangeError('Reference cannot be an empty string');
   }
 
@@ -285,10 +285,10 @@ export function n(cand: string, ref: string, opts?: RougeNOptions): number {
  * @return {number}                 The ROUGE-S score
  */
 export function s(cand: string, ref: string, opts?: RougeSOptions): number {
-  if (cand.trim().length === 0) {
+  if (cand.replace(/\u0085/g, '').trim().length === 0) {
     throw new RangeError('Candidate cannot be an empty string');
   }
-  if (ref.trim().length === 0) {
+  if (ref.replace(/\u0085/g, '').trim().length === 0) {
     throw new RangeError('Reference cannot be an empty string');
   }
 
@@ -358,10 +358,10 @@ export function s(cand: string, ref: string, opts?: RougeSOptions): number {
  * @return {number}                 The ROUGE-L score
  */
 export function l(cand: string, ref: string, opts?: RougeLOptions): number {
-  if (cand.trim().length === 0) {
+  if (cand.replace(/\u0085/g, '').trim().length === 0) {
     throw new RangeError('Candidate cannot be an empty string');
   }
-  if (ref.trim().length === 0) {
+  if (ref.replace(/\u0085/g, '').trim().length === 0) {
     throw new RangeError('Reference cannot be an empty string');
   }
 

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -4,6 +4,8 @@ import { validateBeta, validateMaxSkip, validateNGramSize } from './validation';
 
 export * from './utils';
 
+const whitespaceOnlyReg = /^[\s\u0085]*$/;
+
 /** Options for ROUGE-N evaluation */
 export interface RougeNOptions {
   /** The size of the ngram used (default: 1) */
@@ -222,10 +224,10 @@ function encodeTokens(tokens: string[]): string[] {
  * @return {number}                 The ROUGE-N F-score
  */
 export function n(cand: string, ref: string, opts?: RougeNOptions): number {
-  if (cand.replace(/\u0085/g, '').trim().length === 0) {
+  if (whitespaceOnlyReg.test(cand)) {
     throw new RangeError('Candidate cannot be an empty string');
   }
-  if (ref.replace(/\u0085/g, '').trim().length === 0) {
+  if (whitespaceOnlyReg.test(ref)) {
     throw new RangeError('Reference cannot be an empty string');
   }
 
@@ -285,10 +287,10 @@ export function n(cand: string, ref: string, opts?: RougeNOptions): number {
  * @return {number}                 The ROUGE-S score
  */
 export function s(cand: string, ref: string, opts?: RougeSOptions): number {
-  if (cand.replace(/\u0085/g, '').trim().length === 0) {
+  if (whitespaceOnlyReg.test(cand)) {
     throw new RangeError('Candidate cannot be an empty string');
   }
-  if (ref.replace(/\u0085/g, '').trim().length === 0) {
+  if (whitespaceOnlyReg.test(ref)) {
     throw new RangeError('Reference cannot be an empty string');
   }
 
@@ -358,10 +360,10 @@ export function s(cand: string, ref: string, opts?: RougeSOptions): number {
  * @return {number}                 The ROUGE-L score
  */
 export function l(cand: string, ref: string, opts?: RougeLOptions): number {
-  if (cand.replace(/\u0085/g, '').trim().length === 0) {
+  if (whitespaceOnlyReg.test(cand)) {
     throw new RangeError('Candidate cannot be an empty string');
   }
-  if (ref.replace(/\u0085/g, '').trim().length === 0) {
+  if (whitespaceOnlyReg.test(ref)) {
     throw new RangeError('Reference cannot be an empty string');
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,7 +21,7 @@ import { validateBeta, validateMaxSkip, validateNGramSize } from './validation';
  */
 export function treeBankTokenize(input: string): string[] {
   // Contraction rules below expect spaces, including at word boundaries.
-  const text = input.trim().replace(/\s+/g, ' ');
+  const text = input.replace(/[\s\u0085]+/g, ' ').trim();
   if (text.length === 0) {
     return [];
   }
@@ -42,7 +42,7 @@ export function treeBankTokenize(input: string): string[] {
   // Preserve numeric separators and acronym dots, even at a heuristic sentence boundary.
   parse = parse
     .replace(/\.{3}/g, ' ... ')
-    .replace(/[:,](?!\d)/g, ' $& ')
+    .replace(/[:,](?!\p{Decimal_Number})/gu, ' $& ')
     .replace(/[;@#$%&]/g, ' $& ')
     .replace(/([^.])(?<!\b[A-Za-z]\.[A-Za-z])(\.)([\])}>'\s]*)$/g, '$1 $2$3 ')
     .replace(/[?!]/g, ' $& ')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -220,7 +220,7 @@ export function sentenceSegment(
   }
 
   // Scan terminals before applying abbreviation and line-wrap rules.
-  const chunks = sentenceChunks(input, caseNeutral);
+  const chunks = sentenceChunks(input.replace(/\u0085/g, ' '), caseNeutral);
 
   const acc: string[] = [];
   let pending: SentenceBuffer | undefined;

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1000,7 +1000,7 @@ describe('Utility Functions', () => {
       expect(tbt('')).toEqual([]);
     });
 
-    const whitespace = [' ', '\t', '\n', '\r\n', '\u00a0'];
+    const whitespace = [' ', '\t', '\n', '\r\n', '\u00a0', '\u0085'];
     test.each(whitespace)('should split words separated by %j', (separator) => {
       expect(tbt(`alpha${separator}beta`)).toEqual(['alpha', 'beta']);
       expect(tbt(`${separator}They'll${separator}go.${separator}`)).toEqual([
@@ -1014,6 +1014,20 @@ describe('Utility Functions', () => {
     test.each(whitespace)('should not invent tokens for %j', (separator) => {
       expect(tbt(separator.repeat(3))).toEqual([]);
     });
+
+    test.each(['écannot', 'cannoté', 'Åwanna', 'wanna\u0301', "more'né"])(
+      'does not split contractions inside Unicode words: %s',
+      (word) => {
+        expect(tbt(word)).toEqual([word]);
+      },
+    );
+
+    test.each(['١٢,٣٤٥', '１２,３４５', '١٢:٣٤'])(
+      'preserves numeric separators before Unicode decimal digits: %s',
+      (number) => {
+        expect(tbt(number)).toEqual([number]);
+      },
+    );
 
     const uncommonContractions: [string, string[]][] = [
       ['cannot', ['can', 'not']],
@@ -1440,11 +1454,14 @@ describe('Core Functions', () => {
       expect(score('alpha\tbeta', 'alpha beta')).toBe(1);
       expect(score('alpha\nbeta', 'alpha beta')).toBe(1);
       expect(score('alpha\u00a0beta', 'alpha beta')).toBe(1);
+      expect(score('alpha\u0085beta', 'alpha beta')).toBe(1);
     });
 
     test('should reject whitespace-only summaries like empty strings', () => {
       expect(() => score(' \t\r\n', 'alpha beta')).toThrow('Candidate cannot be an empty string');
       expect(() => score('alpha beta', ' \t\r\n')).toThrow('Reference cannot be an empty string');
+      expect(() => score('\u0085', 'alpha beta')).toThrow('Candidate cannot be an empty string');
+      expect(() => score('alpha beta', '\u0085')).toThrow('Reference cannot be an empty string');
     });
 
     test('should separate colons without splitting numeric commas', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -412,6 +412,10 @@ describe('Utility Functions', () => {
       expect(ss('Hello World. My name is Jonas.')).toEqual(['Hello World.', 'My name is Jonas.']);
     });
 
+    test('treats NEL as whitespace after sentence terminators', () => {
+      expect(ss('Alpha.\u0085Beta.')).toEqual(['Alpha.', 'Beta.']);
+    });
+
     test.each([
       ['astral uppercase', '\u{10400}', true],
       ['astral lowercase', '\u{10428}', false],
@@ -1015,12 +1019,19 @@ describe('Utility Functions', () => {
       expect(tbt(separator.repeat(3))).toEqual([]);
     });
 
-    test.each(['écannot', 'cannoté', 'Åwanna', 'wanna\u0301', "more'né"])(
-      'does not split contractions inside Unicode words: %s',
-      (word) => {
-        expect(tbt(word)).toEqual([word]);
-      },
-    );
+    test.each([
+      'écannot',
+      'cannoté',
+      'Åwanna',
+      'wanna\u0301',
+      "more'né",
+      'cannot‿foo',
+      'cannot\u200cfoo',
+      'cannot\u200dfoo',
+      'foo‿cannot',
+    ])('does not split contractions inside Unicode words: %s', (word) => {
+      expect(tbt(word)).toEqual([word]);
+    });
 
     test.each(['١٢,٣٤٥', '１２,３４５', '١٢:٣٤'])(
       'preserves numeric separators before Unicode decimal digits: %s',
@@ -1455,6 +1466,7 @@ describe('Core Functions', () => {
       expect(score('alpha\nbeta', 'alpha beta')).toBe(1);
       expect(score('alpha\u00a0beta', 'alpha beta')).toBe(1);
       expect(score('alpha\u0085beta', 'alpha beta')).toBe(1);
+      expect(score('Alpha.\u0085Beta.', 'Alpha. Beta.')).toBe(1);
     });
 
     test('should reject whitespace-only summaries like empty strings', () => {
@@ -1874,6 +1886,10 @@ describe('Core Functions', () => {
 
     const ref = 'police killed the gunman';
     const cands = ['police kill the gunman', 'the gunman kill police', 'the gunman police killed'];
+
+    test('preserves reordered sentence boundaries across NEL separators', () => {
+      expect(l('Alpha.\u0085Beta.', 'Beta.\u0085Alpha.')).toBe(1);
+    });
 
     test('should preserve word separation after an ellipsis for custom tokenizers', () => {
       const tokenizer = (input: string): string[] => input.split(/\s+/);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1029,6 +1029,8 @@ describe('Utility Functions', () => {
       'cannot\u200cfoo',
       'cannot\u200dfoo',
       'foo‿cannot',
+      'cannot·foo',
+      'cannot・foo',
     ])('does not split contractions inside Unicode words: %s', (word) => {
       expect(tbt(word)).toEqual([word]);
     });


### PR DESCRIPTION
## Summary

- avoid splitting contractions embedded in Unicode letters and combining marks
- preserve separators before non-ASCII decimal digits
- recognize U+0085 consistently in tokenization and all public scorer empty-input guards

## Verification

- `npm test -- --runInBand --silent --verbose=false` (full Jest suite)
- `npm run type-check`
- `./node_modules/.bin/biome ci . --error-on-warnings`
- `git diff --check`