### PR TITLE
fix: bound public skip-bigram materialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Omitted options and fields explicitly set to `undefined` use the documented defa
 
 ROUGE-N and ROUGE-S count repeated matching grams up to the smaller of their frequencies in the candidate and reference. Correcting earlier versions' set-based counting changes scores for repeated grams; rerun evaluation baselines when comparing versions.
 
-Built-in ROUGE-S scoring counts skip-bigram frequencies without allocating the full pair arrays. Calling the exported `skipBigram()` utility or supplying a custom `skipBigram` callback still materializes the callback's returned array.
+Built-in ROUGE-S scoring counts skip-bigram frequencies without allocating the full pair arrays. The exported `skipBigram()` utility bounds its pair and character materialization and throws `RangeError` when the limit is exceeded. Custom `skipBigram` callbacks remain responsible for their returned arrays.
 
 Built-in scoring preserves token boundaries even when custom tokenizers return tokens containing spaces, quotes, or separators. For example, `["new york", "city"]` and `["new", "york city"]` no longer count as the same bigram. The exported `nGram()` and `skipBigram()` utilities retain their readable, space-joined output strings; those strings are not collision-free identifiers for arbitrary token arrays. Custom gram generators still receive the original tokens and their returned strings are used as identities, so those callbacks remain responsible for any encoding they need.
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -567,6 +567,17 @@ export function skipBigram(tokens: string[], maxSkip: number = Number.POSITIVE_I
     throw new RangeError('Input must have at least two words');
   }
 
+  const distance = Math.min(maxSkip, tokens.length - 1);
+  let work = distance * tokens.length - (distance * (distance + 1)) / 2;
+  for (let index = 0; index < tokens.length && work <= 1_000_000; index++) {
+    work +=
+      tokens[index].length *
+      (Math.min(distance, index) + Math.min(distance, tokens.length - index - 1));
+  }
+  if (work > 1_000_000) {
+    throw new RangeError('Skip-bigram generation exceeds the materialization limit');
+  }
+
   const acc: string[] = [];
   for (let baseIdx = 0; baseIdx < tokens.length - 1; baseIdx++) {
     const maxIdx = Math.min(baseIdx + 1 + maxSkip, tokens.length);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -395,6 +395,33 @@ describe('Utility Functions', () => {
     test('should return pairs within skip distance of 3', () => {
       expect(sb(data, 3)).toEqual(['a b', 'a c', 'a d', 'b c', 'b d', 'c d']);
     });
+
+    test('rejects excessive pair counts before materializing bigrams', () => {
+      expect(() => sb(new Array<string>(1600).fill('a'))).toThrow(/materialization limit/);
+    });
+
+    test('accounts for long token values in the materialization limit', () => {
+      expect(() => sb(['a'.repeat(500_000), 'b'.repeat(500_000)])).toThrow(/materialization limit/);
+      expect(sb(['a'.repeat(500_000), 'b'.repeat(500_000)], 0)).toEqual([]);
+    });
+
+    test('rejects oversized inputs within a constrained heap', () => {
+      expectBundledScriptToPass(
+        `
+          try {
+            module.exports.skipBigram(new Array(1600).fill('token'));
+            throw new Error('Oversized skip-bigrams were accepted');
+          } catch (error) {
+            if (!(error instanceof RangeError) || !/materialization limit/.test(error.message)) {
+              throw error;
+            }
+          }
+          process.stdout.write('ok');
+        `,
+        10_000,
+        ['--max-old-space-size=32'],
+      );
+    }, 10_000);
   });
 
   describe('sentenceSegment', () => {


### PR DESCRIPTION
## Summary

- reject skip-bigram outputs exceeding their projected pair or character budget before allocating them
- preserve zero-window behavior and document the public utility limit
- verify rejection under a 32 MB heap without restricting streaming ROUGE-S scoring

## Verification

- `npm test -- --runInBand --silent --verbose=false` (554 passing Jest tests and README Prettier check)
- `npm run type-check`
- `./node_modules/.bin/biome ci . --error-on-warnings`
- `git diff --check`