### PR TITLE
fix: preserve abbreviation boundaries across whitespace

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,7 +113,7 @@ class SentenceBuffer {
   #parts: string[] = [];
   #normalizedThrough = 0;
   #words: { titleCase: boolean; lowerCase: boolean }[] = [];
-  #delimiterDepth = 0;
+  #openingDelimiters: string[] = [];
   #insideDoubleQuotes = false;
   #insideSingleQuotes = false;
   #lastCharacter = '';
@@ -138,7 +138,9 @@ class SentenceBuffer {
   }
 
   get hasOpenDelimiter(): boolean {
-    return this.#delimiterDepth > 0 || this.#insideDoubleQuotes || this.#insideSingleQuotes;
+    return (
+      this.#openingDelimiters.length > 0 || this.#insideDoubleQuotes || this.#insideSingleQuotes
+    );
   }
 
   get suffix(): string {
@@ -185,13 +187,19 @@ class SentenceBuffer {
     for (let index = 0; index < text.length; index++) {
       const character = text[index];
       if (character === '"') {
-        this.#insideDoubleQuotes = opensDoubleQuote(text, index, this.#insideDoubleQuotes);
+        const previous = index === 0 ? this.#lastCharacter : text[index - 1];
+        this.#insideDoubleQuotes =
+          !this.#insideDoubleQuotes &&
+          (previous.length === 0 || /^[\s\p{Punctuation}]$/u.test(previous));
       } else if (character === "'") {
         this.#trackSingleQuote(text, index);
       } else if (openingBracketReg.test(character)) {
-        this.#delimiterDepth++;
+        this.#openingDelimiters.push(character);
       } else if (closingBracketReg.test(character)) {
-        this.#delimiterDepth = Math.max(0, this.#delimiterDepth - 1);
+        const opener = '([{<'[')]}>'.indexOf(character)];
+        if (this.#openingDelimiters.at(-1) === opener) {
+          this.#openingDelimiters.pop();
+        }
       }
     }
     this.#lastCharacter = text.at(-1) ?? this.#lastCharacter;
@@ -201,11 +209,16 @@ class SentenceBuffer {
     const previous = index === 0 ? this.#lastCharacter : text[index - 1];
     const following = text[index + 1] ?? '';
     if (this.#insideSingleQuotes) {
-      this.#insideSingleQuotes = following.length > 0 && !/[\s.,!?;:)\]}]/.test(following);
+      const possessive =
+        previous.toLowerCase() === 's' &&
+        /\s/.test(following) &&
+        strIsTitleCase(text.slice(index + 1));
+      this.#insideSingleQuotes =
+        possessive || (following.length > 0 && !/[\s.,!?;:)\]}]/.test(following));
       return;
     }
     this.#insideSingleQuotes =
-      (previous.length === 0 || /[\s([{<]/.test(previous)) && /\S/.test(following);
+      (previous.length === 0 || /^[\s\p{Punctuation}]$/u.test(previous)) && /\S/.test(following);
   }
 
   trimEnd(): void {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,6 +113,10 @@ class SentenceBuffer {
   #parts: string[] = [];
   #normalizedThrough = 0;
   #words: { titleCase: boolean; lowerCase: boolean }[] = [];
+  #delimiterDepth = 0;
+  #insideDoubleQuotes = false;
+  #insideSingleQuotes = false;
+  #lastCharacter = '';
   hasLineBreaks = false;
   startsWithTitleCase = false;
 
@@ -133,6 +137,10 @@ class SentenceBuffer {
     return this.#words.at(-2)?.titleCase ?? false;
   }
 
+  get hasOpenDelimiter(): boolean {
+    return this.#delimiterDepth > 0 || this.#insideDoubleQuotes || this.#insideSingleQuotes;
+  }
+
   get suffix(): string {
     let suffix = '';
     for (let i = this.#parts.length - 1; i >= 0 && suffix.length < sentenceSuffixLength; i--) {
@@ -145,6 +153,8 @@ class SentenceBuffer {
     if (text.length === 0) {
       return;
     }
+
+    this.#trackDelimiters(text);
 
     // A merge without separating whitespace can continue the previous word.
     const previous = this.#words.at(-1);
@@ -169,6 +179,33 @@ class SentenceBuffer {
 
     this.hasLineBreaks = this.hasLineBreaks || breakReg.test(text);
     this.#parts.push(text);
+  }
+
+  #trackDelimiters(text: string): void {
+    for (let index = 0; index < text.length; index++) {
+      const character = text[index];
+      if (character === '"') {
+        this.#insideDoubleQuotes = opensDoubleQuote(text, index, this.#insideDoubleQuotes);
+      } else if (character === "'") {
+        this.#trackSingleQuote(text, index);
+      } else if (openingBracketReg.test(character)) {
+        this.#delimiterDepth++;
+      } else if (closingBracketReg.test(character)) {
+        this.#delimiterDepth = Math.max(0, this.#delimiterDepth - 1);
+      }
+    }
+    this.#lastCharacter = text.at(-1) ?? this.#lastCharacter;
+  }
+
+  #trackSingleQuote(text: string, index: number): void {
+    const previous = index === 0 ? this.#lastCharacter : text[index - 1];
+    const following = text[index + 1] ?? '';
+    if (this.#insideSingleQuotes) {
+      this.#insideSingleQuotes = following.length > 0 && !/[\s.,!?;:)\]}]/.test(following);
+      return;
+    }
+    this.#insideSingleQuotes =
+      (previous.length === 0 || /[\s([{<]/.test(previous)) && /\S/.test(following);
   }
 
   trimEnd(): void {
@@ -257,10 +294,9 @@ export function sentenceSegment(
           abbrvReg.test(suffix.trimEnd()) &&
           !excepReg.test(abbreviation) &&
           (caseNeutral
-            ? startsWithCasedCharacter(nextChunk) &&
-              (strIsTitleCase(nextChunk) || !placeAbbreviationReg.test(abbreviation))
+            ? startsWithCasedCharacter(nextChunk) && !placeAbbreviationReg.test(abbreviation)
             : strIsTitleCase(nextChunk)) &&
-          !hasOpenSentenceDelimiter(chunk.text())
+          !chunk.hasOpenDelimiter
         ) {
           chunk.normalizeWhitespace();
           acc.push(chunk.text());
@@ -342,22 +378,6 @@ export function sentenceSegment(
 
   // If no matches were found, return the input treated as a single sentence
   return acc.length === 0 ? [input] : acc;
-}
-
-function hasOpenSentenceDelimiter(input: string): boolean {
-  let depth = 0;
-  let insideQuotes = false;
-  for (let index = 0; index < input.length; index++) {
-    const character = input[index];
-    if (character === '"') {
-      insideQuotes = opensDoubleQuote(input, index, insideQuotes);
-    } else if (openingBracketReg.test(character)) {
-      depth++;
-    } else if (closingBracketReg.test(character)) {
-      depth = Math.max(0, depth - 1);
-    }
-  }
-  return insideQuotes || depth > 0;
 }
 
 /** Options for rule-based sentence segmentation. */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,9 @@
-import { GATE_EXCEPTIONS, GATE_SUBSTITUTIONS, TREEBANK_CONTRACTIONS } from './constants';
+import {
+  ABBR_PLACES,
+  GATE_EXCEPTIONS,
+  GATE_SUBSTITUTIONS,
+  TREEBANK_CONTRACTIONS,
+} from './constants';
 import { lcsIndices } from './lcs';
 import { validateBeta, validateMaxSkip, validateNGramSize } from './validation';
 
@@ -80,6 +85,10 @@ function escapeRegExp(input: string): string {
 }
 
 const abbrvReg = new RegExp(`\\b(${GATE_SUBSTITUTIONS.map(escapeRegExp).join('|')})[.!?] ?$`, 'i');
+const placeAbbreviationReg = new RegExp(
+  `\\b(${ABBR_PLACES.map(escapeRegExp).join('|')})[.!?] ?$`,
+  'i',
+);
 const acronymReg = /[ |.][A-Z].?$/i;
 // Case mappings can add combining marks (for example, `İ` lowercases to `i` + dot above).
 const caseNeutralAcronymReg = /(?:^|[ |.])\p{Cased}\p{M}*.?$/u;
@@ -247,7 +256,11 @@ export function sentenceSegment(
           nextChunk &&
           abbrvReg.test(suffix.trimEnd()) &&
           !excepReg.test(abbreviation) &&
-          strIsTitleCase(nextChunk)
+          (caseNeutral
+            ? startsWithCasedCharacter(nextChunk) &&
+              (strIsTitleCase(nextChunk) || !placeAbbreviationReg.test(abbreviation))
+            : strIsTitleCase(nextChunk)) &&
+          !hasOpenSentenceDelimiter(chunk.text())
         ) {
           chunk.normalizeWhitespace();
           acc.push(chunk.text());
@@ -329,6 +342,22 @@ export function sentenceSegment(
 
   // If no matches were found, return the input treated as a single sentence
   return acc.length === 0 ? [input] : acc;
+}
+
+function hasOpenSentenceDelimiter(input: string): boolean {
+  let depth = 0;
+  let insideQuotes = false;
+  for (let index = 0; index < input.length; index++) {
+    const character = input[index];
+    if (character === '"') {
+      insideQuotes = opensDoubleQuote(input, index, insideQuotes);
+    } else if (openingBracketReg.test(character)) {
+      depth++;
+    } else if (closingBracketReg.test(character)) {
+      depth = Math.max(0, depth - 1);
+    }
+  }
+  return insideQuotes || depth > 0;
 }
 
 /** Options for rule-based sentence segmentation. */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -195,7 +195,8 @@ class SentenceBuffer {
         this.#trackSingleQuote(text, index);
       } else if (
         !(this.#insideDoubleQuotes || this.#insideSingleQuotes) &&
-        openingBracketReg.test(character)
+        openingBracketReg.test(character) &&
+        (character !== '<' || /^\p{Letter}$/u.test(characterAt(text, index + 1)))
       ) {
         this.#openingDelimiters.push(character);
       } else if (
@@ -215,9 +216,12 @@ class SentenceBuffer {
     const previous = index === 0 ? this.#lastCharacter : text[index - 1];
     const following = text[index + 1] ?? '';
     if (this.#insideSingleQuotes) {
+      const openingQuote = text.lastIndexOf("'", index - 1);
+      const singleQuotedWord = openingQuote >= 0 && !/\s/.test(text.slice(openingQuote + 1, index));
       const possessive =
         previous.toLowerCase() === 's' &&
         /\s/.test(following) &&
+        !singleQuotedWord &&
         !/^(?:said|asked|replied|wrote|today|yesterday|tomorrow|then|and|but|or|in|on|at|for|with|to|from)\b/i.test(
           text.slice(index + 1).trimStart(),
         );
@@ -309,14 +313,15 @@ export function sentenceSegment(
 
       if (chunk.hasLineBreaks) {
         const nextChunk = chunks[idx + 1];
+        const nextSentence = nextChunk?.replace(/^[\s"'([{<]+/, '');
         const abbreviation = gateSuffix.trimEnd();
         if (
-          nextChunk &&
+          nextSentence &&
           abbrvReg.test(suffix.trimEnd()) &&
           !excepReg.test(abbreviation) &&
           (caseNeutral
-            ? startsWithCasedCharacter(nextChunk) && !placeAbbreviationReg.test(abbreviation)
-            : strIsTitleCase(nextChunk)) &&
+            ? startsWithCasedCharacter(nextSentence) && !placeAbbreviationReg.test(abbreviation)
+            : strIsTitleCase(nextSentence)) &&
           !chunk.hasOpenDelimiter
         ) {
           chunk.normalizeWhitespace();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -193,9 +193,15 @@ class SentenceBuffer {
           (previous.length === 0 || /^[\s\p{Punctuation}]$/u.test(previous));
       } else if (character === "'") {
         this.#trackSingleQuote(text, index);
-      } else if (openingBracketReg.test(character)) {
+      } else if (
+        !(this.#insideDoubleQuotes || this.#insideSingleQuotes) &&
+        openingBracketReg.test(character)
+      ) {
         this.#openingDelimiters.push(character);
-      } else if (closingBracketReg.test(character)) {
+      } else if (
+        !(this.#insideDoubleQuotes || this.#insideSingleQuotes) &&
+        closingBracketReg.test(character)
+      ) {
         const opener = '([{<'[')]}>'.indexOf(character)];
         if (this.#openingDelimiters.at(-1) === opener) {
           this.#openingDelimiters.pop();
@@ -212,7 +218,9 @@ class SentenceBuffer {
       const possessive =
         previous.toLowerCase() === 's' &&
         /\s/.test(following) &&
-        strIsTitleCase(text.slice(index + 1));
+        !/^(?:said|asked|replied|wrote|today|yesterday|tomorrow|then|and|but|or|in|on|at|for|with|to|from)\b/i.test(
+          text.slice(index + 1).trimStart(),
+        );
       this.#insideSingleQuotes =
         possessive || (following.length > 0 && !/[\s.,!?;:)\]}]/.test(following));
       return;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,4 @@
-import {
-  ABBR_PLACES,
-  GATE_EXCEPTIONS,
-  GATE_SUBSTITUTIONS,
-  TREEBANK_CONTRACTIONS,
-} from './constants';
+import { GATE_EXCEPTIONS, GATE_SUBSTITUTIONS, TREEBANK_CONTRACTIONS } from './constants';
 import { lcsIndices } from './lcs';
 import { validateBeta, validateMaxSkip, validateNGramSize } from './validation';
 
@@ -85,10 +80,6 @@ function escapeRegExp(input: string): string {
 }
 
 const abbrvReg = new RegExp(`\\b(${GATE_SUBSTITUTIONS.map(escapeRegExp).join('|')})[.!?] ?$`, 'i');
-const placeAbbreviationReg = new RegExp(
-  `\\b(${ABBR_PLACES.map(escapeRegExp).join('|')})[.!?] ?$`,
-  'i',
-);
 const acronymReg = /[ |.][A-Z].?$/i;
 // Case mappings can add combining marks (for example, `İ` lowercases to `i` + dot above).
 const caseNeutralAcronymReg = /(?:^|[ |.])\p{Cased}\p{M}*.?$/u;
@@ -317,11 +308,9 @@ export function sentenceSegment(
         const abbreviation = gateSuffix.trimEnd();
         if (
           nextSentence &&
-          abbrvReg.test(suffix.trimEnd()) &&
+          abbrvReg.test(abbreviation) &&
           !excepReg.test(abbreviation) &&
-          (caseNeutral
-            ? startsWithCasedCharacter(nextSentence) && !placeAbbreviationReg.test(abbreviation)
-            : strIsTitleCase(nextSentence)) &&
+          (caseNeutral ? startsWithCasedCharacter(nextSentence) : strIsTitleCase(nextSentence)) &&
           !chunk.hasOpenDelimiter
         ) {
           chunk.normalizeWhitespace();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -241,11 +241,21 @@ export function sentenceSegment(
       const lastWord = suffix.match(/\S+$/)?.[0] ?? '';
 
       if (chunk.hasLineBreaks) {
-        if (chunks[idx + 1] && chunk.startsWithTitleCase) {
+        const nextChunk = chunks[idx + 1];
+        const abbreviation = gateSuffix.trimEnd();
+        if (
+          nextChunk &&
+          abbrvReg.test(suffix.trimEnd()) &&
+          !excepReg.test(abbreviation) &&
+          strIsTitleCase(nextChunk)
+        ) {
+          chunk.normalizeWhitespace();
+          acc.push(chunk.text());
+        } else if (nextChunk && chunk.startsWithTitleCase) {
           // Catch line breaks embedded within valid sentences
           // i.e. sentences that start with a capital letter
           // and normalize every wrap before reprocessing the joined chunk.
-          chunk.append(` ${chunks[idx + 1]}`);
+          chunk.append(` ${nextChunk}`);
           chunk.normalizeWhitespace();
           pending = chunk;
         } else {
@@ -268,7 +278,7 @@ export function sentenceSegment(
           acc.push(chunk.text());
         } else {
           // Catch common abbreviations and merge them with a delimiting space
-          chunk.append(` ${trimSpaces(nextChunk.replace(/ +/g, ' '))}`);
+          chunk.append(` ${trimSpaces(nextChunk.replace(/[^\S\r\n]+/g, ' '))}`);
           pending = chunk;
         }
       } else if (chunks[idx + 1] && matchesAcronymSuffix(suffix, lastWord, caseNeutral)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -207,15 +207,10 @@ class SentenceBuffer {
     const previous = index === 0 ? this.#lastCharacter : text[index - 1];
     const following = text[index + 1] ?? '';
     if (this.#insideSingleQuotes) {
-      const openingQuote = text.lastIndexOf("'", index - 1);
-      const singleQuotedWord = openingQuote >= 0 && !/\s/.test(text.slice(openingQuote + 1, index));
       const possessive =
         previous.toLowerCase() === 's' &&
         /\s/.test(following) &&
-        !singleQuotedWord &&
-        !/^(?:said|asked|replied|wrote|today|yesterday|tomorrow|then|and|but|or|in|on|at|for|with|to|from)\b/i.test(
-          text.slice(index + 1).trimStart(),
-        );
+        /^(?:\p{Lu}|\p{Ll}+\s+\p{Lu})/u.test(text.slice(index + 1).trimStart());
       this.#insideSingleQuotes =
         possessive || (following.length > 0 && !/[\s.,!?;:)\]}]/.test(following));
       return;

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -442,8 +442,8 @@ describe('Utility Functions', () => {
       const mixedCase = 'Da\u212a.\nNext.';
       const lowerCase = mixedCase.toLowerCase();
       expect(ss(mixedCase)).toEqual(['Da\u212a.', 'Next.']);
-      expect(segmentCaseNeutrally(mixedCase)).toEqual(['Da\u212a. Next.']);
-      expect(segmentCaseNeutrally(lowerCase)).toEqual(['dak. next.']);
+      expect(segmentCaseNeutrally(mixedCase)).toEqual(['Da\u212a.', 'Next.']);
+      expect(segmentCaseNeutrally(lowerCase)).toEqual(['dak.', 'next.']);
     });
 
     test('should preserve gate exceptions in case-neutral quoted continuations', () => {
@@ -594,8 +594,12 @@ describe('Utility Functions', () => {
 
     test('keeps wrapped place abbreviations invariant under case folding', () => {
       const input = 'He moved to Calif.\nNext year.';
-      expect(segmentCaseNeutrally(input)).toEqual(['He moved to Calif. Next year.']);
-      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(['he moved to calif. next year.']);
+      expect(segmentCaseNeutrally(input)).toEqual(['He moved to Calif.', 'Next year.']);
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([
+        'he moved to calif.',
+        'next year.',
+      ]);
+      expect(segmentCaseNeutrally(input)).toEqual(segmentCaseNeutrally(input.replace('\n', ' ')));
     });
 
     test.each(['\n', '\r\n', '\r'])(

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -571,6 +571,20 @@ describe('Utility Functions', () => {
       },
     );
 
+    test('keeps wrapped place abbreviations invariant under case folding', () => {
+      const input = 'He moved to Calif.\nNext year.';
+      expect(segmentCaseNeutrally(input)).toEqual(['He moved to Calif. Next year.']);
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(['he moved to calif. next year.']);
+    });
+
+    test.each(['\n', '\r\n', '\r'])(
+      'does not split abbreviations inside wrapped single quotes across %j',
+      (lineBreak) => {
+        const input = `We invested in 'Acme Co.${lineBreak}International Holdings' today.`;
+        expect(ss(input)).toEqual(["We invested in 'Acme Co. International Holdings' today."]);
+      },
+    );
+
     test('should split two letter uppercase abbreviations at the end of a sentence', () => {
       expect(ss('They closed the deal with Pitt, Briggs & Co. It closed yesterday.')).toEqual([
         'They closed the deal with Pitt, Briggs & Co.',
@@ -906,6 +920,22 @@ describe('Utility Functions', () => {
           ['--max-old-space-size=64'],
         );
       });
+
+      test('tracks enclosing delimiters without rescanning wrapped abbreviation chains', () => {
+        expectBundledScriptToPass(
+          `
+            const content = Array.from({ length: 4000 }, (_, index) => 'A' + index + ' etc.\\n').join('');
+            const summary = 'Intro (' + content + 'Tail) done.';
+            const sentences = module.exports.sentenceSegment(summary);
+            if (sentences.length !== 1 || !sentences[0].endsWith('Tail) done.')) {
+              throw new Error('Wrapped abbreviation segmentation changed');
+            }
+            process.stdout.write('ok');
+          `,
+          3000,
+          ['--max-old-space-size=64'],
+        );
+      }, 10_000);
 
       test('should handle long strings without sentence terminators quickly', () => {
         const input = 'a'.repeat(64_000);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -585,6 +585,23 @@ describe('Utility Functions', () => {
       },
     );
 
+    test.each([
+      [
+        "We invested—'Acme Co.\nInternational Holdings'—today.",
+        "We invested—'Acme Co. International Holdings'—today.",
+      ],
+      [
+        "He described 'the students' Acme Co.\nInternational project' today.",
+        "He described 'the students' Acme Co. International project' today.",
+      ],
+      [
+        'We invested in (score > 5, Acme Co.\nInternational Holdings) today.',
+        'We invested in (score > 5, Acme Co. International Holdings) today.',
+      ],
+    ])('keeps wrapped abbreviations inside punctuation-aware delimiters: %s', (input, expected) => {
+      expect(ss(input)).toEqual([expected]);
+    });
+
     test('should split two letter uppercase abbreviations at the end of a sentence', () => {
       expect(ss('They closed the deal with Pitt, Briggs & Co. It closed yesterday.')).toEqual([
         'They closed the deal with Pitt, Briggs & Co.',

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -560,6 +560,27 @@ describe('Utility Functions', () => {
       },
     );
 
+    test.each(['"Next sentence."', '(Next sentence.)', '[Next sentence.]'])(
+      'recognizes opening punctuation after a wrapped abbreviation: %s',
+      (nextSentence) => {
+        expect(ss(`Use etc.\n${nextSentence}`)).toEqual(['Use etc.', nextSentence]);
+      },
+    );
+
+    test('closes single-quoted words ending in s', () => {
+      expect(ss("He called it 'Success' before we use etc.\nNext sentence.")).toEqual([
+        "He called it 'Success' before we use etc.",
+        'Next sentence.',
+      ]);
+    });
+
+    test('does not treat comparison operators as opening delimiters', () => {
+      expect(ss('The result was x < 5 and we use etc.\nNext sentence.')).toEqual([
+        'The result was x < 5 and we use etc.',
+        'Next sentence.',
+      ]);
+    });
+
     test.each(['\n', '\r\n', '\r'])(
       'does not split abbreviations inside wrapped parentheses across %j',
       (lineBreak) => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -595,8 +595,16 @@ describe('Utility Functions', () => {
         "He described 'the students' Acme Co. International project' today.",
       ],
       [
+        "He described 'the students' favorite Acme Co.\nInternational project' today.",
+        "He described 'the students' favorite Acme Co. International project' today.",
+      ],
+      [
         'We invested in (score > 5, Acme Co.\nInternational Holdings) today.',
         'We invested in (score > 5, Acme Co. International Holdings) today.',
+      ],
+      [
+        'We noted (the symbol ")" then Acme Co.\nInternational Holdings) today.',
+        'We noted (the symbol ")" then Acme Co. International Holdings) today.',
       ],
     ])('keeps wrapped abbreviations inside punctuation-aware delimiters: %s', (input, expected) => {
       expect(ss(input)).toEqual([expected]);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -574,6 +574,15 @@ describe('Utility Functions', () => {
       ]);
     });
 
+    test('closes single-quoted spans after their opening fragment', () => {
+      expect(
+        ss("We invested in 'Acme Co.\nInternational Holdings' before we use etc.\nNext sentence."),
+      ).toEqual([
+        "We invested in 'Acme Co. International Holdings' before we use etc.",
+        'Next sentence.',
+      ]);
+    });
+
     test('does not treat comparison operators as opening delimiters', () => {
       expect(ss('The result was x < 5 and we use etc.\nNext sentence.')).toEqual([
         'The result was x < 5 and we use etc.',

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -540,6 +540,7 @@ describe('Utility Functions', () => {
         const input = `Use etc.${lineBreak}Next sentence.`;
         expect(ss(input)).toEqual(['Use etc.', 'Next sentence.']);
         expect(segmentCaseNeutrally(input)).toEqual(['Use etc.', 'Next sentence.']);
+        expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(['use etc.', 'next sentence.']);
       },
     );
 
@@ -556,6 +557,17 @@ describe('Utility Functions', () => {
       (lineBreak) => {
         expect(ss(`Dr.${lineBreak}Jones arrived.`)).toEqual(['Dr. Jones arrived.']);
         expect(ss(`Use e.g.${lineBreak}Examples.`)).toEqual(['Use e.g. Examples.']);
+      },
+    );
+
+    test.each(['\n', '\r\n', '\r'])(
+      'does not split abbreviations inside wrapped parentheses across %j',
+      (lineBreak) => {
+        const input = `We invested in (Acme Co.${lineBreak}International Holdings) today.`;
+        expect(ss(input)).toEqual(['We invested in (Acme Co. International Holdings) today.']);
+        expect(segmentCaseNeutrally(input)).toEqual([
+          'We invested in (Acme Co. International Holdings) today.',
+        ]);
       },
     );
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -534,6 +534,31 @@ describe('Utility Functions', () => {
       ]);
     });
 
+    test.each(['\n', '\r\n', '\r'])(
+      'keeps a terminal abbreviation boundary across %j',
+      (lineBreak) => {
+        const input = `Use etc.${lineBreak}Next sentence.`;
+        expect(ss(input)).toEqual(['Use etc.', 'Next sentence.']);
+        expect(segmentCaseNeutrally(input)).toEqual(['Use etc.', 'Next sentence.']);
+      },
+    );
+
+    test.each(['\t', '\u00a0'])(
+      'normalizes horizontal whitespace after abbreviations: %j',
+      (separator) => {
+        expect(ss(`We use etc.${separator}and more.`)).toEqual(['We use etc. and more.']);
+        expect(ss(`Dr.${separator}Jones arrived.`)).toEqual(['Dr. Jones arrived.']);
+      },
+    );
+
+    test.each(['\n', '\r\n', '\r'])(
+      'preserves wrapped honorifics and abbreviation exceptions across %j',
+      (lineBreak) => {
+        expect(ss(`Dr.${lineBreak}Jones arrived.`)).toEqual(['Dr. Jones arrived.']);
+        expect(ss(`Use e.g.${lineBreak}Examples.`)).toEqual(['Use e.g. Examples.']);
+      },
+    );
+
     test('should split two letter uppercase abbreviations at the end of a sentence', () => {
       expect(ss('They closed the deal with Pitt, Briggs & Co. It closed yesterday.')).toEqual([
         'They closed the deal with Pitt, Briggs & Co.',

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -599,7 +599,9 @@ describe('Utility Functions', () => {
         'he moved to calif.',
         'next year.',
       ]);
-      expect(segmentCaseNeutrally(input)).toEqual(segmentCaseNeutrally(input.replace('\n', ' ')));
+      expect(segmentCaseNeutrally(input)).toEqual(
+        segmentCaseNeutrally(input.replaceAll('\n', ' ')),
+      );
     });
 
     test.each(['\n', '\r\n', '\r'])(


### PR DESCRIPTION
## Summary

- keep terminal abbreviation sentence boundaries across LF, CRLF, and CR
- normalize tabs and non-breaking spaces after abbreviations without changing honorific or exception behavior
- cover case-neutral segmentation and wrapped continuation regressions

## Verification

- `npm test -- --runInBand --silent --verbose=false` (559 passing Jest tests)
- `npm run type-check`
- `./node_modules/.bin/biome ci . --error-on-warnings`
- `git diff --check`