### PR TITLE
perf: stop ROUGE-L once candidate tokens are exhausted

### DIFF
--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -401,10 +401,28 @@ export function l(cand: string, ref: string, opts?: RougeLOptions): number {
     return 0;
   }
 
+  const matches = countSummaryLcsMatches(candSents, refSents, remaining, getLcs, getLcsIndices);
+  if (matches === 0) {
+    return 0;
+  }
+  return utils.fMeasure(matches / candLength, matches / refLength, beta);
+}
+
+function countSummaryLcsMatches(
+  candidates: string[][],
+  references: string[][],
+  remaining: Map<string, number>,
+  getLcs: (a: string[], b: string[]) => string[],
+  getLcsIndices?: (candidate: string[], reference: string[]) => number[],
+): number {
   let matches = 0;
-  for (const reference of refSents) {
+  for (const reference of references) {
+    if (getLcs === utils.lcs && getLcsIndices === undefined && remaining.size === 0) {
+      break;
+    }
+
     const union = new Set<number>();
-    for (const candidate of candSents) {
+    for (const candidate of candidates) {
       for (const index of matchedReferenceIndices(candidate, reference, getLcs, getLcsIndices)) {
         union.add(index);
       }
@@ -416,15 +434,15 @@ export function l(cand: string, ref: string, opts?: RougeLOptions): number {
       const count = remaining.get(token) ?? 0;
       if (count > 0) {
         matches++;
-        remaining.set(token, count - 1);
+        if (count === 1) {
+          remaining.delete(token);
+        } else {
+          remaining.set(token, count - 1);
+        }
       }
     }
   }
-
-  if (matches === 0) {
-    return 0;
-  }
-  return utils.fMeasure(matches / candLength, matches / refLength, beta);
+  return matches;
 }
 
 function matchedReferenceIndices(

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1932,6 +1932,51 @@ describe('Core Functions', () => {
       expect(l(text, 'cat. cat.', { tokenizer })).toBeCloseTo(expected);
     });
 
+    test('stops built-in LCS evaluation once the candidate token budget is exhausted', () => {
+      const segmenter = (input: string): string[] => input.split('|');
+      const tokenizer = (input: string): string[] => input.split(' ');
+      expect(l('a b', 'a b|a b|a b', { segmenter, tokenizer })).toBe(1 / 2);
+    });
+
+    test('does not suppress custom LCS callbacks after the candidate budget is exhausted', () => {
+      const segmenter = (input: string): string[] => input.split('|');
+      const customLcs = jest.fn(() => ['a']);
+      expect(l('a', 'a|a', { segmenter, lcs: customLcs })).toBeCloseTo(2 / 3);
+      expect(customLcs).toHaveBeenCalledTimes(2);
+    });
+
+    test('still validates custom LCS-index callbacks after the candidate budget is exhausted', () => {
+      const segmenter = (input: string): string[] => input.split('|');
+      let invocation = 0;
+      expect(() =>
+        l('a', 'a|a', {
+          segmenter,
+          lcsIndices: () => (++invocation === 1 ? [0] : [1]),
+        }),
+      ).toThrow(/strictly increasing integer indices within the reference/);
+    });
+
+    test('handles repeated reference sentences without redundant LCS work', () => {
+      expectBundledScriptToPass(
+        `
+          const sentence = Array.from({ length: 120 }, () => 'a').join(' ');
+          const reference = Array.from({ length: 1500 }, () => sentence).join('|');
+          const segmenter = (input) => input.split('|');
+          const tokenizer = (input) => input.split(' ');
+          const score = module.exports.l(sentence, reference, {
+            beta: Number.POSITIVE_INFINITY,
+            segmenter,
+            tokenizer,
+          });
+          if (score !== 1 / 1500) {
+            throw new Error('Clipped ROUGE-L recall changed');
+          }
+          process.stdout.write('ok');
+        `,
+        3000,
+      );
+    }, 10_000);
+
     test.each([true, false])('keeps boundaries with caseSensitive=%s', (caseSensitive) => {
       const tokenizer = (text: string): string[] => text.match(/[A-Za-z]+/g) || [];
       const first = 'Alpha works at Acme Co. Beta sleeps near Luna Inc.';


### PR DESCRIPTION
## Summary

- stop built-in summary-level LCS work once every candidate occurrence has been consumed
- extract and simplify clipped match counting without changing summary-level union semantics
- continue invoking and validating user-supplied LCS callbacks even after the built-in token budget is exhausted

## Verification

- `npm test -- --runInBand --silent --verbose=false` (555 passing tests)
- `npm run type-check`
- `./node_modules/.bin/biome ci . --error-on-warnings`
- `git diff --check`