### PR TITLE
fix: align conditional ESM declarations with runtime exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,14 @@
   "types": "dist/rouge.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/rouge.d.ts",
-      "import": "./dist/rouge.mjs",
-      "require": "./dist/rouge.js"
+      "import": {
+        "types": "./dist/rouge.d.mts",
+        "default": "./dist/rouge.mjs"
+      },
+      "require": {
+        "types": "./dist/rouge.d.ts",
+        "default": "./dist/rouge.js"
+      }
     }
   },
   "scripts": {
@@ -17,7 +22,7 @@
     "test:package": "node scripts/package-smoke.js",
     "build": "npm run clean && npm run build:js && npm run build:types",
     "build:js": "esbuild src/rouge.ts --bundle --minify --sourcemap --platform=node --target=node18 --outfile=dist/rouge.js && esbuild src/rouge.ts --bundle --minify --sourcemap --platform=neutral --format=esm --target=node18 --outfile=dist/rouge.mjs",
-    "build:types": "tsc -p tsconfig.json --emitDeclarationOnly --outDir dist",
+    "build:types": "tsc -p tsconfig.json --emitDeclarationOnly --outDir dist && node scripts/write-esm-types.js",
     "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
     "type-check": "tsc -p tsconfig.test.json",
     "lint": "biome lint .",

--- a/scripts/package-smoke.js
+++ b/scripts/package-smoke.js
@@ -51,21 +51,28 @@ assert.equal(s('a b', 'a b'), 1);
   writeConsumerFile(
     'commonjs.cjs',
     `const assert = require('node:assert/strict');
-const { l, n, s } = require('js-rouge');
+const rouge = require('js-rouge');
+const { l, n, s } = rouge;
+assert.equal(Object.hasOwn(rouge, 'default'), false);
 ${runtimeAssertions}`,
   );
   writeConsumerFile(
     'module.mjs',
     `import assert from 'node:assert/strict';
 import { l, n, s } from 'js-rouge';
+import * as rouge from 'js-rouge';
+assert.equal(Object.hasOwn(rouge, 'default'), false);
 ${runtimeAssertions}`,
   );
   writeConsumerFile(
     'types.ts',
     `import { n, type RougeNOptions } from 'js-rouge';
+// @ts-expect-error The ESM entry point does not export a default.
+import missingDefault from 'js-rouge';
 const options: RougeNOptions = { n: 2, caseSensitive: false };
 const score: number = n('a b', 'A B', options);
 void score;
+void missingDefault;
 `,
   );
   writeConsumerJson('tsconfig.json', {

--- a/scripts/write-esm-types.js
+++ b/scripts/write-esm-types.js
@@ -1,0 +1,3 @@
+const { writeFileSync } = require('node:fs');
+
+writeFileSync('dist/rouge.d.mts', "export * from './rouge.js';\n");


### PR DESCRIPTION
## Summary

- provide an ESM-specific declaration entry through conditional package exports without inventing a runtime default export
- preserve existing CommonJS declarations and named imports
- prove the packed ESM consumer rejects nonexistent default imports while both installed runtime formats remain default-free

## Verification

- reproduced the previous failure as TypeScript `TS2578: Unused '@ts-expect-error' directive`
- `npm run build`
- `env npm_config_cache=/private/tmp/js-rouge-13prs-npm-cache npm run test:package`
- `npm test -- --runInBand --silent --verbose=false` (551 passing tests)
- `npm run type-check`
- `./node_modules/.bin/biome ci . --error-on-warnings`