### PR TITLE
fix: close upstream sentence segmentation golden rule gaps

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,7 +97,8 @@ const sentenceSuffixLength = Math.max(10, ...GATE_SUBSTITUTIONS.map((word) => wo
 const closingDelimiterReg = /[\])}>"']/;
 const openingBracketReg = /[([{<]/;
 const closingBracketReg = /[\])}>]/;
-const listMarkerReg = /(?:^|\s)(?:(?:[•⁃]\s*)?\d+(?:\.\)|[.)])|\p{Cased}\.)(?=\s+\p{Cased})/gu;
+const listMarkerReg =
+  /(?:^|\s)(?:(?:[•⁃]\s*)?\d+(?:\.\)|[.)])|\p{Cased}\.)(?=\s+["'([{<]*\p{Cased})/gu;
 const geographicAcronymReg = /\bU\.S(?:\.A)?\.$/i;
 const geographicContinuationReg = /^(?:government|army|navy|military|congress)\b/i;
 
@@ -628,7 +629,10 @@ function isUnspacedSentenceBoundary(
   caseNeutral: boolean,
 ): boolean {
   const nextCharacter = characterAt(input, next);
-  if (!(caseNeutral ? isCasedCharacter(nextCharacter) : charIsUpperCase(nextCharacter))) {
+  const startsWithLetter = caseNeutral
+    ? isCasedCharacter(nextCharacter)
+    : charIsUpperCase(nextCharacter);
+  if (!(startsWithLetter || (input[index] !== '.' && /^\p{Number}$/u.test(nextCharacter)))) {
     return false;
   }
   const precedingToken = input.slice(Math.max(0, index - 320), next).match(/\S+$/)?.[0] ?? '';
@@ -639,7 +643,8 @@ function isUnspacedSentenceBoundary(
 
   const suffix = input.slice(Math.max(0, index + 1 - sentenceSuffixLength), index + 1);
   const following = input.slice(next);
-  const insideAddress = precedingToken.includes('@');
+  const insideAddress =
+    precedingToken.includes('@') && !/@[^\s.]+(?:\.[^\s.]+)+\.$/u.test(precedingToken);
   const hostnameLabel = following.match(
     /^(com|org|net|edu|gov|mil|io|dev|app|co|uk|us|ca|ai|info|biz|me|tv)(?=[/.\s]|$)/i,
   )?.[0];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -341,14 +341,19 @@ export function sentenceSegment(
   return acc.length === 0 ? [input] : acc;
 }
 
-function nextListMarker(input: string, expression: RegExp): RegExpExecArray | null {
+function nextListMarker(
+  input: string,
+  expression: RegExp,
+  numbered?: boolean,
+): RegExpExecArray | null {
   let marker = expression.exec(input);
   while (marker !== null) {
     if (
-      marker.index === 0 ||
-      !/\b(?:section|chapter|page|figure|table|paragraph|article|clause)$/i.test(
-        input.slice(Math.max(0, marker.index - 24), marker.index).trimEnd(),
-      )
+      (numbered === undefined || /\d/.test(marker[0]) === numbered) &&
+      (marker.index === 0 ||
+        !/\b(?:section|chapter|page|figure|table|paragraph|article|clause)$/i.test(
+          input.slice(Math.max(0, marker.index - 24), marker.index).trimEnd(),
+        ))
     ) {
       return marker;
     }
@@ -363,7 +368,8 @@ function segmentList(input: string, caseNeutral: boolean): string[] | undefined 
   if (current === null || input.slice(0, current.index).trim().length > 0) {
     return undefined;
   }
-  let next = nextListMarker(input, expression);
+  const numbered = /\d/.test(current[0]);
+  let next = nextListMarker(input, expression, numbered);
   if (next === null) {
     return undefined;
   }
@@ -372,9 +378,12 @@ function segmentList(input: string, caseNeutral: boolean): string[] | undefined 
   do {
     const body = input.slice(current.index + current[0].length, next?.index ?? input.length).trim();
     const sentences = /[.!?\r\n]/.test(body) ? sentenceSegment(body, { caseNeutral }) : [body];
+    if (sentences.length > 1 && /^\p{Cased}\.$/u.test(sentences[0])) {
+      sentences.splice(0, 2, `${sentences[0]} ${sentences[1]}`);
+    }
     segments.push(`${current[0].trim()} ${sentences[0]}`, ...sentences.slice(1));
     current = next;
-    next = nextListMarker(input, expression);
+    next = nextListMarker(input, expression, numbered);
   } while (current !== null);
   return segments;
 }
@@ -526,7 +535,11 @@ function sentenceEnd(
   brackets: { depth: number; standalone: boolean },
   caseNeutral: boolean,
 ): number {
-  if (!insideQuotes && isUnspacedDelimitedSentenceStart(input, index, caseNeutral)) {
+  if (
+    !insideQuotes &&
+    brackets.depth === 0 &&
+    isUnspacedDelimitedSentenceStart(input, index, caseNeutral)
+  ) {
     return index + 1;
   }
   const end = closingDelimiterEnd(input, index, insideQuotes);
@@ -593,6 +606,9 @@ function isUnspacedDelimitedSentenceStart(
   if (!/["([{<]/.test(input[next] ?? '')) {
     return false;
   }
+  if (/^\[\p{Number}+\]/u.test(input.slice(next))) {
+    return false;
+  }
   while (next < input.length && /["'([{<]/.test(input[next])) {
     next++;
   }
@@ -620,17 +636,19 @@ function isUnspacedSentenceBoundary(
 
   const suffix = input.slice(Math.max(0, index + 1 - sentenceSuffixLength), index + 1);
   const following = input.slice(next);
-  const preceding = input.slice(Math.max(0, index - 320), next);
-  const previousAt = preceding.lastIndexOf('@');
-  const insideAddress = previousAt !== -1 && !/\s/.test(preceding.slice(previousAt));
+  const precedingToken = input.slice(Math.max(0, index - 320), next).match(/\S+$/)?.[0] ?? '';
+  const insideAddress = precedingToken.includes('@');
   const hostnameLabel = following.match(
     /^(com|org|net|edu|gov|mil|io|dev|app|co|uk|us|ca|ai|info|biz|me|tv)(?=[/.\s]|$)/i,
   )?.[0];
   const insideHostname =
-    /https?:\/\/|www\./i.test(preceding) ||
+    /https?:\/\/|www\./i.test(precedingToken) ||
     (hostnameLabel !== undefined &&
       (hostnameLabel === hostnameLabel.toLowerCase() ||
         hostnameLabel === hostnameLabel.toUpperCase()));
+  const dottedIdentifier =
+    /\b\p{Lu}[\p{Letter}\p{Number}_-]*\.$/u.test(suffix) &&
+    /^[\p{Lu}\p{Number}_-]+(?=\s|[/.]|$)/u.test(following);
   const initial = caseNeutral ? /^\p{Cased}\./u : /^\p{Lu}\./u;
   const trailingInitial = caseNeutral ? /\b\p{Cased}\.$/u : /\b\p{Lu}\.$/u;
   const nextInitial = caseNeutral ? /^\p{Cased}(?=\s|$)/u : /^\p{Lu}(?=\s|$)/u;
@@ -645,7 +663,8 @@ function isUnspacedSentenceBoundary(
     (trailingInitial.test(suffix) && nextInitial.test(following)) ||
     /^[^\s]*@/.test(following) ||
     insideAddress ||
-    insideHostname
+    insideHostname ||
+    dottedIdentifier
   );
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,7 +97,7 @@ const sentenceSuffixLength = Math.max(10, ...GATE_SUBSTITUTIONS.map((word) => wo
 const closingDelimiterReg = /[\])}>"']/;
 const openingBracketReg = /[([{<]/;
 const closingBracketReg = /[\])}>]/;
-const listMarkerReg = /(?:^|\s)(?:(?:[•⁃]\s*)?\d+(?:\.\)|[.)])|[a-z]\.)(?=\s+\p{Lu})/gu;
+const listMarkerReg = /(?:^|\s)(?:(?:[•⁃]\s*)?\d+(?:\.\)|[.)])|\p{Cased}\.)(?=\s+\p{Cased})/gu;
 const geographicAcronymReg = /\b(?:U\.S(?:\.A)?|E\.U)\.$/i;
 const geographicContinuationReg = /^(?:government|army|navy|military|congress)\b/i;
 
@@ -222,11 +222,23 @@ export function sentenceSegment(
     return [];
   }
 
-  const listMarkers = [...input.matchAll(listMarkerReg)];
+  const listMarkers = [...input.matchAll(listMarkerReg)].filter(
+    (marker) =>
+      marker.index === 0 ||
+      !/\b(?:section|chapter|page|figure|table|paragraph|article|clause)$/i.test(
+        input.slice(Math.max(0, marker.index - 24), marker.index).trimEnd(),
+      ),
+  );
   if (listMarkers.length > 1 && listMarkers[0].index === 0) {
-    return listMarkers.map((marker, index) =>
-      input.slice(marker.index, listMarkers[index + 1]?.index ?? input.length).trim(),
-    );
+    return listMarkers.flatMap((marker, index) => {
+      const markerText = marker[0].trim();
+      const body = input
+        .slice(marker.index + marker[0].length, listMarkers[index + 1]?.index ?? input.length)
+        .trim();
+      return sentenceSegment(body, { caseNeutral }).map((sentence, sentenceIndex) =>
+        sentenceIndex === 0 ? `${markerText} ${sentence}` : sentence,
+      );
+    });
   }
 
   // Scan terminals before applying abbreviation and line-wrap rules.
@@ -319,7 +331,10 @@ export function sentenceSegment(
         // Catch mid-sentence ellipses (and their derivatives) and merge them
         const nextChunk = chunks[idx + 1];
         const nextSentence = nextChunk.trim() || chunks[idx + 2] || '';
-        if (/\.{4}$/.test(suffix) && strIsTitleCase(nextSentence)) {
+        if (
+          /\.{4}$/.test(suffix) &&
+          (caseNeutral ? startsWithCasedCharacter(nextSentence) : strIsTitleCase(nextSentence))
+        ) {
           acc.push(chunk.text());
           continue;
         }
@@ -349,7 +364,8 @@ export interface SentenceSegmentOptions {
 /** Scan sentence boundaries once, preserving the former captured-split layout. */
 function sentenceChunks(input: string, caseNeutral: boolean): string[] {
   const chunks: string[] = [];
-  const protectedPeriods = spacedEllipsisPeriods(input);
+  const protectedPeriods = spacedEllipsisRanges(input, caseNeutral);
+  const ellipsisCursor = { index: 0 };
   let lastEnd = 0;
   let start = -1;
   let insideQuotes = false;
@@ -380,7 +396,11 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
       // A terminal must follow the initial character, even if it is punctuation.
       continue;
     }
-    if ((char === '.' && !protectedPeriods.has(index)) || char === '?' || char === '!') {
+    if (
+      (char === '.' && !isProtectedEllipsisPeriod(index, protectedPeriods, ellipsisCursor)) ||
+      char === '?' ||
+      char === '!'
+    ) {
       const end = sentenceEnd(input, index, insideQuotes, brackets, caseNeutral);
       if (end === -1) {
         continue;
@@ -396,24 +416,53 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
   return chunks;
 }
 
-function spacedEllipsisPeriods(input: string): Set<number> {
-  const protectedPeriods = new Set<number>();
+interface SpacedEllipsisRange {
+  start: number;
+  end: number;
+  boundary: number;
+}
+
+function spacedEllipsisRanges(input: string, caseNeutral: boolean): SpacedEllipsisRange[] {
+  const ranges: SpacedEllipsisRange[] = [];
   for (const match of input.matchAll(/(?:\.[^\S\r\n]+){2,}\./g)) {
-    const offsets = [...match[0].matchAll(/\./g)].map((period) => period.index);
-    let boundary = -1;
-    if (
-      offsets.length >= 4 &&
-      /^\p{Lu}/u.test(input.slice(match.index + match[0].length).trimStart())
-    ) {
-      boundary = /\S/.test(input[match.index - 1] ?? '') ? offsets[0] : (offsets.at(-1) ?? -1);
-    }
-    for (const offset of offsets) {
-      if (offset !== boundary) {
-        protectedPeriods.add(match.index + offset);
+    let periods = 0;
+    for (const character of match[0]) {
+      if (character === '.') {
+        periods++;
       }
     }
+
+    let next = match.index + match[0].length;
+    while (next < input.length && /[\s"'([{<]/.test(input[next])) {
+      next++;
+    }
+    const following = characterAt(input, next);
+    const sentenceStart =
+      /^\p{Number}$/u.test(following) ||
+      (caseNeutral
+        ? isCasedCharacter(following)
+        : following.length > 0 && charIsUpperCase(following));
+    let boundary = -1;
+    if (periods >= 4 && sentenceStart) {
+      boundary = /\S/.test(input[match.index - 1] ?? '')
+        ? match.index
+        : match.index + match[0].lastIndexOf('.');
+    }
+    ranges.push({ start: match.index, end: match.index + match[0].length, boundary });
   }
-  return protectedPeriods;
+  return ranges;
+}
+
+function isProtectedEllipsisPeriod(
+  position: number,
+  ranges: SpacedEllipsisRange[],
+  cursor: { index: number },
+): boolean {
+  while (cursor.index < ranges.length && position >= ranges[cursor.index].end) {
+    cursor.index++;
+  }
+  const range = ranges[cursor.index];
+  return range !== undefined && position >= range.start && position !== range.boundary;
 }
 
 /** Scan closing delimiters, including whitespace before a pending closing quote. */
@@ -509,17 +558,28 @@ function isUnspacedSentenceBoundary(
   next: number,
   caseNeutral: boolean,
 ): boolean {
-  if (input[index] !== '.' || !charIsUpperCase(characterAt(input, next))) {
+  const nextCharacter = characterAt(input, next);
+  if (
+    input[index] !== '.' ||
+    !(caseNeutral ? isCasedCharacter(nextCharacter) : charIsUpperCase(nextCharacter))
+  ) {
     return false;
   }
 
   const suffix = input.slice(Math.max(0, index + 1 - sentenceSuffixLength), index + 1);
   const following = input.slice(next);
+  const preceding = input.slice(Math.max(0, index - 320), next);
+  const previousAt = preceding.lastIndexOf('@');
+  const insideAddress = previousAt !== -1 && !/\s/.test(preceding.slice(previousAt));
+  const initial = caseNeutral ? /^\p{Cased}\./u : /^\p{Lu}\./u;
+  const trailingInitial = caseNeutral ? /\b\p{Cased}\.$/u : /\b\p{Lu}\.$/u;
+  const nextInitial = caseNeutral ? /^\p{Cased}(?=\s|$)/u : /^\p{Lu}(?=\s|$)/u;
   return !(
     abbrvReg.test(caseNeutral ? suffix.toLowerCase() : suffix) ||
-    /^\p{Lu}\./u.test(following) ||
-    (/\b\p{Lu}\.$/u.test(suffix) && /^\p{Lu}(?=\s|$)/u.test(following)) ||
-    /^[^\s]*@/.test(following)
+    initial.test(following) ||
+    (trailingInitial.test(suffix) && nextInitial.test(following)) ||
+    /^[^\s]*@/.test(following) ||
+    insideAddress
   );
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -222,23 +222,9 @@ export function sentenceSegment(
     return [];
   }
 
-  const listMarkers = [...input.matchAll(listMarkerReg)].filter(
-    (marker) =>
-      marker.index === 0 ||
-      !/\b(?:section|chapter|page|figure|table|paragraph|article|clause)$/i.test(
-        input.slice(Math.max(0, marker.index - 24), marker.index).trimEnd(),
-      ),
-  );
-  if (listMarkers.length > 1 && input.slice(0, listMarkers[0].index).trim().length === 0) {
-    return listMarkers.flatMap((marker, index) => {
-      const markerText = marker[0].trim();
-      const body = input
-        .slice(marker.index + marker[0].length, listMarkers[index + 1]?.index ?? input.length)
-        .trim();
-      return sentenceSegment(body, { caseNeutral }).map((sentence, sentenceIndex) =>
-        sentenceIndex === 0 ? `${markerText} ${sentence}` : sentence,
-      );
-    });
+  const list = segmentList(input, caseNeutral);
+  if (list !== undefined) {
+    return list;
   }
 
   // Scan terminals before applying abbreviation and line-wrap rules.
@@ -353,6 +339,44 @@ export function sentenceSegment(
 
   // If no matches were found, return the input treated as a single sentence
   return acc.length === 0 ? [input] : acc;
+}
+
+function nextListMarker(input: string, expression: RegExp): RegExpExecArray | null {
+  let marker = expression.exec(input);
+  while (marker !== null) {
+    if (
+      marker.index === 0 ||
+      !/\b(?:section|chapter|page|figure|table|paragraph|article|clause)$/i.test(
+        input.slice(Math.max(0, marker.index - 24), marker.index).trimEnd(),
+      )
+    ) {
+      return marker;
+    }
+    marker = expression.exec(input);
+  }
+  return null;
+}
+
+function segmentList(input: string, caseNeutral: boolean): string[] | undefined {
+  const expression = new RegExp(listMarkerReg);
+  let current = nextListMarker(input, expression);
+  if (current === null || input.slice(0, current.index).trim().length > 0) {
+    return undefined;
+  }
+  let next = nextListMarker(input, expression);
+  if (next === null) {
+    return undefined;
+  }
+
+  const segments: string[] = [];
+  do {
+    const body = input.slice(current.index + current[0].length, next?.index ?? input.length).trim();
+    const sentences = /[.!?\r\n]/.test(body) ? sentenceSegment(body, { caseNeutral }) : [body];
+    segments.push(`${current[0].trim()} ${sentences[0]}`, ...sentences.slice(1));
+    current = next;
+    next = nextListMarker(input, expression);
+  } while (current !== null);
+  return segments;
 }
 
 /** Options for rule-based sentence segmentation. */
@@ -574,7 +598,9 @@ function isUnspacedDelimitedSentenceStart(
   }
   const character = characterAt(input, next);
   return (
-    character.length > 0 && (caseNeutral ? isCasedCharacter(character) : charIsUpperCase(character))
+    character.length > 0 &&
+    (/^\p{Number}$/u.test(character) ||
+      (caseNeutral ? isCasedCharacter(character) : charIsUpperCase(character)))
   );
 }
 
@@ -585,11 +611,11 @@ function isUnspacedSentenceBoundary(
   caseNeutral: boolean,
 ): boolean {
   const nextCharacter = characterAt(input, next);
-  if (
-    input[index] !== '.' ||
-    !(caseNeutral ? isCasedCharacter(nextCharacter) : charIsUpperCase(nextCharacter))
-  ) {
+  if (!(caseNeutral ? isCasedCharacter(nextCharacter) : charIsUpperCase(nextCharacter))) {
     return false;
+  }
+  if (input[index] !== '.') {
+    return true;
   }
 
   const suffix = input.slice(Math.max(0, index + 1 - sentenceSuffixLength), index + 1);
@@ -597,16 +623,24 @@ function isUnspacedSentenceBoundary(
   const preceding = input.slice(Math.max(0, index - 320), next);
   const previousAt = preceding.lastIndexOf('@');
   const insideAddress = previousAt !== -1 && !/\s/.test(preceding.slice(previousAt));
+  const hostnameLabel = following.match(
+    /^(com|org|net|edu|gov|mil|io|dev|app|co|uk|us|ca|ai|info|biz|me|tv)(?=[/.\s]|$)/i,
+  )?.[0];
   const insideHostname =
     /https?:\/\/|www\./i.test(preceding) ||
-    /^(?:com|org|net|edu|gov|mil|io|dev|app|co|uk|us|ca|ai|info|biz|me|tv)(?=[/.\s]|$)/i.test(
-      following,
-    );
+    (hostnameLabel !== undefined &&
+      (hostnameLabel === hostnameLabel.toLowerCase() ||
+        hostnameLabel === hostnameLabel.toUpperCase()));
   const initial = caseNeutral ? /^\p{Cased}\./u : /^\p{Lu}\./u;
   const trailingInitial = caseNeutral ? /\b\p{Cased}\.$/u : /\b\p{Lu}\.$/u;
   const nextInitial = caseNeutral ? /^\p{Cased}(?=\s|$)/u : /^\p{Lu}(?=\s|$)/u;
+  const gateSuffix = caseNeutral ? suffix.toLowerCase() : suffix;
+  const continuesAbbreviation =
+    abbrvReg.test(gateSuffix) &&
+    (excepReg.test(gateSuffix) ||
+      (geographicAcronymReg.test(gateSuffix) && geographicContinuationReg.test(following)));
   return !(
-    abbrvReg.test(caseNeutral ? suffix.toLowerCase() : suffix) ||
+    continuesAbbreviation ||
     initial.test(following) ||
     (trailingInitial.test(suffix) && nextInitial.test(following)) ||
     /^[^\s]*@/.test(following) ||

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,6 +97,9 @@ const sentenceSuffixLength = Math.max(10, ...GATE_SUBSTITUTIONS.map((word) => wo
 const closingDelimiterReg = /[\])}>"']/;
 const openingBracketReg = /[([{<]/;
 const closingBracketReg = /[\])}>]/;
+const listMarkerReg = /(?:^|\s)(?:(?:[•⁃]\s*)?\d+(?:\.\)|[.)])|[a-z]\.)(?=\s+\p{Lu})/gu;
+const geographicAcronymReg = /\b(?:U\.S(?:\.A)?|E\.U)\.$/i;
+const geographicContinuationReg = /^(?:government|army|navy|military|congress)\b/i;
 
 /** Keep merged fragments separate; boundary rules only need a suffix and word casing. */
 class SentenceBuffer {
@@ -219,6 +222,13 @@ export function sentenceSegment(
     return [];
   }
 
+  const listMarkers = [...input.matchAll(listMarkerReg)];
+  if (listMarkers.length > 1 && listMarkers[0].index === 0) {
+    return listMarkers.map((marker, index) =>
+      input.slice(marker.index, listMarkers[index + 1]?.index ?? input.length).trim(),
+    );
+  }
+
   // Scan terminals before applying abbreviation and line-wrap rules.
   const chunks = sentenceChunks(input, caseNeutral);
 
@@ -262,7 +272,11 @@ export function sentenceSegment(
         const nextChunk = chunks[idx + 1];
         if (
           (caseNeutral ? startsWithCasedCharacter(nextChunk) : strIsTitleCase(nextChunk)) &&
-          !excepReg.test(gateSuffix)
+          !excepReg.test(gateSuffix) &&
+          !(
+            geographicAcronymReg.test(gateSuffix) &&
+            geographicContinuationReg.test(nextChunk.trim())
+          )
         ) {
           // Catch abbreviations followed by a capital letter and treat as a boundary.
           acc.push(chunk.text());
@@ -304,6 +318,11 @@ export function sentenceSegment(
       } else if (chunks[idx + 1] && ellipseReg.test(suffix)) {
         // Catch mid-sentence ellipses (and their derivatives) and merge them
         const nextChunk = chunks[idx + 1];
+        const nextSentence = nextChunk.trim() || chunks[idx + 2] || '';
+        if (/\.{4}$/.test(suffix) && strIsTitleCase(nextSentence)) {
+          acc.push(chunk.text());
+          continue;
+        }
         chunk.append(nextChunk.replace(/ +/g, ' '));
         if (!(nextChunk.trim() || breakReg.test(nextChunk)) && chunks[idx + 2]) {
           // Keep the separator inside the sentence; leave line breaks to the newline rule.
@@ -330,6 +349,7 @@ export interface SentenceSegmentOptions {
 /** Scan sentence boundaries once, preserving the former captured-split layout. */
 function sentenceChunks(input: string, caseNeutral: boolean): string[] {
   const chunks: string[] = [];
+  const protectedPeriods = spacedEllipsisPeriods(input);
   let lastEnd = 0;
   let start = -1;
   let insideQuotes = false;
@@ -360,7 +380,7 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
       // A terminal must follow the initial character, even if it is punctuation.
       continue;
     }
-    if (char === '.' || char === '?' || char === '!') {
+    if ((char === '.' && !protectedPeriods.has(index)) || char === '?' || char === '!') {
       const end = sentenceEnd(input, index, insideQuotes, brackets, caseNeutral);
       if (end === -1) {
         continue;
@@ -374,6 +394,26 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
 
   chunks.push(input.slice(lastEnd));
   return chunks;
+}
+
+function spacedEllipsisPeriods(input: string): Set<number> {
+  const protectedPeriods = new Set<number>();
+  for (const match of input.matchAll(/(?:\.[^\S\r\n]+){2,}\./g)) {
+    const offsets = [...match[0].matchAll(/\./g)].map((period) => period.index);
+    let boundary = -1;
+    if (
+      offsets.length >= 4 &&
+      /^\p{Lu}/u.test(input.slice(match.index + match[0].length).trimStart())
+    ) {
+      boundary = /\S/.test(input[match.index - 1] ?? '') ? offsets[0] : (offsets.at(-1) ?? -1);
+    }
+    for (const offset of offsets) {
+      if (offset !== boundary) {
+        protectedPeriods.add(match.index + offset);
+      }
+    }
+  }
+  return protectedPeriods;
 }
 
 /** Scan closing delimiters, including whitespace before a pending closing quote. */
@@ -415,7 +455,7 @@ function sentenceEnd(
 ): number {
   const end = closingDelimiterEnd(input, index, insideQuotes);
   if (end < input.length && !/\s/.test(input[end])) {
-    return -1;
+    return isUnspacedSentenceBoundary(input, index, end, caseNeutral) ? end : -1;
   }
   if (end === index + 1) {
     return end;
@@ -461,6 +501,26 @@ function sentenceEnd(
     return -1;
   }
   return abbrvReg.test(gateSuffix) && excepReg.test(gateSuffix) ? -1 : end;
+}
+
+function isUnspacedSentenceBoundary(
+  input: string,
+  index: number,
+  next: number,
+  caseNeutral: boolean,
+): boolean {
+  if (input[index] !== '.' || !charIsUpperCase(characterAt(input, next))) {
+    return false;
+  }
+
+  const suffix = input.slice(Math.max(0, index + 1 - sentenceSuffixLength), index + 1);
+  const following = input.slice(next);
+  return !(
+    abbrvReg.test(caseNeutral ? suffix.toLowerCase() : suffix) ||
+    /^\p{Lu}\./u.test(following) ||
+    (/\b\p{Lu}\.$/u.test(suffix) && /^\p{Lu}(?=\s|$)/u.test(following)) ||
+    /^[^\s]*@/.test(following)
+  );
 }
 
 function trimSpaces(input: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,7 +98,7 @@ const closingDelimiterReg = /[\])}>"']/;
 const openingBracketReg = /[([{<]/;
 const closingBracketReg = /[\])}>]/;
 const listMarkerReg = /(?:^|\s)(?:(?:[•⁃]\s*)?\d+(?:\.\)|[.)])|\p{Cased}\.)(?=\s+\p{Cased})/gu;
-const geographicAcronymReg = /\b(?:U\.S(?:\.A)?|E\.U)\.$/i;
+const geographicAcronymReg = /\bU\.S(?:\.A)?\.$/i;
 const geographicContinuationReg = /^(?:government|army|navy|military|congress)\b/i;
 
 /** Keep merged fragments separate; boundary rules only need a suffix and word casing. */
@@ -229,7 +229,7 @@ export function sentenceSegment(
         input.slice(Math.max(0, marker.index - 24), marker.index).trimEnd(),
       ),
   );
-  if (listMarkers.length > 1 && listMarkers[0].index === 0) {
+  if (listMarkers.length > 1 && input.slice(0, listMarkers[0].index).trim().length === 0) {
     return listMarkers.flatMap((marker, index) => {
       const markerText = marker[0].trim();
       const body = input
@@ -502,6 +502,9 @@ function sentenceEnd(
   brackets: { depth: number; standalone: boolean },
   caseNeutral: boolean,
 ): number {
+  if (!insideQuotes && isUnspacedDelimitedSentenceStart(input, index, caseNeutral)) {
+    return index + 1;
+  }
   const end = closingDelimiterEnd(input, index, insideQuotes);
   if (end < input.length && !/\s/.test(input[end])) {
     return isUnspacedSentenceBoundary(input, index, end, caseNeutral) ? end : -1;
@@ -510,12 +513,7 @@ function sentenceEnd(
     return end;
   }
 
-  let closedBrackets = 0;
-  for (let i = index + 1; i < end; i++) {
-    if (closingBracketReg.test(input[i])) {
-      closedBrackets++;
-    }
-  }
+  const closedBrackets = countClosingBrackets(input, index + 1, end);
   const closesQuotation = insideQuotes && input[end - 1] === '"';
   if (
     closedBrackets > 0 &&
@@ -552,6 +550,34 @@ function sentenceEnd(
   return abbrvReg.test(gateSuffix) && excepReg.test(gateSuffix) ? -1 : end;
 }
 
+function countClosingBrackets(input: string, start: number, end: number): number {
+  let count = 0;
+  for (let index = start; index < end; index++) {
+    if (closingBracketReg.test(input[index])) {
+      count++;
+    }
+  }
+  return count;
+}
+
+function isUnspacedDelimitedSentenceStart(
+  input: string,
+  index: number,
+  caseNeutral: boolean,
+): boolean {
+  let next = index + 1;
+  if (!/["([{<]/.test(input[next] ?? '')) {
+    return false;
+  }
+  while (next < input.length && /["'([{<]/.test(input[next])) {
+    next++;
+  }
+  const character = characterAt(input, next);
+  return (
+    character.length > 0 && (caseNeutral ? isCasedCharacter(character) : charIsUpperCase(character))
+  );
+}
+
 function isUnspacedSentenceBoundary(
   input: string,
   index: number,
@@ -571,6 +597,11 @@ function isUnspacedSentenceBoundary(
   const preceding = input.slice(Math.max(0, index - 320), next);
   const previousAt = preceding.lastIndexOf('@');
   const insideAddress = previousAt !== -1 && !/\s/.test(preceding.slice(previousAt));
+  const insideHostname =
+    /https?:\/\/|www\./i.test(preceding) ||
+    /^(?:com|org|net|edu|gov|mil|io|dev|app|co|uk|us|ca|ai|info|biz|me|tv)(?=[/.\s]|$)/i.test(
+      following,
+    );
   const initial = caseNeutral ? /^\p{Cased}\./u : /^\p{Lu}\./u;
   const trailingInitial = caseNeutral ? /\b\p{Cased}\.$/u : /\b\p{Lu}\.$/u;
   const nextInitial = caseNeutral ? /^\p{Cased}(?=\s|$)/u : /^\p{Lu}(?=\s|$)/u;
@@ -579,7 +610,8 @@ function isUnspacedSentenceBoundary(
     initial.test(following) ||
     (trailingInitial.test(suffix) && nextInitial.test(following)) ||
     /^[^\s]*@/.test(following) ||
-    insideAddress
+    insideAddress ||
+    insideHostname
   );
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -344,12 +344,12 @@ export function sentenceSegment(
 function nextListMarker(
   input: string,
   expression: RegExp,
-  numbered?: boolean,
+  family?: RegExp,
 ): RegExpExecArray | null {
   let marker = expression.exec(input);
   while (marker !== null) {
     if (
-      (numbered === undefined || /\d/.test(marker[0]) === numbered) &&
+      (family === undefined || family.test(marker[0])) &&
       (marker.index === 0 ||
         !/\b(?:section|chapter|page|figure|table|paragraph|article|clause)$/i.test(
           input.slice(Math.max(0, marker.index - 24), marker.index).trimEnd(),
@@ -368,8 +368,9 @@ function segmentList(input: string, caseNeutral: boolean): string[] | undefined 
   if (current === null || input.slice(0, current.index).trim().length > 0) {
     return undefined;
   }
-  const numbered = /\d/.test(current[0]);
-  let next = nextListMarker(input, expression, numbered);
+  const firstMarker = current[0];
+  const family = [/\d/, /^\s*\p{Lu}/u, /^\s*\p{Ll}/u].find((pattern) => pattern.test(firstMarker));
+  let next = nextListMarker(input, expression, family);
   if (next === null) {
     return undefined;
   }
@@ -383,7 +384,7 @@ function segmentList(input: string, caseNeutral: boolean): string[] | undefined 
     }
     segments.push(`${current[0].trim()} ${sentences[0]}`, ...sentences.slice(1));
     current = next;
-    next = nextListMarker(input, expression, numbered);
+    next = nextListMarker(input, expression, family);
   } while (current !== null);
   return segments;
 }
@@ -603,10 +604,10 @@ function isUnspacedDelimitedSentenceStart(
   caseNeutral: boolean,
 ): boolean {
   let next = index + 1;
-  if (!/["([{<]/.test(input[next] ?? '')) {
+  if (!/["'([{<]/.test(input[next] ?? '')) {
     return false;
   }
-  if (/^\[\p{Number}+\]/u.test(input.slice(next))) {
+  if (/^(?:\[\p{Number}+\]|\(\p{Number}+\))/u.test(input.slice(next))) {
     return false;
   }
   while (next < input.length && /["'([{<]/.test(input[next])) {
@@ -630,25 +631,29 @@ function isUnspacedSentenceBoundary(
   if (!(caseNeutral ? isCasedCharacter(nextCharacter) : charIsUpperCase(nextCharacter))) {
     return false;
   }
+  const precedingToken = input.slice(Math.max(0, index - 320), next).match(/\S+$/)?.[0] ?? '';
+  const insideUrl = /https?:\/\/|www\./i.test(precedingToken);
   if (input[index] !== '.') {
-    return true;
+    return !insideUrl;
   }
 
   const suffix = input.slice(Math.max(0, index + 1 - sentenceSuffixLength), index + 1);
   const following = input.slice(next);
-  const precedingToken = input.slice(Math.max(0, index - 320), next).match(/\S+$/)?.[0] ?? '';
   const insideAddress = precedingToken.includes('@');
   const hostnameLabel = following.match(
     /^(com|org|net|edu|gov|mil|io|dev|app|co|uk|us|ca|ai|info|biz|me|tv)(?=[/.\s]|$)/i,
   )?.[0];
   const insideHostname =
-    /https?:\/\/|www\./i.test(precedingToken) ||
+    insideUrl ||
     (hostnameLabel !== undefined &&
-      (hostnameLabel === hostnameLabel.toLowerCase() ||
+      (caseNeutral ||
+        hostnameLabel === hostnameLabel.toLowerCase() ||
         hostnameLabel === hostnameLabel.toUpperCase()));
-  const dottedIdentifier =
-    /\b\p{Lu}[\p{Letter}\p{Number}_-]*\.$/u.test(suffix) &&
-    /^[\p{Lu}\p{Number}_-]+(?=\s|[/.]|$)/u.test(following);
+  const dottedIdentifier = caseNeutral
+    ? /\b\p{Cased}[\p{Letter}\p{Number}_-]*\.$/u.test(suffix) &&
+      /^[\p{Cased}\p{Number}_-]{1,2}(?=\s|[/.]|$)/u.test(following)
+    : /\b\p{Lu}[\p{Letter}\p{Number}_-]*\.$/u.test(suffix) &&
+      /^[\p{Lu}\p{Number}_-]+(?=\s|[/.]|$)/u.test(following);
   const initial = caseNeutral ? /^\p{Cased}\./u : /^\p{Lu}\./u;
   const trailingInitial = caseNeutral ? /\b\p{Cased}\.$/u : /\b\p{Lu}\.$/u;
   const nextInitial = caseNeutral ? /^\p{Cased}(?=\s|$)/u : /^\p{Lu}(?=\s|$)/u;

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -500,6 +500,13 @@ describe('Utility Functions', () => {
       ]);
     });
 
+    test('keeps name initials inside numbered list items', () => {
+      expect(ss('1. J. Smith will attend 2. A. Brown will attend')).toEqual([
+        '1. J. Smith will attend',
+        '2. A. Brown will attend',
+      ]);
+    });
+
     test('recognizes list markers without depending on item capitalization', () => {
       const input = '1. The first item 2. The second item';
       const expected = ['1. The first item', '2. The second item'];
@@ -548,8 +555,26 @@ describe('Utility Functions', () => {
     test.each([
       ['The build failed.App restarted.', ['The build failed.', 'App restarted.']],
       ['The service stopped.Dev investigated.', ['The service stopped.', 'Dev investigated.']],
+      [
+        'Visit https://example.com. Then it failed.App restarted.',
+        ['Visit https://example.com.', 'Then it failed.', 'App restarted.'],
+      ],
     ])('does not mistake an unspaced sentence for a hostname: %s', (input, expected) => {
       expect(ss(input)).toEqual(expected);
+    });
+
+    test.each(['He earned a Ph.D in physics.', 'Open README.MD before continuing.'])(
+      'keeps dotted identifiers inside a sentence: %s',
+      (input) => {
+        expect(ss(input)).toEqual([input]);
+      },
+    );
+
+    test('keeps bracketed references inside their sentence', () => {
+      expect(ss('He wrote (see Fig.[2] for details). Next.')).toEqual([
+        'He wrote (see Fig.[2] for details).',
+        'Next.',
+      ]);
     });
 
     test.each([

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -408,6 +408,85 @@ describe('Utility Functions', () => {
     // Golden Rule tests from https://github.com/diasks2/pragmatic_segmenter
     // =====================================================================
 
+    test.each([
+      [
+        '016',
+        'I work for the U.S. Government in Virginia.',
+        ['I work for the U.S. Government in Virginia.'],
+      ],
+      [
+        '031',
+        '1.) The first item 2.) The second item',
+        ['1.) The first item', '2.) The second item'],
+      ],
+      ['033', '1) The first item 2) The second item', ['1) The first item', '2) The second item']],
+      ['035', '1. The first item 2. The second item', ['1. The first item', '2. The second item']],
+      [
+        '036',
+        '1. The first item. 2. The second item.',
+        ['1. The first item.', '2. The second item.'],
+      ],
+      [
+        '037',
+        '• 9. The first item • 10. The second item',
+        ['• 9. The first item', '• 10. The second item'],
+      ],
+      [
+        '038',
+        '⁃9. The first item ⁃10. The second item',
+        ['⁃9. The first item', '⁃10. The second item'],
+      ],
+      [
+        '039',
+        'a. The first item b. The second item c. The third list item',
+        ['a. The first item', 'b. The second item', 'c. The third list item'],
+      ],
+      [
+        '046',
+        'Thoreau argues that by simplifying one’s life, “the laws of the universe will appear less complex. . . .”',
+        [
+          'Thoreau argues that by simplifying one’s life, “the laws of the universe will appear less complex. . . .”',
+        ],
+      ],
+      [
+        '048',
+        'Omitted words end in a period . . . . Next sentence.',
+        ['Omitted words end in a period . . . .', 'Next sentence.'],
+      ],
+      [
+        '049',
+        'I never meant that.... She left the store.',
+        ['I never meant that....', 'She left the store.'],
+      ],
+      [
+        '050',
+        "I wasn’t really ... well, what I mean...see . . . what I'm saying, the thing is . . . I didn’t mean it.",
+        [
+          "I wasn’t really ... well, what I mean...see . . . what I'm saying, the thing is . . . I didn’t mean it.",
+        ],
+      ],
+      [
+        '051',
+        'One further habit which was somewhat weakened . . . was that of combining words into self-interpreting compounds. . . . The practice was not abandoned. . . .',
+        [
+          'One further habit which was somewhat weakened . . . was that of combining words into self-interpreting compounds.',
+          '. . . The practice was not abandoned. . . .',
+        ],
+      ],
+      [
+        '052',
+        'Hello world.Today is Tuesday.Mr. Smith went to the store and bought 1,000.That is a lot.',
+        [
+          'Hello world.',
+          'Today is Tuesday.',
+          'Mr. Smith went to the store and bought 1,000.',
+          'That is a lot.',
+        ],
+      ],
+    ] as const)('matches upstream English Golden Rule #%s', (_rule, input, expected) => {
+      expect(ss(input)).toEqual(expected);
+    });
+
     test('should split simple periods', () => {
       expect(ss('Hello World. My name is Jonas.')).toEqual(['Hello World.', 'My name is Jonas.']);
     });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -546,8 +546,18 @@ describe('Utility Functions', () => {
     );
 
     test.each([
+      ['The build failed.App restarted.', ['The build failed.', 'App restarted.']],
+      ['The service stopped.Dev investigated.', ['The service stopped.', 'Dev investigated.']],
+    ])('does not mistake an unspaced sentence for a hostname: %s', (input, expected) => {
+      expect(ss(input)).toEqual(expected);
+    });
+
+    test.each([
       ['Hello world."Next sentence."', ['Hello world.', '"Next sentence."']],
       ['Hello world.(Next sentence.)', ['Hello world.', '(Next sentence.)']],
+      ['Hello world.(2 people agreed.)', ['Hello world.', '(2 people agreed.)']],
+      ['Hello world.[2 people agreed.]', ['Hello world.', '[2 people agreed.]']],
+      ['Hello world."2 people agreed."', ['Hello world.', '"2 people agreed."']],
     ])('keeps opening delimiters with adjacent sentence starts in %s', (input, expected) => {
       expect(ss(input)).toEqual(expected);
     });
@@ -557,6 +567,15 @@ describe('Utility Functions', () => {
         'The treaty applies in the E.U.',
         'Congress meets tomorrow.',
       ]);
+    });
+
+    test.each([
+      ['Use etc.Today is Tuesday.', ['Use etc.', 'Today is Tuesday.']],
+      ['He moved to the U.S.Today is Tuesday.', ['He moved to the U.S.', 'Today is Tuesday.']],
+      ['Are you ready?Yes, I am.', ['Are you ready?', 'Yes, I am.']],
+      ['Stop!Run now.', ['Stop!', 'Run now.']],
+    ])('recognizes adjacent terminal boundaries in %s', (input, expected) => {
+      expect(ss(input)).toEqual(expected);
     });
 
     test.each([
@@ -1023,6 +1042,21 @@ describe('Utility Functions', () => {
           ['--max-old-space-size=64'],
         );
       }, 20_000);
+
+      test('streams large list-marker runs within a constrained heap', () => {
+        expectBundledScriptToPass(
+          `
+            const summary = '1. Item '.repeat(400000);
+            const sentences = module.exports.sentenceSegment(summary);
+            if (sentences.length !== 400000 || sentences[0] !== '1. Item') {
+              throw new Error('List-marker segmentation changed');
+            }
+            process.stdout.write('ok');
+          `,
+          20_000,
+          ['--max-old-space-size=64'],
+        );
+      }, 25_000);
 
       test('should segment abbreviation chains within a small heap', () => {
         expectBundledScriptToPass(

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -509,6 +509,13 @@ describe('Utility Functions', () => {
       );
     });
 
+    test('recognizes list markers after document indentation', () => {
+      expect(ss('  1. The first item 2. The second item')).toEqual([
+        '1. The first item',
+        '2. The second item',
+      ]);
+    });
+
     test('keeps four-dot boundaries invariant under case folding', () => {
       expect(segmentCaseNeutrally('First.... Second.')).toEqual(['First....', 'Second.']);
       expect(segmentCaseNeutrally('first.... second.')).toEqual(['first....', 'second.']);
@@ -528,6 +535,27 @@ describe('Utility Functions', () => {
     test('keeps uppercase email domain labels inside their address', () => {
       expect(ss('Mail Jane.Doe@example.COM for help.')).toEqual([
         'Mail Jane.Doe@example.COM for help.',
+      ]);
+    });
+
+    test.each(['Visit example.COM for help.', 'Visit https://example.COM/path today.'])(
+      'keeps uppercase hostname labels inside %s',
+      (input) => {
+        expect(ss(input)).toEqual([input]);
+      },
+    );
+
+    test.each([
+      ['Hello world."Next sentence."', ['Hello world.', '"Next sentence."']],
+      ['Hello world.(Next sentence.)', ['Hello world.', '(Next sentence.)']],
+    ])('keeps opening delimiters with adjacent sentence starts in %s', (input, expected) => {
+      expect(ss(input)).toEqual(expected);
+    });
+
+    test('does not merge incompatible geographic-acronym continuations', () => {
+      expect(ss('The treaty applies in the E.U. Congress meets tomorrow.')).toEqual([
+        'The treaty applies in the E.U.',
+        'Congress meets tomorrow.',
       ]);
     });
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -487,6 +487,58 @@ describe('Utility Functions', () => {
       expect(ss(input)).toEqual(expected);
     });
 
+    test('continues segmenting sentences inside numbered list items', () => {
+      expect(ss('1. First sentence. Another sentence. 2. Second item.')).toEqual([
+        '1. First sentence.',
+        'Another sentence.',
+        '2. Second item.',
+      ]);
+      expect(ss('1. See section 2. Details follow. 2. Actual item.')).toEqual([
+        '1. See section 2.',
+        'Details follow.',
+        '2. Actual item.',
+      ]);
+    });
+
+    test('recognizes list markers without depending on item capitalization', () => {
+      const input = '1. The first item 2. The second item';
+      const expected = ['1. The first item', '2. The second item'];
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+        expected.map((sentence) => sentence.toLowerCase()),
+      );
+    });
+
+    test('keeps four-dot boundaries invariant under case folding', () => {
+      expect(segmentCaseNeutrally('First.... Second.')).toEqual(['First....', 'Second.']);
+      expect(segmentCaseNeutrally('first.... second.')).toEqual(['first....', 'second.']);
+    });
+
+    test('keeps unspaced boundaries invariant under case folding', () => {
+      expect(segmentCaseNeutrally('Hello world.Today is Tuesday.')).toEqual([
+        'Hello world.',
+        'Today is Tuesday.',
+      ]);
+      expect(segmentCaseNeutrally('hello world.today is tuesday.')).toEqual([
+        'hello world.',
+        'today is tuesday.',
+      ]);
+    });
+
+    test('keeps uppercase email domain labels inside their address', () => {
+      expect(ss('Mail Jane.Doe@example.COM for help.')).toEqual([
+        'Mail Jane.Doe@example.COM for help.',
+      ]);
+    });
+
+    test.each([
+      ['"Next sentence."', '"Next sentence."'],
+      ['(Next sentence.)', '(Next sentence.)'],
+      ['2 people agreed.', '2 people agreed.'],
+    ])('retains a spaced-ellipsis boundary before %s', (start, expected) => {
+      expect(ss(`Omitted words . . . . ${start}`)).toEqual(['Omitted words . . . .', expected]);
+    });
+
     test('should split simple periods', () => {
       expect(ss('Hello World. My name is Jonas.')).toEqual(['Hello World.', 'My name is Jonas.']);
     });
@@ -928,6 +980,21 @@ describe('Utility Functions', () => {
     // Using 500ms threshold to account for CI environment variability
     describe('ReDoS prevention', () => {
       const TIMEOUT_MS = 500;
+
+      test('segments large spaced-ellipsis runs within a constrained heap', () => {
+        expectBundledScriptToPass(
+          `
+            const summary = '. '.repeat(600000) + '.';
+            const sentences = module.exports.sentenceSegment(summary);
+            if (sentences.length !== 1 || sentences[0] !== summary) {
+              throw new Error('Spaced-ellipsis content changed');
+            }
+            process.stdout.write('ok');
+          `,
+          15_000,
+          ['--max-old-space-size=64'],
+        );
+      }, 20_000);
 
       test('should segment abbreviation chains within a small heap', () => {
         expectBundledScriptToPass(

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -507,6 +507,13 @@ describe('Utility Functions', () => {
       ]);
     });
 
+    test('keeps name initials inside lettered list items', () => {
+      expect(ss('a. J. Smith will attend b. A. Brown will attend')).toEqual([
+        'a. J. Smith will attend',
+        'b. A. Brown will attend',
+      ]);
+    });
+
     test('recognizes list markers without depending on item capitalization', () => {
       const input = '1. The first item 2. The second item';
       const expected = ['1. The first item', '2. The second item'];
@@ -552,6 +559,17 @@ describe('Utility Functions', () => {
       },
     );
 
+    test('keeps mixed-case hostnames invariant under case folding', () => {
+      const input = 'Visit example.Com for help.';
+      expect(segmentCaseNeutrally(input)).toEqual([input]);
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([input.toLowerCase()]);
+    });
+
+    test.each(['?', '!'])('keeps uppercase URL components after a %s separator', (separator) => {
+      const input = `Visit https://example.com${separator}Next=value for details.`;
+      expect(ss(input)).toEqual([input]);
+    });
+
     test.each([
       ['The build failed.App restarted.', ['The build failed.', 'App restarted.']],
       ['The service stopped.Dev investigated.', ['The service stopped.', 'Dev investigated.']],
@@ -567,6 +585,8 @@ describe('Utility Functions', () => {
       'keeps dotted identifiers inside a sentence: %s',
       (input) => {
         expect(ss(input)).toEqual([input]);
+        expect(segmentCaseNeutrally(input)).toEqual([input]);
+        expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([input.toLowerCase()]);
       },
     );
 
@@ -577,8 +597,14 @@ describe('Utility Functions', () => {
       ]);
     });
 
+    test('keeps parenthesized page references inside their sentence', () => {
+      const input = 'See p.(10) for details.';
+      expect(ss(input)).toEqual([input]);
+    });
+
     test.each([
       ['Hello world."Next sentence."', ['Hello world.', '"Next sentence."']],
+      ["Hello world.'Next sentence.'", ['Hello world.', "'Next sentence.'"]],
       ['Hello world.(Next sentence.)', ['Hello world.', '(Next sentence.)']],
       ['Hello world.(2 people agreed.)', ['Hello world.', '(2 people agreed.)']],
       ['Hello world.[2 people agreed.]', ['Hello world.', '[2 people agreed.]']],

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -514,6 +514,17 @@ describe('Utility Functions', () => {
       ]);
     });
 
+    test('recognizes quoted and bracketed list-item starts', () => {
+      expect(ss('1. "First item" 2. "Second item"')).toEqual([
+        '1. "First item"',
+        '2. "Second item"',
+      ]);
+      expect(ss('1. (First item) 2. (Second item)')).toEqual([
+        '1. (First item)',
+        '2. (Second item)',
+      ]);
+    });
+
     test('recognizes list markers without depending on item capitalization', () => {
       const input = '1. The first item 2. The second item';
       const expected = ['1. The first item', '2. The second item'];
@@ -549,6 +560,13 @@ describe('Utility Functions', () => {
     test('keeps uppercase email domain labels inside their address', () => {
       expect(ss('Mail Jane.Doe@example.COM for help.')).toEqual([
         'Mail Jane.Doe@example.COM for help.',
+      ]);
+    });
+
+    test('splits adjacent sentences after email addresses', () => {
+      expect(ss('Contact me@example.com.Next sentence.')).toEqual([
+        'Contact me@example.com.',
+        'Next sentence.',
       ]);
     });
 
@@ -624,7 +642,9 @@ describe('Utility Functions', () => {
       ['Use etc.Today is Tuesday.', ['Use etc.', 'Today is Tuesday.']],
       ['He moved to the U.S.Today is Tuesday.', ['He moved to the U.S.', 'Today is Tuesday.']],
       ['Are you ready?Yes, I am.', ['Are you ready?', 'Yes, I am.']],
+      ['Are any left?2 remain.', ['Are any left?', '2 remain.']],
       ['Stop!Run now.', ['Stop!', 'Run now.']],
+      ['Stop!2 people stayed.', ['Stop!', '2 people stayed.']],
     ])('recognizes adjacent terminal boundaries in %s', (input, expected) => {
       expect(ss(input)).toEqual(expected);
     });


### PR DESCRIPTION
## Summary

- add failing-first regressions for all 14 missing English Golden Rules from pragmatic_segmenter
- recognize numbered, parenthesized, bulleted, and alphabetical list items; preserve geographic organization names
- distinguish spaced and four-dot ellipses plus adjacent unspaced sentences without splitting email addresses or acronyms

## Verification

- reproduced all 14 Golden Rule failures against the unchanged main implementation
- `npm test -- --runInBand --silent --verbose=false` (565 passing tests)
- `npm run type-check`
- `./node_modules/.bin/biome ci . --error-on-warnings`
- source: https://github.com/diasks2/pragmatic_segmenter/blob/master/spec/pragmatic_segmenter/languages/english_spec.rb