### PR TITLE
fix: preserve Unicode case expansion in dotted identifiers

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -748,15 +748,31 @@ function caseNeutralIdentifierContext(input: string, index: number): boolean {
   if (!/\p{Cased}/u.test(token)) {
     return false;
   }
-  const stableAscii = token
-    .replace(/[Ii]\u0307\p{Mark}*/gu, '')
-    .replace(/[A-Za-z]\p{Mark}/gu, (cluster) => cluster.normalize('NFC'));
   return (
-    /[a-jl-z0-9_]/i.test(stableAscii) ||
-    (/k/i.test(stableAscii) &&
-      (tokenStart > 0 || !/^no\b/i.test(input.slice(index + 1, index + 8)))) ||
+    hasStableAsciiIdentifierEvidence(input, tokenStart, index) ||
     (/\p{Script=Latin}/u.test(token) && /\p{Script=Greek}/u.test(token))
   );
+}
+
+function hasStableAsciiIdentifierEvidence(input: string, start: number, end: number): boolean {
+  const noOneContinuation = /^no\s+one\b/i.test(input.slice(end + 1, end + 16));
+  for (let cursor = start; cursor < end; cursor++) {
+    const code = input.charCodeAt(cursor);
+    if ((code >= 48 && code <= 57) || code === 95) {
+      return true;
+    }
+    const lowerCode = code | 32;
+    if (lowerCode < 97 || lowerCode > 122) {
+      continue;
+    }
+    if (/^\p{Mark}$/u.test(characterAt(input, cursor + 1))) {
+      continue;
+    }
+    if (lowerCode !== 107 || start > 0 || !noOneContinuation) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function isUnspacedSentenceBoundary(
@@ -793,16 +809,15 @@ function isUnspacedSentenceBoundary(
         hostnameLabel === hostnameLabel.toLowerCase() ||
         hostnameLabel === hostnameLabel.toUpperCase()));
   const dottedIdentifier = caseNeutral
-    ? identifier && /^(?:[\p{Cased}\p{Number}_-]\p{M}*){1,2}(?=\s|[/.]|$)/u.test(following)
+    ? identifier &&
+      /^(?:[\p{Cased}\p{Number}_-](?:\u0307\p{M}*)?){1,2}(?=\s|[/.]|$)/u.test(following)
     : /\b\p{Lu}[\p{Letter}\p{Number}_-]*\.$/u.test(suffix) &&
       /^[\p{Lu}\p{Number}_-]+(?=\s|[/.]|$)/u.test(following);
   const initial = caseNeutral ? /^\p{Cased}\p{M}*\./u : /^\p{Lu}\./u;
   const trailingInitial = caseNeutral
     ? /(?:^|[^\p{Letter}\p{Mark}\p{Number}_-])\p{Cased}\p{M}*\.$/u
     : /\b\p{Lu}\.$/u;
-  const nextInitial = caseNeutral
-    ? /^(?!i\s+\p{Letter})\p{Cased}\p{M}*(?=\s|$)/iu
-    : /^\p{Lu}(?=\s|$)/u;
+  const nextInitial = caseNeutral ? /^(?!i(?:\s|$))\p{Cased}\p{M}*(?=\s|$)/iu : /^\p{Lu}(?=\s|$)/u;
   const gateSuffix = caseNeutral ? suffix.toLowerCase() : suffix;
   const contextChangingGreekInitial = /^[Σσς]\p{M}+\.\p{Case_Ignorable}*\p{Cased}/u.test(following);
   const continuesAbbreviation =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -766,7 +766,7 @@ function isUnspacedSentenceBoundary(
         hostnameLabel === hostnameLabel.toLowerCase() ||
         hostnameLabel === hostnameLabel.toUpperCase()));
   const dottedIdentifier = caseNeutral
-    ? /(?:^|[^\p{Letter}\p{Mark}\p{Number}_-])(?:[\p{Letter}\p{Mark}\p{Number}_-]*\p{Cased}|\p{Mark})[\p{Letter}\p{Mark}\p{Number}_-]*\.$/u.test(
+    ? /(?:^|[^\p{Letter}\p{Mark}\p{Number}_-])(?=[\p{Letter}\p{Mark}\p{Number}_-]*[A-Za-z0-9_İ\p{Mark}-])(?:[\p{Letter}\p{Mark}\p{Number}_-]*\p{Cased}|\p{Mark})[\p{Letter}\p{Mark}\p{Number}_-]*\.$/u.test(
         suffix,
       ) && /^(?:[\p{Cased}\p{Number}_-]\p{M}*){1,2}(?=\s|[/.]|$)/u.test(following)
     : /\b\p{Lu}[\p{Letter}\p{Number}_-]*\.$/u.test(suffix) &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -766,7 +766,7 @@ function isUnspacedSentenceBoundary(
         hostnameLabel === hostnameLabel.toLowerCase() ||
         hostnameLabel === hostnameLabel.toUpperCase()));
   const dottedIdentifier = caseNeutral
-    ? /(?:^|[^\p{Letter}\p{Mark}\p{Number}_-])(?=[\p{Letter}\p{Mark}\p{Number}_-]*[A-Za-z0-9_İ\p{Mark}-])(?:[\p{Letter}\p{Mark}\p{Number}_-]*\p{Cased}|\p{Mark})[\p{Letter}\p{Mark}\p{Number}_-]*\.$/u.test(
+    ? /(?:^|[^\p{Letter}\p{Mark}\p{Number}_-])(?=\p{Mark}|[\p{Letter}\p{Mark}\p{Number}_-]*[A-Za-z0-9_İ-])(?:[\p{Letter}\p{Mark}\p{Number}_-]*\p{Cased}|\p{Mark})[\p{Letter}\p{Mark}\p{Number}_-]*\.$/u.test(
         suffix,
       ) && /^(?:[\p{Cased}\p{Number}_-]\p{M}*){1,2}(?=\s|[/.]|$)/u.test(following)
     : /\b\p{Lu}[\p{Letter}\p{Number}_-]*\.$/u.test(suffix) &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -752,7 +752,10 @@ function isUnspacedSentenceBoundary(
     return !insideUrl;
   }
 
-  const suffix = input.slice(Math.max(0, index + 1 - sentenceSuffixLength), index + 1);
+  const suffixStart = Math.max(0, index + 1 - sentenceSuffixLength);
+  const suffix = input.slice(suffixStart, index + 1);
+  const identifierSuffix =
+    suffixStart > 0 && /^\p{Mark}/u.test(suffix) ? `${input[suffixStart - 1]}${suffix}` : suffix;
   const following = input.slice(next);
   const insideAddress =
     precedingToken.includes('@') && !/@[^\s.]+(?:\.[^\s.]+)+\.$/u.test(precedingToken);
@@ -766,8 +769,8 @@ function isUnspacedSentenceBoundary(
         hostnameLabel === hostnameLabel.toLowerCase() ||
         hostnameLabel === hostnameLabel.toUpperCase()));
   const dottedIdentifier = caseNeutral
-    ? /(?:^|[^\p{Letter}\p{Mark}\p{Number}_-])(?=\p{Mark}|[\p{Letter}\p{Mark}\p{Number}_-]*[A-Za-z0-9_İ-])(?:[\p{Letter}\p{Mark}\p{Number}_-]*\p{Cased}|\p{Mark})[\p{Letter}\p{Mark}\p{Number}_-]*\.$/u.test(
-        suffix,
+    ? /(?:^|[^\p{Letter}\p{Mark}\p{Number}_-])(?=[\p{Letter}\p{Mark}\p{Number}_-]*[A-Za-z0-9_İ-])(?:[\p{Letter}\p{Mark}\p{Number}_-]*\p{Cased}|\p{Mark})[\p{Letter}\p{Mark}\p{Number}_-]*\.$/u.test(
+        identifierSuffix,
       ) && /^(?:[\p{Cased}\p{Number}_-]\p{M}*){1,2}(?=\s|[/.]|$)/u.test(following)
     : /\b\p{Lu}[\p{Letter}\p{Number}_-]*\.$/u.test(suffix) &&
       /^[\p{Lu}\p{Number}_-]+(?=\s|[/.]|$)/u.test(following);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -766,13 +766,16 @@ function isUnspacedSentenceBoundary(
         hostnameLabel === hostnameLabel.toLowerCase() ||
         hostnameLabel === hostnameLabel.toUpperCase()));
   const dottedIdentifier = caseNeutral
-    ? /\b\p{Cased}[\p{Letter}\p{Number}_-]*\.$/u.test(suffix) &&
-      /^[\p{Cased}\p{Number}_-]{1,2}(?=\s|[/.]|$)/u.test(following)
+    ? /(?:^|[^\p{Letter}\p{Mark}\p{Number}_-])\p{Mark}*\p{Cased}[\p{Letter}\p{Mark}\p{Number}_-]*\.$/u.test(
+        suffix,
+      ) && /^(?:[\p{Cased}\p{Number}_-]\p{M}*){1,2}(?=\s|[/.]|$)/u.test(following)
     : /\b\p{Lu}[\p{Letter}\p{Number}_-]*\.$/u.test(suffix) &&
       /^[\p{Lu}\p{Number}_-]+(?=\s|[/.]|$)/u.test(following);
-  const initial = caseNeutral ? /^\p{Cased}\./u : /^\p{Lu}\./u;
-  const trailingInitial = caseNeutral ? /\b\p{Cased}\.$/u : /\b\p{Lu}\.$/u;
-  const nextInitial = caseNeutral ? /^\p{Cased}(?=\s|$)/u : /^\p{Lu}(?=\s|$)/u;
+  const initial = caseNeutral ? /^\p{Cased}\p{M}*\./u : /^\p{Lu}\./u;
+  const trailingInitial = caseNeutral
+    ? /(?:^|[^\p{Letter}\p{Mark}\p{Number}_-])\p{Cased}\p{M}*\.$/u
+    : /\b\p{Lu}\.$/u;
+  const nextInitial = caseNeutral ? /^\p{Cased}\p{M}*(?=\s|$)/u : /^\p{Lu}(?=\s|$)/u;
   const gateSuffix = caseNeutral ? suffix.toLowerCase() : suffix;
   const continuesAbbreviation =
     abbrvReg.test(gateSuffix) &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -753,7 +753,8 @@ function caseNeutralIdentifierContext(input: string, index: number): boolean {
     .replace(/[A-Za-z]\p{Mark}/gu, (cluster) => cluster.normalize('NFC'));
   return (
     /[a-jl-z0-9_]/i.test(stableAscii) ||
-    (/k/i.test(stableAscii) && !/^no\b/i.test(input.slice(index + 1, index + 8))) ||
+    (/k/i.test(stableAscii) &&
+      (tokenStart > 0 || !/^no\b/i.test(input.slice(index + 1, index + 8)))) ||
     (/\p{Script=Latin}/u.test(token) && /\p{Script=Greek}/u.test(token))
   );
 }
@@ -799,7 +800,9 @@ function isUnspacedSentenceBoundary(
   const trailingInitial = caseNeutral
     ? /(?:^|[^\p{Letter}\p{Mark}\p{Number}_-])\p{Cased}\p{M}*\.$/u
     : /\b\p{Lu}\.$/u;
-  const nextInitial = caseNeutral ? /^\p{Cased}\p{M}*(?=\s|$)/u : /^\p{Lu}(?=\s|$)/u;
+  const nextInitial = caseNeutral
+    ? /^(?!i\s+\p{Letter})\p{Cased}\p{M}*(?=\s|$)/iu
+    : /^\p{Lu}(?=\s|$)/u;
   const gateSuffix = caseNeutral ? suffix.toLowerCase() : suffix;
   const contextChangingGreekInitial = /^[Σσς]\p{M}+\.\p{Case_Ignorable}*\p{Cased}/u.test(following);
   const continuesAbbreviation =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -753,6 +753,7 @@ function caseNeutralIdentifierContext(input: string, index: number): boolean {
     .replace(/[A-Za-z]\p{Mark}/gu, (cluster) => cluster.normalize('NFC'));
   return (
     /[a-jl-z0-9_]/i.test(stableAscii) ||
+    (/k/i.test(stableAscii) && !/^no\b/i.test(input.slice(index + 1, index + 8))) ||
     (/\p{Script=Latin}/u.test(token) && /\p{Script=Greek}/u.test(token))
   );
 }
@@ -800,7 +801,7 @@ function isUnspacedSentenceBoundary(
     : /\b\p{Lu}\.$/u;
   const nextInitial = caseNeutral ? /^\p{Cased}\p{M}*(?=\s|$)/u : /^\p{Lu}(?=\s|$)/u;
   const gateSuffix = caseNeutral ? suffix.toLowerCase() : suffix;
-  const contextChangingGreekInitial = /^[Σσς]\p{M}+\.\p{Cased}/u.test(following);
+  const contextChangingGreekInitial = /^[Σσς]\p{M}+\.\p{Case_Ignorable}*\p{Cased}/u.test(following);
   const continuesAbbreviation =
     abbrvReg.test(gateSuffix) &&
     (excepReg.test(gateSuffix) ||

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -733,11 +733,7 @@ function isUnspacedDelimitedSentenceStart(
   );
 }
 
-function caseNeutralIdentifierContext(
-  input: string,
-  index: number,
-  suffixStart: number,
-): { suffix: string; evidence: boolean } {
+function caseNeutralIdentifierContext(input: string, index: number, suffixStart: number): boolean {
   let start = suffixStart;
   if (/^\p{Mark}/u.test(input.slice(start, index + 1))) {
     while (start > 0 && /^\p{Mark}$/u.test(input[start - 1])) {
@@ -747,12 +743,26 @@ function caseNeutralIdentifierContext(
       start--;
     }
   }
-  const suffix = input.slice(start, index + 1);
-  const token = suffix.match(/[\p{Letter}\p{Mark}\p{Number}_-]+\.$/u)?.[0] ?? '';
-  const evidence =
-    (start < suffixStart && token.length === suffix.length && /^\p{Cased}$/u.test(input[start])) ||
-    /[A-Za-z0-9_-]/.test(token.replace(/İ\p{Mark}*|i\p{Mark}+/gu, ''));
-  return { suffix, evidence };
+  let tokenStart = index;
+  while (tokenStart > start) {
+    const previousUnit = input.charCodeAt(tokenStart - 1);
+    const width = previousUnit >= 0xdc_00 && previousUnit <= 0xdf_ff ? 2 : 1;
+    const character = input.slice(tokenStart - width, tokenStart);
+    if (!/^[\p{Letter}\p{Mark}\p{Number}_-]$/u.test(character)) {
+      break;
+    }
+    tokenStart -= width;
+  }
+  const token = input.slice(tokenStart, index);
+  if (!/\p{Cased}/u.test(token)) {
+    return false;
+  }
+  const normalized = token.normalize('NFC').toLowerCase().normalize('NFC');
+  const stableAscii = normalized.replace(/i\u0307\p{Mark}*/gu, '');
+  return (
+    /[a-z0-9_-]/.test(stableAscii) ||
+    (/\p{Script=Latin}/u.test(normalized) && /\p{Script=Greek}/u.test(normalized))
+  );
 }
 
 function isUnspacedSentenceBoundary(
@@ -776,7 +786,7 @@ function isUnspacedSentenceBoundary(
 
   const suffixStart = Math.max(0, index + 1 - sentenceSuffixLength);
   const suffix = input.slice(suffixStart, index + 1);
-  const identifier = caseNeutralIdentifierContext(input, index, suffixStart);
+  const identifier = caseNeutral && caseNeutralIdentifierContext(input, index, suffixStart);
   const following = input.slice(next);
   const insideAddress =
     precedingToken.includes('@') && !/@[^\s.]+(?:\.[^\s.]+)+\.$/u.test(precedingToken);
@@ -790,11 +800,7 @@ function isUnspacedSentenceBoundary(
         hostnameLabel === hostnameLabel.toLowerCase() ||
         hostnameLabel === hostnameLabel.toUpperCase()));
   const dottedIdentifier = caseNeutral
-    ? identifier.evidence &&
-      /(?:^|[^\p{Letter}\p{Mark}\p{Number}_-])(?:[\p{Letter}\p{Mark}\p{Number}_-]*\p{Cased}|\p{Mark})[\p{Letter}\p{Mark}\p{Number}_-]*\.$/u.test(
-        identifier.suffix,
-      ) &&
-      /^(?:[\p{Cased}\p{Number}_-]\p{M}*){1,2}(?=\s|[/.]|$)/u.test(following)
+    ? identifier && /^(?:[\p{Cased}\p{Number}_-]\p{M}*){1,2}(?=\s|[/.]|$)/u.test(following)
     : /\b\p{Lu}[\p{Letter}\p{Number}_-]*\.$/u.test(suffix) &&
       /^[\p{Lu}\p{Number}_-]+(?=\s|[/.]|$)/u.test(following);
   const initial = caseNeutral ? /^\p{Cased}\p{M}*\./u : /^\p{Lu}\./u;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -766,7 +766,7 @@ function isUnspacedSentenceBoundary(
         hostnameLabel === hostnameLabel.toLowerCase() ||
         hostnameLabel === hostnameLabel.toUpperCase()));
   const dottedIdentifier = caseNeutral
-    ? /(?:^|[^\p{Letter}\p{Mark}\p{Number}_-])\p{Mark}*\p{Cased}[\p{Letter}\p{Mark}\p{Number}_-]*\.$/u.test(
+    ? /(?:^|[^\p{Letter}\p{Mark}\p{Number}_-])(?:[\p{Letter}\p{Mark}\p{Number}_-]*\p{Cased}|\p{Mark})[\p{Letter}\p{Mark}\p{Number}_-]*\.$/u.test(
         suffix,
       ) && /^(?:[\p{Cased}\p{Number}_-]\p{M}*){1,2}(?=\s|[/.]|$)/u.test(following)
     : /\b\p{Lu}[\p{Letter}\p{Number}_-]*\.$/u.test(suffix) &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -733,6 +733,28 @@ function isUnspacedDelimitedSentenceStart(
   );
 }
 
+function caseNeutralIdentifierContext(
+  input: string,
+  index: number,
+  suffixStart: number,
+): { suffix: string; evidence: boolean } {
+  let start = suffixStart;
+  if (/^\p{Mark}/u.test(input.slice(start, index + 1))) {
+    while (start > 0 && /^\p{Mark}$/u.test(input[start - 1])) {
+      start--;
+    }
+    if (start > 0) {
+      start--;
+    }
+  }
+  const suffix = input.slice(start, index + 1);
+  const token = suffix.match(/[\p{Letter}\p{Mark}\p{Number}_-]+\.$/u)?.[0] ?? '';
+  const evidence =
+    (start < suffixStart && token.length === suffix.length && /^\p{Cased}$/u.test(input[start])) ||
+    /[A-Za-z0-9_-]/.test(token.replace(/İ\p{Mark}*|i\p{Mark}+/gu, ''));
+  return { suffix, evidence };
+}
+
 function isUnspacedSentenceBoundary(
   input: string,
   index: number,
@@ -754,8 +776,7 @@ function isUnspacedSentenceBoundary(
 
   const suffixStart = Math.max(0, index + 1 - sentenceSuffixLength);
   const suffix = input.slice(suffixStart, index + 1);
-  const identifierSuffix =
-    suffixStart > 0 && /^\p{Mark}/u.test(suffix) ? `${input[suffixStart - 1]}${suffix}` : suffix;
+  const identifier = caseNeutralIdentifierContext(input, index, suffixStart);
   const following = input.slice(next);
   const insideAddress =
     precedingToken.includes('@') && !/@[^\s.]+(?:\.[^\s.]+)+\.$/u.test(precedingToken);
@@ -769,9 +790,11 @@ function isUnspacedSentenceBoundary(
         hostnameLabel === hostnameLabel.toLowerCase() ||
         hostnameLabel === hostnameLabel.toUpperCase()));
   const dottedIdentifier = caseNeutral
-    ? /(?:^|[^\p{Letter}\p{Mark}\p{Number}_-])(?=[\p{Letter}\p{Mark}\p{Number}_-]*[A-Za-z0-9_İ-])(?:[\p{Letter}\p{Mark}\p{Number}_-]*\p{Cased}|\p{Mark})[\p{Letter}\p{Mark}\p{Number}_-]*\.$/u.test(
-        identifierSuffix,
-      ) && /^(?:[\p{Cased}\p{Number}_-]\p{M}*){1,2}(?=\s|[/.]|$)/u.test(following)
+    ? identifier.evidence &&
+      /(?:^|[^\p{Letter}\p{Mark}\p{Number}_-])(?:[\p{Letter}\p{Mark}\p{Number}_-]*\p{Cased}|\p{Mark})[\p{Letter}\p{Mark}\p{Number}_-]*\.$/u.test(
+        identifier.suffix,
+      ) &&
+      /^(?:[\p{Cased}\p{Number}_-]\p{M}*){1,2}(?=\s|[/.]|$)/u.test(following)
     : /\b\p{Lu}[\p{Letter}\p{Number}_-]*\.$/u.test(suffix) &&
       /^[\p{Lu}\p{Number}_-]+(?=\s|[/.]|$)/u.test(following);
   const initial = caseNeutral ? /^\p{Cased}\p{M}*\./u : /^\p{Lu}\./u;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -752,7 +752,7 @@ function caseNeutralIdentifierContext(input: string, index: number): boolean {
     .replace(/[Ii]\u0307\p{Mark}*/gu, '')
     .replace(/[A-Za-z]\p{Mark}/gu, (cluster) => cluster.normalize('NFC'));
   return (
-    /[a-z0-9_]/i.test(stableAscii) ||
+    /[a-jl-z0-9_]/i.test(stableAscii) ||
     (/\p{Script=Latin}/u.test(token) && /\p{Script=Greek}/u.test(token))
   );
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -733,18 +733,9 @@ function isUnspacedDelimitedSentenceStart(
   );
 }
 
-function caseNeutralIdentifierContext(input: string, index: number, suffixStart: number): boolean {
-  let start = suffixStart;
-  if (/^\p{Mark}/u.test(input.slice(start, index + 1))) {
-    while (start > 0 && /^\p{Mark}$/u.test(input[start - 1])) {
-      start--;
-    }
-    if (start > 0) {
-      start--;
-    }
-  }
+function caseNeutralIdentifierContext(input: string, index: number): boolean {
   let tokenStart = index;
-  while (tokenStart > start) {
+  while (tokenStart > 0) {
     const previousUnit = input.charCodeAt(tokenStart - 1);
     const width = previousUnit >= 0xdc_00 && previousUnit <= 0xdf_ff ? 2 : 1;
     const character = input.slice(tokenStart - width, tokenStart);
@@ -760,7 +751,7 @@ function caseNeutralIdentifierContext(input: string, index: number, suffixStart:
   const normalized = token.normalize('NFC').toLowerCase().normalize('NFC');
   const stableAscii = normalized.replace(/i\u0307\p{Mark}*/gu, '');
   return (
-    /[a-z0-9_-]/.test(stableAscii) ||
+    /[a-z0-9_]/.test(stableAscii) ||
     (/\p{Script=Latin}/u.test(normalized) && /\p{Script=Greek}/u.test(normalized))
   );
 }
@@ -784,9 +775,8 @@ function isUnspacedSentenceBoundary(
     return !insideUrl;
   }
 
-  const suffixStart = Math.max(0, index + 1 - sentenceSuffixLength);
-  const suffix = input.slice(suffixStart, index + 1);
-  const identifier = caseNeutral && caseNeutralIdentifierContext(input, index, suffixStart);
+  const suffix = input.slice(Math.max(0, index + 1 - sentenceSuffixLength), index + 1);
+  const identifier = caseNeutral && caseNeutralIdentifierContext(input, index);
   const following = input.slice(next);
   const insideAddress =
     precedingToken.includes('@') && !/@[^\s.]+(?:\.[^\s.]+)+\.$/u.test(precedingToken);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -748,11 +748,12 @@ function caseNeutralIdentifierContext(input: string, index: number): boolean {
   if (!/\p{Cased}/u.test(token)) {
     return false;
   }
-  const normalized = token.normalize('NFC').toLowerCase().normalize('NFC');
-  const stableAscii = normalized.replace(/i\u0307\p{Mark}*/gu, '');
+  const stableAscii = token
+    .replace(/[Ii]\u0307\p{Mark}*/gu, '')
+    .replace(/[A-Za-z]\p{Mark}/gu, (cluster) => cluster.normalize('NFC'));
   return (
-    /[a-z0-9_]/.test(stableAscii) ||
-    (/\p{Script=Latin}/u.test(normalized) && /\p{Script=Greek}/u.test(normalized))
+    /[a-z0-9_]/i.test(stableAscii) ||
+    (/\p{Script=Latin}/u.test(token) && /\p{Script=Greek}/u.test(token))
   );
 }
 
@@ -799,18 +800,18 @@ function isUnspacedSentenceBoundary(
     : /\b\p{Lu}\.$/u;
   const nextInitial = caseNeutral ? /^\p{Cased}\p{M}*(?=\s|$)/u : /^\p{Lu}(?=\s|$)/u;
   const gateSuffix = caseNeutral ? suffix.toLowerCase() : suffix;
+  const contextChangingGreekInitial = /^[Σσς]\p{M}+\.\p{Cased}/u.test(following);
   const continuesAbbreviation =
     abbrvReg.test(gateSuffix) &&
     (excepReg.test(gateSuffix) ||
       (geographicAcronymReg.test(gateSuffix) && geographicContinuationReg.test(following)));
   return !(
     continuesAbbreviation ||
-    initial.test(following) ||
+    ((initial.test(following) || dottedIdentifier) && !contextChangingGreekInitial) ||
     (trailingInitial.test(suffix) && nextInitial.test(following)) ||
     /^[^\s]*@/.test(following) ||
     insideAddress ||
-    insideHostname ||
-    dottedIdentifier
+    insideHostname
   );
 }
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -664,7 +664,7 @@ describe('Utility Functions', () => {
       expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([input.toLowerCase()]);
     });
 
-    test.each(['κόσμος', 'κόσμος'])(
+    test.each(['κόσμος', 'κόσμος', '\u0301κόσμος'])(
       'preserves adjacent sentences after ordinary non-ASCII word %s',
       (word) => {
         const input = `${word}.No one answered.`;

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -684,6 +684,19 @@ describe('Utility Functions', () => {
       );
     });
 
+    test('does not normalize a Kelvin sign into ASCII identifier evidence', () => {
+      const input = 'K.No one answered.';
+      expect(segmentCaseNeutrally(input)).toEqual(['K.', 'No one answered.']);
+      expect(rouge.l(input, 'K. No one answered.', { caseSensitive: false })).toBe(1);
+    });
+
+    test('preserves case-folding context around marked Greek initials', () => {
+      const input = 'A.Σ́.No one answered.';
+      expect(rouge.n(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
+      expect(rouge.s(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
+      expect(rouge.l(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
+    });
+
     test('does not let a truncated mark qualify an unrelated later word', () => {
       const input = 'İ?0b/]]\té.𝒜B';
       expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
@@ -1434,6 +1447,13 @@ describe('Utility Functions', () => {
 
       test('scans recovered combining-mark prefixes without backtracking', () => {
         const input = `I${'\u0301'.repeat(16_000)}/aaaaaaa.X`;
+        const started = Date.now();
+        expect(segmentCaseNeutrally(input)).toEqual([input]);
+        expect(Date.now() - started).toBeLessThan(TIMEOUT_MS);
+      });
+
+      test('scans differently ordered combining marks without quadratic normalization', () => {
+        const input = `A${'\u0315\u0316'.repeat(32_000)}.X`;
         const started = Date.now();
         expect(segmentCaseNeutrally(input)).toEqual([input]);
         expect(Date.now() - started).toBeLessThan(TIMEOUT_MS);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -663,6 +663,7 @@ describe('Utility Functions', () => {
       'αİééééééé.X more',
       'path K.AB more',
       'path K.No more',
+      'K.No more',
     ])('preserves case-expanded dotted identifiers: %s', (input) => {
       expect(segmentCaseNeutrally(input)).toEqual([input]);
       expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([input.toLowerCase()]);
@@ -677,6 +678,7 @@ describe('Utility Functions', () => {
       'İşğüşğüşğ',
       'I\u0307ş',
       'Ḱ',
+      'g\u0303',
     ])('preserves adjacent sentences after ordinary non-ASCII word %s', (word) => {
       const input = `${word}.No one answered.`;
       expect(segmentCaseNeutrally(input)).toEqual([`${word}.`, 'No one answered.']);
@@ -702,11 +704,22 @@ describe('Utility Functions', () => {
       },
     );
 
-    test('preserves an adjacent Unicode one-letter sentence before an I clause', () => {
-      const input = 'Я.I agree.';
-      expect(segmentCaseNeutrally(input)).toEqual(['Я.', 'I agree.']);
+    test.each(['I agree.', 'I 100% agree.'])(
+      'preserves an adjacent Unicode one-letter sentence before %s',
+      (continuation) => {
+        const input = `Я.${continuation}`;
+        expect(segmentCaseNeutrally(input)).toEqual(['Я.', continuation]);
+        for (const score of [rouge.n, rouge.s, rouge.l]) {
+          expect(score(input, `Я. ${continuation}`, { caseSensitive: false })).toBe(1);
+        }
+      },
+    );
+
+    test('does not mistake a decomposed two-letter sentence start for an identifier', () => {
+      const input = 'Stop.E\u0301l left.';
+      expect(segmentCaseNeutrally(input)).toEqual(['Stop.', 'E\u0301l left.']);
       for (const score of [rouge.n, rouge.s, rouge.l]) {
-        expect(score(input, 'Я. I agree.', { caseSensitive: false })).toBe(1);
+        expect(score(input, 'Stop. E\u0301l left.', { caseSensitive: false })).toBe(1);
       }
     });
 
@@ -1477,9 +1490,24 @@ describe('Utility Functions', () => {
       test('scans differently ordered combining marks without quadratic normalization', () => {
         const input = `A${'\u0315\u0316'.repeat(32_000)}.X`;
         const started = Date.now();
-        expect(segmentCaseNeutrally(input)).toEqual([input]);
+        expect(segmentCaseNeutrally(input).join('')).toBe(input);
         expect(Date.now() - started).toBeLessThan(TIMEOUT_MS);
       });
+
+      test('streams repeated marked clusters within a constrained heap', () => {
+        expectBundledScriptToPass(
+          `
+            const summary = 'A\\u0303'.repeat(4_000_000) + '.X';
+            const sentences = module.exports.sentenceSegment(summary, { caseNeutral: true });
+            if (sentences.join('') !== summary) {
+              throw new Error('Marked-cluster content changed');
+            }
+            process.stdout.write('ok');
+          `,
+          20_000,
+          ['--max-old-space-size=80'],
+        );
+      }, 25_000);
 
       test('segments large spaced-ellipsis runs within a constrained heap', () => {
         expectBundledScriptToPass(

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -662,6 +662,7 @@ describe('Utility Functions', () => {
       'İ́ΑΑΑΑΑΑΑΑ.X more',
       'αİééééééé.X more',
       'path K.AB more',
+      'path K.No more',
     ])('preserves case-expanded dotted identifiers: %s', (input) => {
       expect(segmentCaseNeutrally(input)).toEqual([input]);
       expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([input.toLowerCase()]);
@@ -700,6 +701,14 @@ describe('Utility Functions', () => {
         }
       },
     );
+
+    test('preserves an adjacent Unicode one-letter sentence before an I clause', () => {
+      const input = 'Я.I agree.';
+      expect(segmentCaseNeutrally(input)).toEqual(['Я.', 'I agree.']);
+      for (const score of [rouge.n, rouge.s, rouge.l]) {
+        expect(score(input, 'Я. I agree.', { caseSensitive: false })).toBe(1);
+      }
+    });
 
     test.each(['A.Σ́.No one answered.', "A.Σ́.'No one answered.", 'A.Σ́."No one answered.'])(
       'preserves case-folding context around marked Greek initial in %s',

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -664,6 +664,12 @@ describe('Utility Functions', () => {
       expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([input.toLowerCase()]);
     });
 
+    test('preserves adjacent sentences after ordinary non-ASCII words', () => {
+      const input = 'κόσμος.No one answered.';
+      expect(segmentCaseNeutrally(input)).toEqual(['κόσμος.', 'No one answered.']);
+      expect(rouge.l(input, 'κόσμος. No one answered.', { caseSensitive: false })).toBe(1);
+    });
+
     test('keeps bracketed references inside their sentence', () => {
       expect(ss('He wrote (see Fig.[2] for details). Next.')).toEqual([
         'He wrote (see Fig.[2] for details).',

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -659,19 +659,31 @@ describe('Utility Functions', () => {
       'İbBİσİU.İ',
       '中文README.MD before continuing.',
       'İ12345678.X more',
+      'İ́ΑΑΑΑΑΑΑΑ.X more',
     ])('preserves case-expanded dotted identifiers: %s', (input) => {
       expect(segmentCaseNeutrally(input)).toEqual([input]);
       expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([input.toLowerCase()]);
     });
 
-    test.each(['κόσμος', 'κόσμος', '\u0301κόσμος'])(
+    test.each(['κόσμος', 'κόσμος', '\u0301κόσμος', 'İş'])(
       'preserves adjacent sentences after ordinary non-ASCII word %s',
       (word) => {
         const input = `${word}.No one answered.`;
         expect(segmentCaseNeutrally(input)).toEqual([`${word}.`, 'No one answered.']);
         expect(rouge.l(input, `${word}. No one answered.`, { caseSensitive: false })).toBe(1);
+        expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+          [`${word}.`, 'No one answered.'].map((sentence) => sentence.toLowerCase()),
+        );
       },
     );
+
+    test('does not let a truncated mark qualify an unrelated later word', () => {
+      const input = 'İ?0b/]]\té.𝒜B';
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+        segmentCaseNeutrally(input).map((sentence) => sentence.toLowerCase()),
+      );
+      expect(rouge.l(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
+    });
 
     test('keeps bracketed references inside their sentence', () => {
       expect(ss('He wrote (see Fig.[2] for details). Next.')).toEqual([

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -660,22 +660,29 @@ describe('Utility Functions', () => {
       '中文README.MD before continuing.',
       'İ12345678.X more',
       'İ́ΑΑΑΑΑΑΑΑ.X more',
+      'αİééééééé.X more',
     ])('preserves case-expanded dotted identifiers: %s', (input) => {
       expect(segmentCaseNeutrally(input)).toEqual([input]);
       expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([input.toLowerCase()]);
     });
 
-    test.each(['κόσμος', 'κόσμος', '\u0301κόσμος', 'İş', 'İşğüşğüşğ', 'I\u0307ş', 'Ḱ'])(
-      'preserves adjacent sentences after ordinary non-ASCII word %s',
-      (word) => {
-        const input = `${word}.No one answered.`;
-        expect(segmentCaseNeutrally(input)).toEqual([`${word}.`, 'No one answered.']);
-        expect(rouge.l(input, `${word}. No one answered.`, { caseSensitive: false })).toBe(1);
-        expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
-          [`${word}.`, 'No one answered.'].map((sentence) => sentence.toLowerCase()),
-        );
-      },
-    );
+    test.each([
+      'κόσμος',
+      'κόσμος',
+      '\u0301κόσμος',
+      'κόσμος-κόσμος',
+      'İş',
+      'İşğüşğüşğ',
+      'I\u0307ş',
+      'Ḱ',
+    ])('preserves adjacent sentences after ordinary non-ASCII word %s', (word) => {
+      const input = `${word}.No one answered.`;
+      expect(segmentCaseNeutrally(input)).toEqual([`${word}.`, 'No one answered.']);
+      expect(rouge.l(input, `${word}. No one answered.`, { caseSensitive: false })).toBe(1);
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+        [`${word}.`, 'No one answered.'].map((sentence) => sentence.toLowerCase()),
+      );
+    });
 
     test('does not let a truncated mark qualify an unrelated later word', () => {
       const input = 'İ?0b/]]\té.𝒜B';

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -661,6 +661,7 @@ describe('Utility Functions', () => {
       'İ12345678.X more',
       'İ́ΑΑΑΑΑΑΑΑ.X more',
       'αİééééééé.X more',
+      'path K.AB more',
     ])('preserves case-expanded dotted identifiers: %s', (input) => {
       expect(segmentCaseNeutrally(input)).toEqual([input]);
       expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([input.toLowerCase()]);
@@ -700,12 +701,14 @@ describe('Utility Functions', () => {
       },
     );
 
-    test('preserves case-folding context around marked Greek initials', () => {
-      const input = 'A.Σ́.No one answered.';
-      expect(rouge.n(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
-      expect(rouge.s(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
-      expect(rouge.l(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
-    });
+    test.each(['A.Σ́.No one answered.', "A.Σ́.'No one answered.", 'A.Σ́."No one answered.'])(
+      'preserves case-folding context around marked Greek initial in %s',
+      (input) => {
+        expect(rouge.n(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
+        expect(rouge.s(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
+        expect(rouge.l(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
+      },
+    );
 
     test('does not let a truncated mark qualify an unrelated later word', () => {
       const input = 'İ?0b/]]\té.𝒜B';

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -664,11 +664,14 @@ describe('Utility Functions', () => {
       expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([input.toLowerCase()]);
     });
 
-    test('preserves adjacent sentences after ordinary non-ASCII words', () => {
-      const input = 'κόσμος.No one answered.';
-      expect(segmentCaseNeutrally(input)).toEqual(['κόσμος.', 'No one answered.']);
-      expect(rouge.l(input, 'κόσμος. No one answered.', { caseSensitive: false })).toBe(1);
-    });
+    test.each(['κόσμος', 'κόσμος'])(
+      'preserves adjacent sentences after ordinary non-ASCII word %s',
+      (word) => {
+        const input = `${word}.No one answered.`;
+        expect(segmentCaseNeutrally(input)).toEqual([`${word}.`, 'No one answered.']);
+        expect(rouge.l(input, `${word}. No one answered.`, { caseSensitive: false })).toBe(1);
+      },
+    );
 
     test('keeps bracketed references inside their sentence', () => {
       expect(ss('He wrote (see Fig.[2] for details). Next.')).toEqual([

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -647,6 +647,14 @@ describe('Utility Functions', () => {
       },
     );
 
+    test.each(['A.İ', 'Alpha.İ', 'U.Sİ', 'é.İ.', '1.İ.', 'İ.İ.', 'Sİ.𝒜', 'Drİ1.İ', 'İbBİσİU.İ'])(
+      'preserves case-expanded dotted identifiers: %s',
+      (input) => {
+        expect(segmentCaseNeutrally(input)).toEqual([input]);
+        expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([input.toLowerCase()]);
+      },
+    );
+
     test('keeps bracketed references inside their sentence', () => {
       expect(ss('He wrote (see Fig.[2] for details). Next.')).toEqual([
         'He wrote (see Fig.[2] for details).',
@@ -2946,6 +2954,15 @@ describe('Core Functions', () => {
         expect(score(mixedCase, lowerCase, { caseSensitive: false })).toBe(1);
       },
     );
+
+    test.each([
+      ['ROUGE-N', n],
+      ['ROUGE-S', s],
+      ['ROUGE-L', l],
+    ] as const)('%s preserves Unicode case expansion across dotted identifiers', (_name, score) => {
+      const input = 'A.İ Beta';
+      expect(score(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
+    });
 
     test('ROUGE-L passes original text to custom segmenters before case folding', () => {
       const segmenter = jest.fn((input: string): string[] => [input]);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -665,7 +665,7 @@ describe('Utility Functions', () => {
       expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([input.toLowerCase()]);
     });
 
-    test.each(['κόσμος', 'κόσμος', '\u0301κόσμος', 'İş'])(
+    test.each(['κόσμος', 'κόσμος', '\u0301κόσμος', 'İş', 'İşğüşğüşğ', 'I\u0307ş', 'Ḱ'])(
       'preserves adjacent sentences after ordinary non-ASCII word %s',
       (word) => {
         const input = `${word}.No one answered.`;
@@ -1424,6 +1424,13 @@ describe('Utility Functions', () => {
     // Using 500ms threshold to account for CI environment variability
     describe('ReDoS prevention', () => {
       const TIMEOUT_MS = 500;
+
+      test('scans recovered combining-mark prefixes without backtracking', () => {
+        const input = `I${'\u0301'.repeat(16_000)}/aaaaaaa.X`;
+        const started = Date.now();
+        expect(segmentCaseNeutrally(input)).toEqual([input]);
+        expect(Date.now() - started).toBeLessThan(TIMEOUT_MS);
+      });
 
       test('segments large spaced-ellipsis runs within a constrained heap', () => {
         expectBundledScriptToPass(

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -647,13 +647,22 @@ describe('Utility Functions', () => {
       },
     );
 
-    test.each(['A.İ', 'Alpha.İ', 'U.Sİ', 'é.İ.', '1.İ.', 'İ.İ.', 'Sİ.𝒜', 'Drİ1.İ', 'İbBİσİU.İ'])(
-      'preserves case-expanded dotted identifiers: %s',
-      (input) => {
-        expect(segmentCaseNeutrally(input)).toEqual([input]);
-        expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([input.toLowerCase()]);
-      },
-    );
+    test.each([
+      'A.İ',
+      'Alpha.İ',
+      'U.Sİ',
+      'é.İ.',
+      '1.İ.',
+      'İ.İ.',
+      'Sİ.𝒜',
+      'Drİ1.İ',
+      'İbBİσİU.İ',
+      '中文README.MD before continuing.',
+      'İ12345678.X more',
+    ])('preserves case-expanded dotted identifiers: %s', (input) => {
+      expect(segmentCaseNeutrally(input)).toEqual([input]);
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual([input.toLowerCase()]);
+    });
 
     test('keeps bracketed references inside their sentence', () => {
       expect(ss('He wrote (see Fig.[2] for details). Next.')).toEqual([
@@ -2960,8 +2969,9 @@ describe('Core Functions', () => {
       ['ROUGE-S', s],
       ['ROUGE-L', l],
     ] as const)('%s preserves Unicode case expansion across dotted identifiers', (_name, score) => {
-      const input = 'A.İ Beta';
-      expect(score(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
+      for (const input of ['A.İ Beta', 'İ12345678.X more']) {
+        expect(score(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
+      }
     });
 
     test('ROUGE-L passes original text to custom segmenters before case folding', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -684,11 +684,21 @@ describe('Utility Functions', () => {
       );
     });
 
-    test('does not normalize a Kelvin sign into ASCII identifier evidence', () => {
-      const input = 'K.No one answered.';
-      expect(segmentCaseNeutrally(input)).toEqual(['K.', 'No one answered.']);
-      expect(rouge.l(input, 'K. No one answered.', { caseSensitive: false })).toBe(1);
-    });
+    test.each(['K', 'KÁ'])(
+      'does not normalize Kelvin sign %s into ASCII identifier evidence',
+      (word) => {
+        const input = `${word}.No one answered.`;
+        const expected = [`${word}.`, 'No one answered.'];
+        expect(segmentCaseNeutrally(input)).toEqual(expected);
+        expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+          expected.map((sentence) => sentence.toLowerCase()),
+        );
+        for (const score of [rouge.n, rouge.s, rouge.l]) {
+          expect(score(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
+          expect(score(input, `${word}. No one answered.`, { caseSensitive: false })).toBe(1);
+        }
+      },
+    );
 
     test('preserves case-folding context around marked Greek initials', () => {
       const input = 'A.Σ́.No one answered.';


### PR DESCRIPTION
## Summary

- Treat Unicode combining marks as part of case-neutral dotted identifiers and initials without mistaking decomposed ordinary words or any casing of Kelvin signs for identifiers.
- Keep ROUGE-N, ROUGE-S, and ROUGE-L scores unchanged when case folding expands a character such as `İ`.
- Preserve ordinary `K` identifiers and Greek final-sigma casing context, including quoted continuations, with bounded-memory Unicode scanning.

## Verification

- `npm run type-check`
- `npx biome ci . --error-on-warnings`
- `npm run test:package`
- `npm test -- --runInBand` (784 tests)
- 100,000 randomized conservation, case-folding, identity, and scoring checks: zero failures.
- 64,000 differently ordered combining marks are segmented in 18 ms without quadratic normalization.
- Eight million alternating marked characters complete under an 80 MB Node heap.
- 160 upstream English sentence-segmentation cases: no new regressions.
