### PR TITLE
fix: segment embedded and parenthesized lists

### DIFF
--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -11,7 +11,7 @@ import {
 export * from './utils';
 
 const whitespaceOnlyReg = /^[\s\u0085]*$/;
-const maxLcsSentencePairs = 1_000_000;
+const maxLcsSentencePairs = 100_000;
 
 /** Options for ROUGE-N evaluation */
 export interface RougeNOptions {

--- a/src/rouge.ts
+++ b/src/rouge.ts
@@ -11,6 +11,7 @@ import {
 export * from './utils';
 
 const whitespaceOnlyReg = /^[\s\u0085]*$/;
+const maxLcsSentencePairs = 1_000_000;
 
 /** Options for ROUGE-N evaluation */
 export interface RougeNOptions {
@@ -427,6 +428,15 @@ export function l(cand: string, ref: string, opts?: RougeLOptions): number {
 
   if (candLength === 0 || refLength === 0) {
     return 0;
+  }
+
+  if (
+    segmenter === utils.sentenceSegment &&
+    getLcs === utils.lcs &&
+    getLcsIndices === undefined &&
+    candSents.length > maxLcsSentencePairs / refSents.length
+  ) {
+    throw new RangeError('ROUGE-L sentence comparison exceeds the work limit');
   }
 
   const matches = countSummaryLcsMatches(candSents, refSents, remaining, getLcs, getLcsIndices);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -462,7 +462,7 @@ interface ListScanState {
 function listQuoteCloser(input: string, index: number): string | undefined {
   const character = input[index];
   if (character === '"') {
-    return '"';
+    return opensDoubleQuote(input, index, false) ? '"' : undefined;
   }
   if (
     character === "'" &&
@@ -594,7 +594,7 @@ function findListCandidate(
 
     const family = listMarkerFamily(marker, caseNeutral);
     const first = firstByFamily.get(family.source);
-    const identity = caseNeutral ? marker.toUpperCase().toLowerCase() : marker;
+    const identity = caseNeutral ? marker.toLowerCase().toUpperCase().toLowerCase() : marker;
     const joinedNameInitial =
       /^\p{Cased}\p{M}*\.$/u.test(marker) &&
       /(?:\b(?:and|or)|&)\s*$/i.test(input.slice(Math.max(0, current.index - 8), current.index));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -487,7 +487,11 @@ function segmentList(input: string, caseNeutral: boolean): string[] | undefined 
   }
 
   const prefix = input.slice(0, current.index).trim();
-  if (prefix.length > 0 && firstMarker.trim() === next[0].trim()) {
+  const ambiguousMarker = /^(?:\p{Lu}|\d+)\.$/u.test(firstMarker.trim());
+  if (
+    prefix.length > 0 &&
+    (firstMarker.trim() === next[0].trim() || (ambiguousMarker && !/[.!?:]$/.test(prefix)))
+  ) {
     return undefined;
   }
   const segments = prefix.length === 0 ? [] : sentenceSegment(prefix, { caseNeutral });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -564,7 +564,7 @@ interface ListCandidate {
 function listMarkerFamily(marker: string, caseNeutral: boolean): RegExp {
   let start: string;
   if (/\d/.test(marker)) {
-    start = '\\d';
+    start = '^\\s*(?:[•⁃]\\s*)?\\d';
   } else if (caseNeutral) {
     start = '^\\s*\\p{Cased}';
   } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -456,11 +456,17 @@ function nextListMarker(
   input: string,
   expression: RegExp,
   family?: RegExp,
+  expectedNumber?: number,
 ): RegExpExecArray | null {
   let marker = expression.exec(input);
   while (marker !== null) {
+    const closesParenthesis =
+      marker[0].endsWith(')') &&
+      input.lastIndexOf('(', marker.index) > input.lastIndexOf(')', marker.index);
     if (
       (family === undefined || family.test(marker[0])) &&
+      (expectedNumber === undefined || Number(marker[0].match(/\d+/)?.[0]) === expectedNumber) &&
+      !closesParenthesis &&
       (marker.index === 0 ||
         !/\b(?:section|chapter|page|figure|table|paragraph|article|clause)$/i.test(
           input.slice(Math.max(0, marker.index - 24), marker.index).trimEnd(),
@@ -473,27 +479,56 @@ function nextListMarker(
   return null;
 }
 
+interface ListCandidate {
+  current: RegExpExecArray;
+  next: RegExpExecArray;
+  family: RegExp | undefined;
+  expectedNumber: number | undefined;
+  prefix: string;
+}
+
+function findListCandidate(
+  input: string,
+  caseNeutral: boolean,
+  expression: RegExp,
+): ListCandidate | undefined {
+  let current = nextListMarker(input, expression);
+  while (current !== null) {
+    const marker = current[0].trim();
+    const preceding = input.slice(0, current.index);
+    const prefix = preceding.trim();
+    const ambiguousMarker =
+      /^\d+\.$/.test(marker) || (caseNeutral ? /^\p{Cased}\.$/u : /^\p{Lu}\.$/u).test(marker);
+    const startsAfterBoundary = /[.!?:]$/.test(prefix) || /[\r\n]\s*$/.test(preceding);
+
+    if (prefix.length === 0 || !ambiguousMarker || startsAfterBoundary) {
+      const family = [/\d/, /^\s*\p{Lu}/u, /^\s*\p{Ll}/u].find((pattern) => pattern.test(marker));
+      const markerNumber = marker.match(/\d+/)?.[0];
+      const expectedNumber =
+        prefix.length > 0 && markerNumber !== undefined ? Number(markerNumber) + 1 : undefined;
+      const next = nextListMarker(input, expression, family, expectedNumber);
+      if (next !== null && (prefix.length === 0 || marker !== next[0].trim())) {
+        return { current, next, family, expectedNumber, prefix };
+      }
+    }
+
+    expression.lastIndex = current.index + current[0].length;
+    current = nextListMarker(input, expression);
+  }
+  return undefined;
+}
+
 function segmentList(input: string, caseNeutral: boolean): string[] | undefined {
   const expression = new RegExp(listMarkerReg);
-  let current = nextListMarker(input, expression);
-  if (current === null) {
-    return undefined;
-  }
-  const firstMarker = current[0];
-  const family = [/\d/, /^\s*\p{Lu}/u, /^\s*\p{Ll}/u].find((pattern) => pattern.test(firstMarker));
-  let next = nextListMarker(input, expression, family);
-  if (next === null) {
+  const candidate = findListCandidate(input, caseNeutral, expression);
+  if (candidate === undefined) {
     return undefined;
   }
 
-  const prefix = input.slice(0, current.index).trim();
-  const ambiguousMarker = /^(?:\p{Lu}|\d+)\.$/u.test(firstMarker.trim());
-  if (
-    prefix.length > 0 &&
-    (firstMarker.trim() === next[0].trim() || (ambiguousMarker && !/[.!?:]$/.test(prefix)))
-  ) {
-    return undefined;
-  }
+  let current: RegExpExecArray | null = candidate.current;
+  let next: RegExpExecArray | null = candidate.next;
+  let expectedNumber = candidate.expectedNumber;
+  const { family, prefix } = candidate;
   const segments = prefix.length === 0 ? [] : sentenceSegment(prefix, { caseNeutral });
   do {
     const body = input.slice(current.index + current[0].length, next?.index ?? input.length).trim();
@@ -503,7 +538,10 @@ function segmentList(input: string, caseNeutral: boolean): string[] | undefined 
     }
     segments.push(`${current[0].trim()} ${sentences[0]}`, ...sentences.slice(1));
     current = next;
-    next = nextListMarker(input, expression, family);
+    if (expectedNumber !== undefined) {
+      expectedNumber++;
+    }
+    next = nextListMarker(input, expression, family, expectedNumber);
   } while (current !== null);
   return segments;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,7 +121,7 @@ const closingDelimiterReg = /[\])}>"']/;
 const openingBracketReg = /[([{<]/;
 const closingBracketReg = /[\])}>]/;
 const listMarkerReg =
-  /(?:^|\s)(?:(?:[•⁃]\s*)?\d+|\p{Cased}\p{M}*)(?:\.\)|[.)])(?=\s+["'([{<]*\p{Cased})/gu;
+  /(?:^|\s)(?:(?:[•⁃]\s*)?\d+|\p{Cased}\p{M}*)(?:\.\)|[.)])(?=\s+["'([{<]*[\p{Letter}\p{Number}\p{Symbol}])/gu;
 const nestedListDepth = Symbol('nestedListDepth');
 const maxNestedListDepth = 32;
 const geographicAcronymReg = /\bU\.S(?:\.A)?\.$/i;
@@ -459,9 +459,17 @@ interface ListScanState {
   quote: string | undefined;
 }
 
-function listQuoteCloser(character: string): string | undefined {
+function listQuoteCloser(input: string, index: number): string | undefined {
+  const character = input[index];
   if (character === '"') {
     return '"';
+  }
+  if (
+    character === "'" &&
+    (index === 0 || /^[\s\p{Punctuation}]$/u.test(input[index - 1])) &&
+    !/^\p{Number}$/u.test(characterAt(input, index + 1))
+  ) {
+    return "'";
   }
   if (character === '“') {
     return '”';
@@ -471,14 +479,15 @@ function listQuoteCloser(character: string): string | undefined {
 
 function advanceListScan(input: string, end: number, state: ListScanState): void {
   while (state.cursor < end) {
-    const character = input[state.cursor++];
+    const index = state.cursor++;
+    const character = input[index];
     if (state.quote !== undefined) {
       if (character === state.quote) {
         state.quote = undefined;
       }
       continue;
     }
-    const quote = listQuoteCloser(character);
+    const quote = listQuoteCloser(input, index);
     if (quote !== undefined) {
       state.quote = quote;
       continue;
@@ -555,7 +564,9 @@ function listMarkerFamily(marker: string, caseNeutral: boolean): RegExp {
   if (caseNeutral) {
     return /^\s*\p{Cased}/u;
   }
-  return /^[\p{Lu}\p{Lt}]/u.test(marker) ? /^\s*[\p{Lu}\p{Lt}]/u : /^\s*\p{Ll}/u;
+  return /^[\p{Uppercase}\p{Lt}]/u.test(marker)
+    ? /^\s*[\p{Uppercase}\p{Lt}]/u
+    : /^\s*\p{Lowercase}/u;
 }
 
 function findListCandidate(
@@ -565,6 +576,9 @@ function findListCandidate(
   state: ListScanState,
 ): ListCandidate | undefined {
   const firstByFamily = new Map<string, { marker: RegExpExecArray; emptyPrefix: boolean }>();
+  let deferred:
+    | { candidate: ListCandidate; expressionIndex: number; state: ListScanState }
+    | undefined;
   let current = nextListMarker(input, expression, state);
   while (current !== null) {
     const marker = current[0].trim();
@@ -578,11 +592,29 @@ function findListCandidate(
       ? previousMarker?.toLowerCase() !== marker.toLowerCase()
       : previousMarker !== marker;
     if (first !== undefined && (first.emptyPrefix || distinctMarker)) {
-      return {
+      const candidate: ListCandidate = {
         current: first.marker,
         next: current,
         family,
         prefix: input.slice(0, first.marker.index).trim(),
+      };
+      const hasEarlierFamily = [...firstByFamily.values()].some(
+        (entry) => entry.marker.index < first.marker.index,
+      );
+      const firstNumber = Number(previousMarker?.match(/^\d+/)?.[0]);
+      const currentNumber = Number(marker.match(/^\d+/)?.[0]);
+      const distantNumber =
+        Number.isFinite(firstNumber) &&
+        Number.isFinite(currentNumber) &&
+        Math.abs(currentNumber - firstNumber) > 10 &&
+        !context.boundary;
+      if (!(hasEarlierFamily || distantNumber)) {
+        return candidate;
+      }
+      deferred ??= {
+        candidate,
+        expressionIndex: expression.lastIndex,
+        state: { ...state },
       };
     }
 
@@ -592,7 +624,11 @@ function findListCandidate(
 
     current = nextListMarker(input, expression, state);
   }
-  return undefined;
+  if (deferred !== undefined) {
+    expression.lastIndex = deferred.expressionIndex;
+    Object.assign(state, deferred.state);
+  }
+  return deferred?.candidate;
 }
 
 function segmentNestedSentence(input: string, caseNeutral: boolean, depth: number): string[] {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -456,11 +456,33 @@ export function sentenceSegment(input: string, options: SentenceSegmentOptions =
 interface ListScanState {
   cursor: number;
   parenthesisDepth: number;
+  quote: string | undefined;
+}
+
+function listQuoteCloser(character: string): string | undefined {
+  if (character === '"') {
+    return '"';
+  }
+  if (character === '“') {
+    return '”';
+  }
+  return character === '‘' ? '’' : undefined;
 }
 
 function advanceListScan(input: string, end: number, state: ListScanState): void {
   while (state.cursor < end) {
     const character = input[state.cursor++];
+    if (state.quote !== undefined) {
+      if (character === state.quote) {
+        state.quote = undefined;
+      }
+      continue;
+    }
+    const quote = listQuoteCloser(character);
+    if (quote !== undefined) {
+      state.quote = quote;
+      continue;
+    }
     if (character === '(') {
       state.parenthesisDepth++;
     } else if (character === ')') {
@@ -482,7 +504,7 @@ function listMarkerPrefix(
     lineBreak ||= /[\r\n]/.test(input[index]);
     index--;
   }
-  return { empty: index < 0, boundary: lineBreak || /[.!?:]/.test(input[index] ?? '') };
+  return { empty: index < 0, boundary: lineBreak || /[.!?:\p{Pd}]/u.test(input[index] ?? '') };
 }
 
 function nextListMarker(
@@ -497,10 +519,16 @@ function nextListMarker(
     const closesParenthesis = marker[0].endsWith(')') && state.parenthesisDepth > 0;
     const yearInProse =
       /^(?:1\d{3}|20\d{2})\.$/.test(marker[0].trim()) && !listMarkerPrefix(input, marker).boundary;
+    const countInProse =
+      /^\d+\.$/.test(marker[0].trim()) &&
+      /\b(?:am|is|are|was|were|be|been|being|has|have|had|reached|numbered|total(?:ed)?|hit|equals?|equaled|became|remained|scored|costs?|in|of|at|by|to|from|about|around|roughly|approximately)$/i.test(
+        input.slice(Math.max(0, marker.index - 24), marker.index).trimEnd(),
+      );
     if (
       (family === undefined || family.test(marker[0])) &&
       !closesParenthesis &&
       !yearInProse &&
+      !countInProse &&
       (marker.index === 0 ||
         !/\b(?:section|chapter|page|figure|table|paragraph|article|clause)$/i.test(
           input.slice(Math.max(0, marker.index - 24), marker.index).trimEnd(),
@@ -527,7 +555,7 @@ function listMarkerFamily(marker: string, caseNeutral: boolean): RegExp {
   if (caseNeutral) {
     return /^\s*\p{Cased}/u;
   }
-  return /^\p{Lu}/u.test(marker) ? /^\s*\p{Lu}/u : /^\s*\p{Ll}/u;
+  return /^[\p{Lu}\p{Lt}]/u.test(marker) ? /^\s*[\p{Lu}\p{Lt}]/u : /^\s*\p{Ll}/u;
 }
 
 function findListCandidate(
@@ -541,9 +569,7 @@ function findListCandidate(
   while (current !== null) {
     const marker = current[0].trim();
     const context = listMarkerPrefix(input, current);
-    const ambiguousMarker =
-      /^\d+\.$/.test(marker) ||
-      (caseNeutral ? /^\p{Cased}\p{M}*\.$/u : /^\p{Lu}\p{M}*\.$/u).test(marker);
+    const ambiguousMarker = /^\d+\.$/.test(marker) || /^\p{Cased}\p{M}*\.$/u.test(marker);
 
     const family = listMarkerFamily(marker, caseNeutral);
     const first = firstByFamily.get(family.source);
@@ -582,7 +608,7 @@ function segmentList(input: string, caseNeutral: boolean, depth: number): string
     return undefined;
   }
   const expression = new RegExp(listMarkerReg);
-  const state: ListScanState = { cursor: 0, parenthesisDepth: 0 };
+  const state: ListScanState = { cursor: 0, parenthesisDepth: 0, quote: undefined };
   const candidate = findListCandidate(input, caseNeutral, expression, state);
   if (candidate === undefined) {
     return undefined;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -525,7 +525,8 @@ function nextListMarker(
   let marker = expression.exec(input);
   while (marker !== null) {
     advanceListScan(input, marker.index, state);
-    const closesParenthesis = marker[0].endsWith(')') && state.parenthesisDepth > 0;
+    const closesParenthesis =
+      marker[0].endsWith(')') && (state.parenthesisDepth > 0 || state.quote !== undefined);
     const yearInProse =
       /^(?:1\d{3}|20\d{2})\.$/.test(marker[0].trim()) && !listMarkerPrefix(input, marker).boundary;
     const countInProse =
@@ -575,7 +576,10 @@ function findListCandidate(
   expression: RegExp,
   state: ListScanState,
 ): ListCandidate | undefined {
-  const firstByFamily = new Map<string, { marker: RegExpExecArray; emptyPrefix: boolean }>();
+  const firstByFamily = new Map<
+    string,
+    { marker: RegExpExecArray; emptyPrefix: boolean; identity: string; number: number }
+  >();
   let deferred:
     | { candidate: ListCandidate; expressionIndex: number; state: ListScanState }
     | undefined;
@@ -587,10 +591,8 @@ function findListCandidate(
 
     const family = listMarkerFamily(marker, caseNeutral);
     const first = firstByFamily.get(family.source);
-    const previousMarker = first?.marker[0].trim();
-    const distinctMarker = caseNeutral
-      ? previousMarker?.toLowerCase() !== marker.toLowerCase()
-      : previousMarker !== marker;
+    const identity = caseNeutral ? marker.toLowerCase() : marker;
+    const distinctMarker = first?.identity !== identity;
     if (first !== undefined && (first.emptyPrefix || distinctMarker)) {
       const candidate: ListCandidate = {
         current: first.marker,
@@ -601,7 +603,7 @@ function findListCandidate(
       const hasEarlierFamily = [...firstByFamily.values()].some(
         (entry) => entry.marker.index < first.marker.index,
       );
-      const firstNumber = Number(previousMarker?.match(/^\d+/)?.[0]);
+      const firstNumber = first.number;
       const currentNumber = Number(marker.match(/^\d+/)?.[0]);
       const distantNumber =
         Number.isFinite(firstNumber) &&
@@ -619,7 +621,12 @@ function findListCandidate(
     }
 
     if (first === undefined && (context.empty || !ambiguousMarker || context.boundary)) {
-      firstByFamily.set(family.source, { marker: current, emptyPrefix: context.empty });
+      firstByFamily.set(family.source, {
+        marker: current,
+        emptyPrefix: context.empty,
+        identity,
+        number: Number(marker.match(/^\d+/)?.[0]),
+      });
     }
 
     current = nextListMarker(input, expression, state);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -122,6 +122,8 @@ const openingBracketReg = /[([{<]/;
 const closingBracketReg = /[\])}>]/;
 const listMarkerReg =
   /(?:^|\s)(?:(?:[•⁃]\s*)?\d+|\p{Cased})(?:\.\)|[.)])(?=\s+["'([{<]*\p{Cased})/gu;
+const nestedListDepth = Symbol('nestedListDepth');
+const maxNestedListDepth = 32;
 const geographicAcronymReg = /\bU\.S(?:\.A)?\.$/i;
 const geographicContinuationReg = /^(?:government|army|navy|military|congress)\b/i;
 const sentenceContinuationReg =
@@ -299,15 +301,14 @@ class SentenceBuffer {
  * @return {Array<string>}            An array of sentences
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Sentence segmentation requires complex NLP logic
-export function sentenceSegment(
-  input: string,
-  { caseNeutral = false }: SentenceSegmentOptions = {},
-): string[] {
+export function sentenceSegment(input: string, options: SentenceSegmentOptions = {}): string[] {
+  const { caseNeutral = false } = options;
+  const depth = (options as InternalSentenceSegmentOptions)[nestedListDepth] ?? 0;
   if (input.length === 0) {
     return [];
   }
 
-  const list = segmentList(input, caseNeutral);
+  const list = segmentList(input, caseNeutral, depth);
   if (list !== undefined) {
     return list;
   }
@@ -452,21 +453,54 @@ export function sentenceSegment(
   return acc.length === 0 ? [input] : acc;
 }
 
+interface ListScanState {
+  cursor: number;
+  parenthesisDepth: number;
+}
+
+function advanceListScan(input: string, end: number, state: ListScanState): void {
+  while (state.cursor < end) {
+    const character = input[state.cursor++];
+    if (character === '(') {
+      state.parenthesisDepth++;
+    } else if (character === ')') {
+      state.parenthesisDepth = Math.max(0, state.parenthesisDepth - 1);
+    }
+  }
+}
+
+function listMarkerPrefix(
+  input: string,
+  marker: RegExpExecArray,
+): {
+  empty: boolean;
+  boundary: boolean;
+} {
+  let index = marker.index - 1;
+  let lineBreak = /[\r\n]/.test(marker[0]);
+  while (index >= 0 && /\s/.test(input[index])) {
+    lineBreak ||= /[\r\n]/.test(input[index]);
+    index--;
+  }
+  return { empty: index < 0, boundary: lineBreak || /[.!?:]/.test(input[index] ?? '') };
+}
+
 function nextListMarker(
   input: string,
   expression: RegExp,
+  state: ListScanState,
   family?: RegExp,
-  expectedNumber?: number,
 ): RegExpExecArray | null {
   let marker = expression.exec(input);
   while (marker !== null) {
-    const closesParenthesis =
-      marker[0].endsWith(')') &&
-      input.lastIndexOf('(', marker.index) > input.lastIndexOf(')', marker.index);
+    advanceListScan(input, marker.index, state);
+    const closesParenthesis = marker[0].endsWith(')') && state.parenthesisDepth > 0;
+    const yearInProse =
+      /^(?:1\d{3}|20\d{2})\.$/.test(marker[0].trim()) && !listMarkerPrefix(input, marker).boundary;
     if (
       (family === undefined || family.test(marker[0])) &&
-      (expectedNumber === undefined || Number(marker[0].match(/\d+/)?.[0]) === expectedNumber) &&
       !closesParenthesis &&
+      !yearInProse &&
       (marker.index === 0 ||
         !/\b(?:section|chapter|page|figure|table|paragraph|article|clause)$/i.test(
           input.slice(Math.max(0, marker.index - 24), marker.index).trimEnd(),
@@ -482,66 +516,88 @@ function nextListMarker(
 interface ListCandidate {
   current: RegExpExecArray;
   next: RegExpExecArray;
-  family: RegExp | undefined;
-  expectedNumber: number | undefined;
+  family: RegExp;
   prefix: string;
+}
+
+function listMarkerFamily(marker: string, caseNeutral: boolean): RegExp {
+  if (/\d/.test(marker)) {
+    return /\d/;
+  }
+  if (caseNeutral) {
+    return /^\s*\p{Cased}/u;
+  }
+  return /^\p{Lu}/u.test(marker) ? /^\s*\p{Lu}/u : /^\s*\p{Ll}/u;
 }
 
 function findListCandidate(
   input: string,
   caseNeutral: boolean,
   expression: RegExp,
+  state: ListScanState,
 ): ListCandidate | undefined {
-  let current = nextListMarker(input, expression);
+  const firstByFamily = new Map<string, { marker: RegExpExecArray; emptyPrefix: boolean }>();
+  let current = nextListMarker(input, expression, state);
   while (current !== null) {
     const marker = current[0].trim();
-    const preceding = input.slice(0, current.index);
-    const prefix = preceding.trim();
+    const context = listMarkerPrefix(input, current);
     const ambiguousMarker =
       /^\d+\.$/.test(marker) || (caseNeutral ? /^\p{Cased}\.$/u : /^\p{Lu}\.$/u).test(marker);
-    const startsAfterBoundary = /[.!?:]$/.test(prefix) || /[\r\n]\s*$/.test(preceding);
 
-    if (prefix.length === 0 || !ambiguousMarker || startsAfterBoundary) {
-      const family = [/\d/, /^\s*\p{Lu}/u, /^\s*\p{Ll}/u].find((pattern) => pattern.test(marker));
-      const markerNumber = marker.match(/\d+/)?.[0];
-      const expectedNumber =
-        prefix.length > 0 && markerNumber !== undefined ? Number(markerNumber) + 1 : undefined;
-      const next = nextListMarker(input, expression, family, expectedNumber);
-      if (next !== null && (prefix.length === 0 || marker !== next[0].trim())) {
-        return { current, next, family, expectedNumber, prefix };
-      }
+    const family = listMarkerFamily(marker, caseNeutral);
+    const first = firstByFamily.get(family.source);
+    if (first !== undefined && (first.emptyPrefix || first.marker[0].trim() !== marker)) {
+      return {
+        current: first.marker,
+        next: current,
+        family,
+        prefix: input.slice(0, first.marker.index).trim(),
+      };
     }
 
-    expression.lastIndex = current.index + current[0].length;
-    current = nextListMarker(input, expression);
+    if (first === undefined && (context.empty || !ambiguousMarker || context.boundary)) {
+      firstByFamily.set(family.source, { marker: current, emptyPrefix: context.empty });
+    }
+
+    current = nextListMarker(input, expression, state);
   }
   return undefined;
 }
 
-function segmentList(input: string, caseNeutral: boolean): string[] | undefined {
+function segmentNestedSentence(input: string, caseNeutral: boolean, depth: number): string[] {
+  const options: InternalSentenceSegmentOptions = {
+    caseNeutral,
+    [nestedListDepth]: depth + 1,
+  };
+  return sentenceSegment(input, options);
+}
+
+function segmentList(input: string, caseNeutral: boolean, depth: number): string[] | undefined {
+  if (depth >= maxNestedListDepth) {
+    return undefined;
+  }
   const expression = new RegExp(listMarkerReg);
-  const candidate = findListCandidate(input, caseNeutral, expression);
+  const state: ListScanState = { cursor: 0, parenthesisDepth: 0 };
+  const candidate = findListCandidate(input, caseNeutral, expression, state);
   if (candidate === undefined) {
     return undefined;
   }
 
   let current: RegExpExecArray | null = candidate.current;
   let next: RegExpExecArray | null = candidate.next;
-  let expectedNumber = candidate.expectedNumber;
   const { family, prefix } = candidate;
-  const segments = prefix.length === 0 ? [] : sentenceSegment(prefix, { caseNeutral });
+  const segments = prefix.length === 0 ? [] : segmentNestedSentence(prefix, caseNeutral, depth);
   do {
     const body = input.slice(current.index + current[0].length, next?.index ?? input.length).trim();
-    const sentences = /[.!?\r\n]/.test(body) ? sentenceSegment(body, { caseNeutral }) : [body];
+    const sentences = /[.!?\r\n]/.test(body)
+      ? segmentNestedSentence(body, caseNeutral, depth)
+      : [body];
     if (sentences.length > 1 && /^\p{Cased}\.$/u.test(sentences[0])) {
       sentences.splice(0, 2, `${sentences[0]} ${sentences[1]}`);
     }
     segments.push(`${current[0].trim()} ${sentences[0]}`, ...sentences.slice(1));
     current = next;
-    if (expectedNumber !== undefined) {
-      expectedNumber++;
-    }
-    next = nextListMarker(input, expression, family, expectedNumber);
+    next = nextListMarker(input, expression, state, family);
   } while (current !== null);
   return segments;
 }
@@ -550,6 +606,10 @@ function segmentList(input: string, caseNeutral: boolean): string[] | undefined 
 export interface SentenceSegmentOptions {
   /** Ignore letter casing when applying sentence-boundary heuristics (default: false). */
   caseNeutral?: boolean;
+}
+
+interface InternalSentenceSegmentOptions extends SentenceSegmentOptions {
+  [nestedListDepth]?: number;
 }
 
 /** Scan sentence boundaries once, preserving the former captured-split layout. */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -467,7 +467,10 @@ function listQuoteCloser(input: string, index: number): string | undefined {
   if (
     character === "'" &&
     (index === 0 || /^[\s\p{Punctuation}]$/u.test(input[index - 1])) &&
-    !/^\p{Number}$/u.test(characterAt(input, index + 1))
+    !/^\p{Number}$/u.test(characterAt(input, index + 1)) &&
+    !/^(?:t(?:is|was|were|will|would|il|ill)|em|cause|cos|round|bout|neath|fore|tween|gainst|cept|(?:twen|thir|for|fif|six|seven|eigh|nine)ties)\b/i.test(
+      input.slice(index + 1, index + 32),
+    )
   ) {
     return "'";
   }
@@ -591,7 +594,7 @@ function findListCandidate(
 
     const family = listMarkerFamily(marker, caseNeutral);
     const first = firstByFamily.get(family.source);
-    const identity = caseNeutral ? marker.toLowerCase() : marker;
+    const identity = caseNeutral ? marker.toUpperCase().toLowerCase() : marker;
     const distinctMarker = first?.identity !== identity;
     if (first !== undefined && (first.emptyPrefix || distinctMarker)) {
       const candidate: ListCandidate = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,7 +121,7 @@ const closingDelimiterReg = /[\])}>"']/;
 const openingBracketReg = /[([{<]/;
 const closingBracketReg = /[\])}>]/;
 const listMarkerReg =
-  /(?:^|\s)(?:(?:[•⁃]\s*)?\d+(?:\.\)|[.)])|\p{Cased}\.)(?=\s+["'([{<]*\p{Cased})/gu;
+  /(?:^|\s)(?:(?:[•⁃]\s*)?\d+|\p{Cased})(?:\.\)|[.)])(?=\s+["'([{<]*\p{Cased})/gu;
 const geographicAcronymReg = /\bU\.S(?:\.A)?\.$/i;
 const geographicContinuationReg = /^(?:government|army|navy|military|congress)\b/i;
 const sentenceContinuationReg =
@@ -476,7 +476,7 @@ function nextListMarker(
 function segmentList(input: string, caseNeutral: boolean): string[] | undefined {
   const expression = new RegExp(listMarkerReg);
   let current = nextListMarker(input, expression);
-  if (current === null || input.slice(0, current.index).trim().length > 0) {
+  if (current === null) {
     return undefined;
   }
   const firstMarker = current[0];
@@ -486,7 +486,11 @@ function segmentList(input: string, caseNeutral: boolean): string[] | undefined 
     return undefined;
   }
 
-  const segments: string[] = [];
+  const prefix = input.slice(0, current.index).trim();
+  if (prefix.length > 0 && firstMarker.trim() === next[0].trim()) {
+    return undefined;
+  }
+  const segments = prefix.length === 0 ? [] : sentenceSegment(prefix, { caseNeutral });
   do {
     const body = input.slice(current.index + current[0].length, next?.index ?? input.length).trim();
     const sentences = /[.!?\r\n]/.test(body) ? sentenceSegment(body, { caseNeutral }) : [body];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,7 +121,7 @@ const closingDelimiterReg = /[\])}>"']/;
 const openingBracketReg = /[([{<]/;
 const closingBracketReg = /[\])}>]/;
 const listMarkerReg =
-  /(?:^|\s)(?:(?:[•⁃]\s*)?\d+|\p{Cased})(?:\.\)|[.)])(?=\s+["'([{<]*\p{Cased})/gu;
+  /(?:^|\s)(?:(?:[•⁃]\s*)?\d+|\p{Cased}\p{M}*)(?:\.\)|[.)])(?=\s+["'([{<]*\p{Cased})/gu;
 const nestedListDepth = Symbol('nestedListDepth');
 const maxNestedListDepth = 32;
 const geographicAcronymReg = /\bU\.S(?:\.A)?\.$/i;
@@ -542,11 +542,16 @@ function findListCandidate(
     const marker = current[0].trim();
     const context = listMarkerPrefix(input, current);
     const ambiguousMarker =
-      /^\d+\.$/.test(marker) || (caseNeutral ? /^\p{Cased}\.$/u : /^\p{Lu}\.$/u).test(marker);
+      /^\d+\.$/.test(marker) ||
+      (caseNeutral ? /^\p{Cased}\p{M}*\.$/u : /^\p{Lu}\p{M}*\.$/u).test(marker);
 
     const family = listMarkerFamily(marker, caseNeutral);
     const first = firstByFamily.get(family.source);
-    if (first !== undefined && (first.emptyPrefix || first.marker[0].trim() !== marker)) {
+    const previousMarker = first?.marker[0].trim();
+    const distinctMarker = caseNeutral
+      ? previousMarker?.toLowerCase() !== marker.toLowerCase()
+      : previousMarker !== marker;
+    if (first !== undefined && (first.emptyPrefix || distinctMarker)) {
       return {
         current: first.marker,
         next: current,
@@ -592,10 +597,13 @@ function segmentList(input: string, caseNeutral: boolean, depth: number): string
     const sentences = /[.!?\r\n]/.test(body)
       ? segmentNestedSentence(body, caseNeutral, depth)
       : [body];
-    if (sentences.length > 1 && /^\p{Cased}\.$/u.test(sentences[0])) {
+    if (sentences.length > 1 && /^\p{Cased}\p{M}*\.$/u.test(sentences[0])) {
       sentences.splice(0, 2, `${sentences[0]} ${sentences[1]}`);
     }
-    segments.push(`${current[0].trim()} ${sentences[0]}`, ...sentences.slice(1));
+    segments.push(`${current[0].trim()} ${sentences[0]}`);
+    for (let index = 1; index < sentences.length; index++) {
+      segments.push(sentences[index]);
+    }
     current = next;
     next = nextListMarker(input, expression, state, family);
   } while (current !== null);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -562,15 +562,18 @@ interface ListCandidate {
 }
 
 function listMarkerFamily(marker: string, caseNeutral: boolean): RegExp {
+  let start: string;
   if (/\d/.test(marker)) {
-    return /\d/;
+    start = '\\d';
+  } else if (caseNeutral) {
+    start = '^\\s*\\p{Cased}';
+  } else {
+    start = /^[\p{Uppercase}\p{Lt}]/u.test(marker)
+      ? '^\\s*[\\p{Uppercase}\\p{Lt}]'
+      : '^\\s*\\p{Lowercase}';
   }
-  if (caseNeutral) {
-    return /^\s*\p{Cased}/u;
-  }
-  return /^[\p{Uppercase}\p{Lt}]/u.test(marker)
-    ? /^\s*[\p{Uppercase}\p{Lt}]/u
-    : /^\s*\p{Lowercase}/u;
+  const ending = marker.endsWith(')') ? '\\)' : '\\.';
+  return new RegExp(`${start}[^\\r\\n]*${ending}$`, 'u');
 }
 
 function findListCandidate(
@@ -597,7 +600,9 @@ function findListCandidate(
     const identity = caseNeutral ? marker.toLowerCase().toUpperCase().toLowerCase() : marker;
     const joinedNameInitial =
       /^\p{Cased}\p{M}*\.$/u.test(marker) &&
-      /(?:\b(?:and|or)|&)\s*$/i.test(input.slice(Math.max(0, current.index - 8), current.index));
+      /(?:\b(?:and|or)|[,;&])\s*$/i.test(
+        input.slice(Math.max(0, current.index - 8), current.index),
+      );
     const distinctMarker = first?.identity !== identity && !joinedNameInitial;
     if (first !== undefined && (first.emptyPrefix || distinctMarker)) {
       const candidate: ListCandidate = {
@@ -894,11 +899,11 @@ function colonIntroducedNameBoundary(input: string, index: number): number {
     return index + 1;
   }
   const joinsName =
-    /(?:[:&]|\b(?:and|or)\b)\s+\p{Cased}\p{M}*\.$/iu.test(
+    /(?:[:,;&]|\b(?:and|or)\b)\s+\p{Cased}\p{M}*\.$/iu.test(
       input.slice(Math.max(0, index - 40), index + 1),
     ) &&
     /^\s+\p{Cased}\p{Letter}/u.test(input.slice(index + 1, index + 40)) &&
-    /:\s+\p{Cased}\p{M}*\.\s+\p{Letter}+\s+(?:and|or|&)\s+\p{Cased}\p{M}*\.\s+\p{Letter}/iu.test(
+    /:\s+\p{Cased}\p{M}*\.\s+\p{Letter}+(?:\s+(?:and|or|&)|[,;])\s+\p{Cased}\p{M}*\.\s+\p{Letter}/iu.test(
       input.slice(Math.max(0, index - 96), index + 96),
     );
   return joinsName ? -1 : index + 1;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -595,7 +595,10 @@ function findListCandidate(
     const family = listMarkerFamily(marker, caseNeutral);
     const first = firstByFamily.get(family.source);
     const identity = caseNeutral ? marker.toUpperCase().toLowerCase() : marker;
-    const distinctMarker = first?.identity !== identity;
+    const joinedNameInitial =
+      /^\p{Cased}\p{M}*\.$/u.test(marker) &&
+      /(?:\b(?:and|or)|&)\s*$/i.test(input.slice(Math.max(0, current.index - 8), current.index));
+    const distinctMarker = first?.identity !== identity && !joinedNameInitial;
     if (first !== undefined && (first.emptyPrefix || distinctMarker)) {
       const candidate: ListCandidate = {
         current: first.marker,
@@ -843,7 +846,7 @@ function sentenceEnd(
     return isUnspacedSentenceBoundary(input, index, end, caseNeutral) ? end : -1;
   }
   if (end === index + 1) {
-    return end;
+    return colonIntroducedNameBoundary(input, index);
   }
 
   const closedBrackets = countClosingBrackets(input, index + 1, end);
@@ -884,6 +887,21 @@ function sentenceEnd(
     return -1;
   }
   return abbrvReg.test(gateSuffix) && excepReg.test(gateSuffix) ? -1 : end;
+}
+
+function colonIntroducedNameBoundary(input: string, index: number): number {
+  if (input[index] !== '.') {
+    return index + 1;
+  }
+  const joinsName =
+    /(?:[:&]|\b(?:and|or)\b)\s+\p{Cased}\p{M}*\.$/iu.test(
+      input.slice(Math.max(0, index - 40), index + 1),
+    ) &&
+    /^\s+\p{Cased}\p{Letter}/u.test(input.slice(index + 1, index + 40)) &&
+    /:\s+\p{Cased}\p{M}*\.\s+\p{Letter}+\s+(?:and|or|&)\s+\p{Cased}\p{M}*\.\s+\p{Letter}/iu.test(
+      input.slice(Math.max(0, index - 96), index + 96),
+    );
+  return joinsName ? -1 : index + 1;
 }
 
 function countClosingBrackets(input: string, start: number, end: number): number {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -600,6 +600,23 @@ describe('Utility Functions', () => {
       expect(rouge.l(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
     });
 
+    test('compares repeated alphabetical markers case-neutrally', () => {
+      const input = 'Intro: A. Alpha a. Beta.';
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+        segmentCaseNeutrally(input).map((sentence) => sentence.toLowerCase()),
+      );
+      expect(rouge.l(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
+    });
+
+    test('accepts case-expanded combining marks in alphabetical markers', () => {
+      const input = 'Intro: İ. Alpha J. Beta.';
+      expect(segmentCaseNeutrally(input)).toEqual(['Intro:', 'İ. Alpha', 'J. Beta.']);
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+        segmentCaseNeutrally(input).map((sentence) => sentence.toLowerCase()),
+      );
+      expect(rouge.l(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
+    });
+
     test('handles many unmatched parenthesized marker candidates', () => {
       const input = `(${' a) A'.repeat(4000)}`;
       expect(ss(input)).toEqual([input]);
@@ -614,6 +631,11 @@ describe('Utility Functions', () => {
       const input = Array.from({ length: 2000 }, (_, index) => `End. ${2 * index + 1}. Alpha`).join(
         ' ',
       );
+      expect(() => ss(input)).not.toThrow();
+    });
+
+    test('appends large embedded list bodies without exceeding the argument limit', () => {
+      const input = `Intro. 1. ${'A!'.repeat(130_000)} 2. End.`;
       expect(() => ss(input)).not.toThrow();
     });
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1630,6 +1630,13 @@ describe('Utility Functions', () => {
     describe('ReDoS prevention', () => {
       const TIMEOUT_MS = 500;
 
+      test('anchors mismatched numeric marker families without backtracking', () => {
+        const input = `1. Alpha 2. Beta ${'9'.repeat(48_000)}) Gamma`;
+        const started = Date.now();
+        expect(ss(input)).toHaveLength(2);
+        expect(Date.now() - started).toBeLessThan(TIMEOUT_MS);
+      });
+
       test('segments large spaced-ellipsis runs within a constrained heap', () => {
         expectBundledScriptToPass(
           `

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -757,6 +757,16 @@ describe('Utility Functions', () => {
       }
     });
 
+    test('does not split parenthesized labels inside a quotation', () => {
+      const input = 'He said "The winners were (team A) Alice and (team B) Bob."';
+      expect(ss(input)).toEqual([input]);
+    });
+
+    test('caches long numeric markers while deferring overlapping list families', () => {
+      const input = `A. x: ${'9'.repeat(4000)}. x ${'1. x '.repeat(4000)}`;
+      expect(() => rouge.n(input, input)).not.toThrow();
+    });
+
     test('does not interpret parenthesized labels as list markers', () => {
       const input = 'The winners were (team A) Alice and (team B) Bob.';
       expect(ss(input)).toEqual([input]);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -612,6 +612,15 @@ describe('Utility Functions', () => {
       expect(rouge.l(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
     });
 
+    test('compares final-sigma list markers with full Unicode case folding', () => {
+      const input = 'Intro: Σ. Alpha ς. Beta.';
+      const expected = ['Intro: Σ.', 'Alpha ς.', 'Beta.'];
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input.toUpperCase())).toEqual(
+        expected.map((sentence) => sentence.toUpperCase()),
+      );
+    });
+
     test('accepts case-expanded combining marks in alphabetical markers', () => {
       const input = 'Intro: İ. Alpha J. Beta.';
       expect(segmentCaseNeutrally(input)).toEqual(['Intro:', 'İ. Alpha', 'J. Beta.']);
@@ -755,6 +764,15 @@ describe('Utility Functions', () => {
           'b) Beta.',
         ]);
       }
+    });
+
+    test('ignores apostrophe-led contractions while finding embedded lists', () => {
+      expect(ss("'Twas nice. Options: a) Alpha b) Beta.")).toEqual([
+        "'Twas nice.",
+        'Options:',
+        'a) Alpha',
+        'b) Beta.',
+      ]);
     });
 
     test('does not split parenthesized labels inside a quotation', () => {
@@ -2876,6 +2894,13 @@ describe('Core Functions', () => {
 
     test('preserves reordered sentence boundaries across NEL separators', () => {
       expect(l('Alpha.\u0085Beta.', 'Beta.\u0085Alpha.')).toBe(1);
+    });
+
+    test('bounds Cartesian comparisons after expanding large embedded lists', () => {
+      const summary = Array.from({ length: 1001 }, (_, index) =>
+        index % 2 === 0 ? 'a) Alpha' : 'b) Beta',
+      ).join(' ');
+      expect(() => l(summary, summary)).toThrow(/sentence comparison exceeds the work limit/);
     });
 
     test('should preserve word separation after an ellipsis for custom tokenizers', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -716,12 +716,22 @@ describe('Utility Functions', () => {
       ]);
     });
 
-    test('does not interpret colon-introduced author initials as list markers', () => {
-      const authors = 'Authors: A. Smith and B. Jones.';
-      const reversed = 'Authors: B. Jones and A. Smith.';
-      expect(ss(authors)).toEqual([authors]);
-      expect(segmentCaseNeutrally(authors)).toEqual([authors]);
-      expect(rouge.l(authors, reversed)).toBeCloseTo(0.625);
+    test.each([' and ', ', ', '; '])(
+      'does not interpret author initials separated by %j as list markers',
+      (separator) => {
+        const authors = `Authors: A. Smith${separator}B. Jones.`;
+        const reversed = `Authors: B. Jones${separator}A. Smith.`;
+        expect(ss(authors)).toEqual([authors]);
+        expect(segmentCaseNeutrally(authors)).toEqual([authors]);
+        expect(rouge.l(authors, reversed)).toBeLessThan(1);
+      },
+    );
+
+    test('does not treat dotted name initials as parenthesized list markers', () => {
+      const input = 'A) J. Smith will attend B) K. Brown will attend';
+      const expected = ['A) J. Smith will attend', 'B) K. Brown will attend'];
+      expect(ss(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
     });
 
     test('finds genuine lists after an earlier false marker', () => {
@@ -2919,7 +2929,7 @@ describe('Core Functions', () => {
     });
 
     test('bounds Cartesian comparisons after expanding large embedded lists', () => {
-      const summary = Array.from({ length: 1001 }, (_, index) =>
+      const summary = Array.from({ length: 317 }, (_, index) =>
         index % 2 === 0 ? 'a) Alpha' : 'b) Beta',
       ).join(' ');
       expect(() => l(summary, summary)).toThrow(/sentence comparison exceeds the work limit/);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -593,6 +593,7 @@ describe('Utility Functions', () => {
       ['a.) Alpha b.) Beta', ['a.) Alpha', 'b.) Beta']],
       ['A) Alpha B) Beta', ['A) Alpha', 'B) Beta']],
       ['Intro. a) Alpha b) Beta', ['Intro.', 'a) Alpha', 'b) Beta']],
+      ['Intro: A. Alpha B. Beta.', ['Intro:', 'A. Alpha', 'B. Beta.']],
     ])('recognizes parenthesized alphabetical list markers in %s', (input, expected) => {
       expect(ss(input)).toEqual(expected);
       expect(segmentCaseNeutrally(input)).toEqual(expected);
@@ -600,6 +601,17 @@ describe('Utility Functions', () => {
 
     test('scores reordered parenthesized alphabetical lists correctly', () => {
       expect(rouge.l('a) Alpha b) Beta', 'b) Beta a) Alpha')).toBe(1);
+    });
+
+    test('does not interpret names or addresses as embedded lists', () => {
+      expect(ss('I met John A. Smith and Mary B. Jones.')).toEqual([
+        'I met John A. Smith and Mary B. Jones.',
+      ]);
+      expect(ss('The address is 1. Main and 2. Broadway.')).toEqual([
+        'The address is 1.',
+        'Main and 2.',
+        'Broadway.',
+      ]);
     });
 
     test('keeps four-dot boundaries invariant under case folding', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -621,6 +621,14 @@ describe('Utility Functions', () => {
       );
     });
 
+    test('compares case-expanding sharp-S list markers consistently', () => {
+      const input = 'Intro: ß. Alpha ẞ. Beta.';
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+        segmentCaseNeutrally(input).map((sentence) => sentence.toLowerCase()),
+      );
+      expect(rouge.l(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
+    });
+
     test('accepts case-expanded combining marks in alphabetical markers', () => {
       const input = 'Intro: İ. Alpha J. Beta.';
       expect(segmentCaseNeutrally(input)).toEqual(['Intro:', 'İ. Alpha', 'J. Beta.']);
@@ -772,6 +780,12 @@ describe('Utility Functions', () => {
           'b) Beta.',
         ]);
       }
+    });
+
+    test('does not mistake inch marks for opening quotations inside lists', () => {
+      const input = '1) board is 6" wide 2) narrow';
+      expect(ss(input)).toEqual(['1) board is 6" wide', '2) narrow']);
+      expect(segmentCaseNeutrally(input)).toEqual(['1) board is 6" wide', '2) narrow']);
     });
 
     test('ignores apostrophe-led contractions while finding embedded lists', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -604,14 +604,40 @@ describe('Utility Functions', () => {
     });
 
     test('does not interpret names or addresses as embedded lists', () => {
-      expect(ss('I met John A. Smith and Mary B. Jones.')).toEqual([
-        'I met John A. Smith and Mary B. Jones.',
-      ]);
+      const names = 'I met John A. Smith and Mary B. Jones.';
+      expect(ss(names)).toEqual([names]);
+      expect(segmentCaseNeutrally(names.toLowerCase())).toEqual(
+        segmentCaseNeutrally(names).map((sentence) => sentence.toLowerCase()),
+      );
+      expect(rouge.l(names, names.toLowerCase(), { caseSensitive: false })).toBe(1);
       expect(ss('The address is 1. Main and 2. Broadway.')).toEqual([
         'The address is 1.',
         'Main and 2.',
         'Broadway.',
       ]);
+    });
+
+    test('finds genuine lists after an earlier false marker', () => {
+      expect(ss('I met John A. Smith. Intro: 1. Alpha 2. Beta.')).toEqual([
+        'I met John A. Smith.',
+        'Intro:',
+        '1. Alpha',
+        '2. Beta.',
+      ]);
+    });
+
+    test('does not treat years as embedded list markers', () => {
+      expect(ss('Results: 1. Alpha was founded in 2020. Growth continued.')).toEqual([
+        'Results: 1.',
+        'Alpha was founded in 2020.',
+        'Growth continued.',
+      ]);
+    });
+
+    test('does not interpret parenthesized labels as list markers', () => {
+      const input = 'The winners were (team A) Alice and (team B) Bob.';
+      expect(ss(input)).toEqual([input]);
+      expect(segmentCaseNeutrally(input)).toEqual([input]);
     });
 
     test('keeps four-dot boundaries invariant under case folding', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -588,6 +588,35 @@ describe('Utility Functions', () => {
       expect(rouge.l(input, '1. Alpha 2. Beta. Intro.')).toBe(1);
     });
 
+    test('segments reordered numbered lists after introductory prose', () => {
+      expect(ss('Intro. 2. Beta 1. Alpha.')).toEqual(['Intro.', '2. Beta', '1. Alpha.']);
+      expect(rouge.l('Intro. 1. Alpha 2. Beta.', 'Intro. 2. Beta 1. Alpha.')).toBe(1);
+    });
+
+    test('keeps mixed-case list markers invariant under case folding', () => {
+      const input = 'Intro: A. Alpha b. Beta.';
+      expect(segmentCaseNeutrally(input)).toEqual(['Intro:', 'A. Alpha', 'b. Beta.']);
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(['intro:', 'a. alpha', 'b. beta.']);
+      expect(rouge.l(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
+    });
+
+    test('handles many unmatched parenthesized marker candidates', () => {
+      const input = `(${' a) A'.repeat(4000)}`;
+      expect(ss(input)).toEqual([input]);
+    });
+
+    test('bounds recursion for deeply nested embedded lists', () => {
+      const input = `${'Intro. 1. '.repeat(512)}Leaf. ${'2. Done. '.repeat(512)}`;
+      expect(() => ss(input)).not.toThrow();
+    });
+
+    test('handles sparse numbered marker sequences', () => {
+      const input = Array.from({ length: 2000 }, (_, index) => `End. ${2 * index + 1}. Alpha`).join(
+        ' ',
+      );
+      expect(() => ss(input)).not.toThrow();
+    });
+
     test.each([
       ['a) Alpha b) Beta', ['a) Alpha', 'b) Beta']],
       ['a.) Alpha b.) Beta', ['a.) Alpha', 'b.) Beta']],

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -625,6 +625,26 @@ describe('Utility Functions', () => {
       expect(ss('ǅ. Alpha ǈ. Beta ǋ. Gamma')).toEqual(['ǅ. Alpha', 'ǈ. Beta', 'ǋ. Gamma']);
     });
 
+    test('keeps Unicode Roman numeral markers in the same alphabetical list', () => {
+      expect(ss('Ⅰ. Alpha Ⅱ. Beta Ⅲ. Gamma')).toEqual(['Ⅰ. Alpha', 'Ⅱ. Beta', 'Ⅲ. Gamma']);
+    });
+
+    test('accepts uncased and numeric alphabetical list-item bodies', () => {
+      expect(ss('a) 100 widgets b) 200 widgets')).toEqual(['a) 100 widgets', 'b) 200 widgets']);
+      expect(rouge.l('a) 100 widgets b) 200 widgets', 'b) 200 widgets a) 100 widgets')).toBe(1);
+      expect(ss('a) 中文 b) 日文')).toEqual(['a) 中文', 'b) 日文']);
+    });
+
+    test('prefers an outer list family over nested marker pairs', () => {
+      const input = '1. Alpha a) One b) Two 2. Beta';
+      expect(ss(input)).toEqual(['1. Alpha a) One b) Two', '2. Beta']);
+      expect(rouge.l(input, '2. Beta 1. Alpha a) One b) Two')).toBe(1);
+    });
+
+    test('preserves genuinely sparse numbered lists after deferring outliers', () => {
+      expect(ss('Options: 1. First 42. Last')).toEqual(['Options:', '1. First', '42. Last']);
+    });
+
     test('handles many unmatched parenthesized marker candidates', () => {
       const input = `(${' a) A'.repeat(4000)}`;
       expect(ss(input)).toEqual([input]);
@@ -703,6 +723,12 @@ describe('Utility Functions', () => {
         'More analysis followed',
         '2. Final.',
       ]);
+      expect(ss('Results: 1. The answer measured 42. More analysis followed 2. Final.')).toEqual([
+        'Results:',
+        '1. The answer measured 42.',
+        'More analysis followed',
+        '2. Final.',
+      ]);
     });
 
     test('ignores quoted parentheses while finding embedded lists', () => {
@@ -712,6 +738,23 @@ describe('Utility Functions', () => {
         'a) Alpha',
         'b) Beta.',
       ]);
+      expect(ss("The symbol '(' is used. Options: a) Alpha b) Beta.")).toEqual([
+        "The symbol '(' is used.",
+        'Options:',
+        'a) Alpha',
+        'b) Beta.',
+      ]);
+      for (const [opening, closing] of [
+        ['“', '”'],
+        ['‘', '’'],
+      ]) {
+        expect(ss(`The symbol ${opening}(${closing} is used. Options: a) Alpha b) Beta.`)).toEqual([
+          `The symbol ${opening}(${closing} is used.`,
+          'Options:',
+          'a) Alpha',
+          'b) Beta.',
+        ]);
+      }
     });
 
     test('does not interpret parenthesized labels as list markers', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -580,6 +580,28 @@ describe('Utility Functions', () => {
       ]);
     });
 
+    test('segments numbered lists after introductory prose', () => {
+      const input = 'Intro. 1. Alpha 2. Beta.';
+      expect(ss(input)).toEqual(['Intro.', '1. Alpha', '2. Beta.']);
+      expect(segmentCaseNeutrally(input)).toEqual(['Intro.', '1. Alpha', '2. Beta.']);
+      expect(rouge.n(input, '1. Alpha 2. Beta. Intro.')).toBe(1);
+      expect(rouge.l(input, '1. Alpha 2. Beta. Intro.')).toBe(1);
+    });
+
+    test.each([
+      ['a) Alpha b) Beta', ['a) Alpha', 'b) Beta']],
+      ['a.) Alpha b.) Beta', ['a.) Alpha', 'b.) Beta']],
+      ['A) Alpha B) Beta', ['A) Alpha', 'B) Beta']],
+      ['Intro. a) Alpha b) Beta', ['Intro.', 'a) Alpha', 'b) Beta']],
+    ])('recognizes parenthesized alphabetical list markers in %s', (input, expected) => {
+      expect(ss(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+    });
+
+    test('scores reordered parenthesized alphabetical lists correctly', () => {
+      expect(rouge.l('a) Alpha b) Beta', 'b) Beta a) Alpha')).toBe(1);
+    });
+
     test('keeps four-dot boundaries invariant under case folding', () => {
       expect(segmentCaseNeutrally('First.... Second.')).toEqual(['First....', 'Second.']);
       expect(segmentCaseNeutrally('first.... second.')).toEqual(['first....', 'second.']);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -708,6 +708,14 @@ describe('Utility Functions', () => {
       ]);
     });
 
+    test('does not interpret colon-introduced author initials as list markers', () => {
+      const authors = 'Authors: A. Smith and B. Jones.';
+      const reversed = 'Authors: B. Jones and A. Smith.';
+      expect(ss(authors)).toEqual([authors]);
+      expect(segmentCaseNeutrally(authors)).toEqual([authors]);
+      expect(rouge.l(authors, reversed)).toBeCloseTo(0.625);
+    });
+
     test('finds genuine lists after an earlier false marker', () => {
       expect(ss('I met John A. Smith. Intro: 1. Alpha 2. Beta.')).toEqual([
         'I met John A. Smith.',

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -593,6 +593,10 @@ describe('Utility Functions', () => {
       expect(rouge.l('Intro. 1. Alpha 2. Beta.', 'Intro. 2. Beta 1. Alpha.')).toBe(1);
     });
 
+    test('accepts dash-delimited introductory prose', () => {
+      expect(ss('Options — 1. Alpha 2. Beta.')).toEqual(['Options —', '1. Alpha', '2. Beta.']);
+    });
+
     test('keeps mixed-case list markers invariant under case folding', () => {
       const input = 'Intro: A. Alpha b. Beta.';
       expect(segmentCaseNeutrally(input)).toEqual(['Intro:', 'A. Alpha', 'b. Beta.']);
@@ -615,6 +619,10 @@ describe('Utility Functions', () => {
         segmentCaseNeutrally(input).map((sentence) => sentence.toLowerCase()),
       );
       expect(rouge.l(input, input.toLowerCase(), { caseSensitive: false })).toBe(1);
+    });
+
+    test('keeps Unicode titlecase markers in the same alphabetical list', () => {
+      expect(ss('ǅ. Alpha ǈ. Beta ǋ. Gamma')).toEqual(['ǅ. Alpha', 'ǈ. Beta', 'ǋ. Gamma']);
     });
 
     test('handles many unmatched parenthesized marker candidates', () => {
@@ -661,6 +669,9 @@ describe('Utility Functions', () => {
         segmentCaseNeutrally(names).map((sentence) => sentence.toLowerCase()),
       );
       expect(rouge.l(names, names.toLowerCase(), { caseSensitive: false })).toBe(1);
+      expect(ss('we hired alice a. smith and bob b. jones.')).toEqual([
+        'we hired alice a. smith and bob b. jones.',
+      ]);
       expect(ss('The address is 1. Main and 2. Broadway.')).toEqual([
         'The address is 1.',
         'Main and 2.',
@@ -682,6 +693,24 @@ describe('Utility Functions', () => {
         'Results: 1.',
         'Alpha was founded in 2020.',
         'Growth continued.',
+      ]);
+    });
+
+    test('does not treat sentence-ending counts as embedded list markers', () => {
+      expect(ss('Results: 1. The answer was 42. More analysis followed 2. Final.')).toEqual([
+        'Results:',
+        '1. The answer was 42.',
+        'More analysis followed',
+        '2. Final.',
+      ]);
+    });
+
+    test('ignores quoted parentheses while finding embedded lists', () => {
+      expect(ss('The symbol "(" is used. Options: a) Alpha b) Beta.')).toEqual([
+        'The symbol "(" is used.',
+        'Options:',
+        'a) Alpha',
+        'b) Beta.',
       ]);
     });
 


### PR DESCRIPTION
## Summary

- Recognize numbered and alphabetical lists after introductory prose, including reordered numbers, case-expanding Unicode markers, `a)`, and `a.)`, while keeping marker families separate.
- Scan marker candidates and parentheses once, cap nested list recursion, and reject author initials, dates, inch marks, apostrophe-led contractions, and ordinary parenthesized labels.
- Reject default ROUGE-L evaluations exceeding 100,000 sentence-pair comparisons while preserving custom callback behavior.

## Verification

- `npm run type-check`
- `npx biome ci . --error-on-warnings`
- `npm run test:package`
- `npm test -- --runInBand` (783 tests)
- 160 upstream English sentence-segmentation cases: six fixed, no new regressions.
- Adversarial 210 KB marker input: 22 ms; 4,000 nested levels complete without stack overflow.
- A 6,400-item expanded-list scoring attack is rejected in 51 ms.
- A 48,000-digit mismatched marker is scanned without regex backtracking.
