### PR TITLE
fix: preserve quoted sentence boundaries

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -146,7 +146,9 @@ function singleQuotationState(
     const possessive =
       previous.toLowerCase() === 's' &&
       /\s/.test(following) &&
-      /^(?:\p{Lu}\p{Ll}*\s+\p{Lu}|\p{Ll}+\s+\p{Lu})/u.test(input.slice(index + 1).trimStart());
+      /^(?:\p{Lu}\p{Ll}*\s+\p{Lu}|(?!(?:in|on|at|from|to|of|for|with|by)\b)\p{Ll}+\s+\p{Lu})/u.test(
+        input.slice(index + 1).trimStart(),
+      );
     return possessive || (following.length > 0 && !/[\s.,!?;:)\]}"”»\p{Pd}]/u.test(following));
   }
   return (
@@ -801,7 +803,7 @@ function isDialogueAttribution(input: string, closesQuotation: boolean): boolean
     return false;
   }
   return (
-    /^(?:aloud\b|(?:am|is|are|was|were|be|been|being|has|have|had|will|would|can|could|should|must)\s+(?!(?:i|we|he|she|they|you|it|this|that|these|those)\b))/i.test(
+    /^(?:aloud\b|(?:am|is|are|was|were|be|been|being|has|have|had|will|would|can|could|should|must)\s+(?![^.!?\r\n]{0,256}\?)(?!(?:i|we|he|she|they|you|it|this|that|these|those)\b))/i.test(
       input,
     ) ||
     /^(?:(?!(?:am|is|are|was|were|be|been|being|has|have|had)\b)[\p{Letter}\p{Mark}'’-]+\s+){1,3}(?:said|thought|asked|replied|answered)(?=\s*[,.;!?]|\s*$)/iu.test(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -181,7 +181,7 @@ const closingDelimiterReg = /[\])}>"'”]/;
 const openingBracketReg = /[([{<]/;
 const closingBracketReg = /[\])}>]/;
 const listMarkerReg =
-  /(?:^|\s)(?:(?:[•⁃]\s*)?\d+(?:\.\)|[.)])|\p{Cased}\.)(?=\s+["'([{<]*\p{Cased})/gu;
+  /(?:^|\s)(?:(?:[•⁃]\s*)?\d+(?:\.\)|[.)])|\p{Cased}\.)(?=\s+["'“‘„«([{<]*\p{Cased})/gu;
 const geographicAcronymReg = /\bU\.S(?:\.A)?\.$/i;
 const geographicContinuationReg = /^(?:government|army|navy|military|congress)\b/i;
 const sentenceContinuationReg =
@@ -797,9 +797,17 @@ function sentenceEnd(
 }
 
 function isDialogueAttribution(input: string, closesQuotation: boolean): boolean {
+  if (!closesQuotation) {
+    return false;
+  }
   return (
-    closesQuotation &&
-    /^(?:aloud\b|(?:[\p{Letter}\p{Mark}'’-]+\s+){1,3}(?:said|thought|asked|replied|answered)(?=\s*[,.;!?]|\s*$))/iu.test(
+    /^(?:aloud\b|(?:am|is|are|was|were|be|been|being|has|have|had|will|would|can|could|should|must)\b)/i.test(
+      input,
+    ) ||
+    /^(?:(?!(?:am|is|are|was|were|be|been|being|has|have|had)\b)[\p{Letter}\p{Mark}'’-]+\s+){1,3}(?:said|thought|asked|replied|answered)(?=\s*[,.;!?]|\s*$)/iu.test(
+      input,
+    ) ||
+    /^(?:said|thought|asked|replied|answered)\s+(?:[\p{Letter}\p{Mark}'’-]+\s*){1,3}(?=\s*[,.;!?]|\s*$)/iu.test(
       input,
     )
   );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -147,7 +147,7 @@ function singleQuotationState(
       previous.toLowerCase() === 's' &&
       /\s/.test(following) &&
       /^(?:\p{Lu}\p{Ll}*\s+\p{Lu}|\p{Ll}+\s+\p{Lu})/u.test(input.slice(index + 1).trimStart());
-    return possessive || (following.length > 0 && !/[\s.,!?;:)\]}\p{Pd}]/u.test(following));
+    return possessive || (following.length > 0 && !/[\s.,!?;:)\]}"”»\p{Pd}]/u.test(following));
   }
   return (
     (previous.length === 0 || /^[\s\p{Punctuation}]$/u.test(previous)) &&
@@ -801,13 +801,13 @@ function isDialogueAttribution(input: string, closesQuotation: boolean): boolean
     return false;
   }
   return (
-    /^(?:aloud\b|(?:am|is|are|was|were|be|been|being|has|have|had|will|would|can|could|should|must)\b)/i.test(
+    /^(?:aloud\b|(?:am|is|are|was|were|be|been|being|has|have|had|will|would|can|could|should|must)\s+(?!(?:i|we|he|she|they|you|it|this|that|these|those)\b))/i.test(
       input,
     ) ||
     /^(?:(?!(?:am|is|are|was|were|be|been|being|has|have|had)\b)[\p{Letter}\p{Mark}'’-]+\s+){1,3}(?:said|thought|asked|replied|answered)(?=\s*[,.;!?]|\s*$)/iu.test(
       input,
     ) ||
-    /^(?:said|thought|asked|replied|answered)\s+(?:[\p{Letter}\p{Mark}'’-]+\s*){1,3}(?=\s*[,.;!?]|\s*$)/iu.test(
+    /^(?:said|thought|asked|replied|answered)\s+[\p{Letter}\p{Mark}'’-]+(?:\s+[\p{Letter}\p{Mark}'’-]+){0,2}(?=\s*[,.;!?]|\s*$)/iu.test(
       input,
     )
   );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,7 +135,7 @@ function singleQuotationState(
   return (
     (previous.length === 0 || /^[\s\p{Punctuation}]$/u.test(previous)) &&
     /\S/.test(following) &&
-    !/^(?:tis|twas|em|cause|(?:twen|thir|for|fif|six|seven|eigh|nine)ties|\d{2}s)\b/i.test(
+    !/^(?:t(?:is|was|were|will|would|il|ill)|em|cause|cos|round|bout|neath|fore|tween|gainst|cept|(?:twen|thir|for|fif|six|seven|eigh|nine)ties|\d{2}s)\b/i.test(
       input.slice(index + 1),
     )
   );
@@ -673,7 +673,7 @@ function closingDelimiterEnd(input: string, index: number, insideQuotes: boolean
   let quotePending = insideQuotes;
   while (end < input.length) {
     if (closingDelimiterReg.test(input[end])) {
-      quotePending &&= input[end] !== '"' && input[end] !== '”';
+      quotePending &&= !/["'”]/.test(input[end]);
       end++;
       continue;
     }
@@ -686,7 +686,7 @@ function closingDelimiterEnd(input: string, index: number, insideQuotes: boolean
     if (
       next > end &&
       next < input.length &&
-      (closingBracketReg.test(input[next]) || (quotePending && /["”]/.test(input[next])))
+      (closingBracketReg.test(input[next]) || (quotePending && /["'”]/.test(input[next])))
     ) {
       end = next;
       continue;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,10 +105,17 @@ function curlyQuotationState(
 ): string | undefined {
   const character = input[index];
   if (character === closingQuote) {
-    return undefined;
+    return character === '’' &&
+      /^\p{Letter}$/u.test(characterAt(input, index - 1)) &&
+      /^\p{Letter}$/u.test(characterAt(input, index + 1))
+      ? closingQuote
+      : undefined;
   }
   if (character === '„') {
     return '“';
+  }
+  if (character === '‘') {
+    return '’';
   }
   return character === '“' ? '”' : closingQuote;
 }
@@ -275,7 +282,7 @@ class SentenceBuffer {
   #trackDelimiters(text: string): void {
     for (let index = 0; index < text.length; index++) {
       const character = text[index];
-      if (/["“”„]/.test(character)) {
+      if (/["“”„‘’]/.test(character)) {
         this.#trackDoubleQuote(text, index);
       } else if (character === "'") {
         this.#trackSingleQuote(text, index);
@@ -770,7 +777,7 @@ function sentenceEnd(
   }
 
   let next = end;
-  while (next < input.length && /[\s"'“„([{<]/.test(input[next])) {
+  while (next < input.length && /[\s"'“„‘([{<]/.test(input[next])) {
     next++;
   }
   if (next === input.length) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -152,7 +152,7 @@ function singleQuotationState(
   return (
     (previous.length === 0 || /^[\s\p{Punctuation}]$/u.test(previous)) &&
     /\S/.test(following) &&
-    !/^(?:t(?:is|was|were|will|would|il|ill)|em|cause|cos|round|bout|neath|fore|tween|gainst|cept|(?:twen|thir|for|fif|six|seven|eigh|nine)ties|\d{2}s)\b/i.test(
+    !/^(?:t(?:is|was|were|will|would|il|ill)|em|cause|cos|round|bout|neath|fore|tween|gainst|cept|(?:twen|thir|for|fif|six|seven|eigh|nine)ties|\d{2}s?)\b/i.test(
       input.slice(index + 1),
     )
   );
@@ -776,9 +776,13 @@ function sentenceEnd(
   }
   const suffix = input.slice(Math.max(0, index + 1 - sentenceSuffixLength), index + 1);
   const gateSuffix = caseNeutral ? suffix.toLowerCase() : suffix;
+  const continuation = input.slice(next);
+  if (isDialogueAttribution(continuation, closesQuotation)) {
+    return -1;
+  }
   const nextCharacter = characterAt(input, next);
   const startsWithLetter = caseNeutral
-    ? isNeutralSentenceStart(input, end, next, closesQuotation)
+    ? isNeutralSentenceStart(input, end, next)
     : charIsUpperCase(nextCharacter);
   const startsWithNumber = isNumericSentenceStart(input, next, nextCharacter, gateSuffix);
   if (!(startsWithLetter || startsWithNumber)) {
@@ -790,6 +794,15 @@ function sentenceEnd(
     return -1;
   }
   return abbrvReg.test(gateSuffix) && excepReg.test(gateSuffix) ? -1 : end;
+}
+
+function isDialogueAttribution(input: string, closesQuotation: boolean): boolean {
+  return (
+    closesQuotation &&
+    /^(?:aloud\b|(?:[\p{Letter}\p{Mark}'’-]+\s+){1,3}(?:said|thought|asked|replied|answered)(?=\s*[,.;!?]|\s*$))/iu.test(
+      input,
+    )
+  );
 }
 
 function standaloneTerminalEnd(input: string, end: number, insideQuotes: boolean): number {
@@ -900,25 +913,16 @@ function isUnspacedSentenceBoundary(
   );
 }
 
-function isNeutralSentenceStart(
-  input: string,
-  previousEnd: number,
-  next: number,
-  closesQuotation: boolean,
-): boolean {
+function isNeutralSentenceStart(input: string, previousEnd: number, next: number): boolean {
   if (!isCasedCharacter(characterAt(input, next))) {
     return false;
   }
 
   const continuation = input.slice(next);
   return (
-    !(
-      closesQuotation &&
-      /^(?:aloud\b|(?:he|she|they|we|i)\s+(?:said|thought)(?=\s*[,.;!?]|\s*$))/i.test(continuation)
-    ) &&
-    (!sentenceContinuationReg.test(continuation) ||
-      independentSentenceReg.test(continuation) ||
-      input.slice(previousEnd, next).includes('"'))
+    !sentenceContinuationReg.test(continuation) ||
+    independentSentenceReg.test(continuation) ||
+    input.slice(previousEnd, next).includes('"')
   );
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -620,6 +620,7 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
         insideQuotes || insideCurlyQuotes || insideSingleQuotes,
         brackets,
         caseNeutral,
+        curlyClosingQuote,
       );
       if (
         end === -1 ||
@@ -695,12 +696,20 @@ function isProtectedEllipsisPeriod(
 }
 
 /** Scan closing delimiters, including whitespace before a pending closing quote. */
-function closingDelimiterEnd(input: string, index: number, insideQuotes: boolean): number {
+function closingDelimiterEnd(
+  input: string,
+  index: number,
+  insideQuotes: boolean,
+  curlyClosingQuote: string | undefined,
+): number {
   let end = index + 1;
   let quotePending = insideQuotes;
   while (end < input.length) {
-    if (closingDelimiterReg.test(input[end]) || (quotePending && input[end] === '“')) {
-      quotePending &&= !/["'”“]/.test(input[end]);
+    if (
+      closingDelimiterReg.test(input[end]) ||
+      (quotePending && input[end] === curlyClosingQuote)
+    ) {
+      quotePending &&= !/["'”]/.test(input[end]) && input[end] !== curlyClosingQuote;
       end++;
       continue;
     }
@@ -713,7 +722,8 @@ function closingDelimiterEnd(input: string, index: number, insideQuotes: boolean
     if (
       next > end &&
       next < input.length &&
-      (closingBracketReg.test(input[next]) || (quotePending && /["'”“]/.test(input[next])))
+      (closingBracketReg.test(input[next]) ||
+        (quotePending && (/["'”]/.test(input[next]) || input[next] === curlyClosingQuote)))
     ) {
       end = next;
       continue;
@@ -730,6 +740,7 @@ function sentenceEnd(
   insideQuotes: boolean,
   brackets: { depth: number; standalone: boolean },
   caseNeutral: boolean,
+  curlyClosingQuote: string | undefined,
 ): number {
   if (
     !insideQuotes &&
@@ -738,7 +749,7 @@ function sentenceEnd(
   ) {
     return index + 1;
   }
-  const end = closingDelimiterEnd(input, index, insideQuotes);
+  const end = closingDelimiterEnd(input, index, insideQuotes, curlyClosingQuote);
   if (end < input.length && !/\s/.test(input[end])) {
     return isUnspacedSentenceBoundary(input, index, end, caseNeutral) ? end : -1;
   }
@@ -747,7 +758,8 @@ function sentenceEnd(
   }
 
   const closedBrackets = countClosingBrackets(input, index + 1, end);
-  const closesQuotation = insideQuotes && /["'”“]/.test(input[end - 1]);
+  const closesQuotation =
+    insideQuotes && (/["'”]/.test(input[end - 1]) || input[end - 1] === curlyClosingQuote);
   if (
     closedBrackets > 0 &&
     (closedBrackets < brackets.depth || !(brackets.standalone || closesQuotation))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -626,7 +626,7 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
       const end = sentenceEnd(
         input,
         index,
-        insideQuotes || insideCurlyQuotes || insideSingleQuotes,
+        Number(insideQuotes) + Number(insideCurlyQuotes) + Number(insideSingleQuotes),
         brackets,
         caseNeutral,
         curlyClosingQuote,
@@ -708,17 +708,21 @@ function isProtectedEllipsisPeriod(
 function closingDelimiterEnd(
   input: string,
   index: number,
-  insideQuotes: boolean,
+  quoteDepth: number,
   curlyClosingQuote: string | undefined,
 ): number {
   let end = index + 1;
-  let quotePending = insideQuotes;
+  let pendingQuotes = quoteDepth;
+  let quotePending = pendingQuotes > 0;
   while (end < input.length) {
     if (
       closingDelimiterReg.test(input[end]) ||
       (quotePending && input[end] === curlyClosingQuote)
     ) {
-      quotePending &&= !/["'”]/.test(input[end]) && input[end] !== curlyClosingQuote;
+      if (quotePending && (/["'”]/.test(input[end]) || input[end] === curlyClosingQuote)) {
+        pendingQuotes--;
+        quotePending = pendingQuotes > 0;
+      }
       end++;
       continue;
     }
@@ -746,11 +750,12 @@ function closingDelimiterEnd(
 function sentenceEnd(
   input: string,
   index: number,
-  insideQuotes: boolean,
+  quoteDepth: number,
   brackets: { depth: number; standalone: boolean },
   caseNeutral: boolean,
   curlyClosingQuote: string | undefined,
 ): number {
+  const insideQuotes = quoteDepth > 0;
   if (
     !insideQuotes &&
     brackets.depth === 0 &&
@@ -758,7 +763,7 @@ function sentenceEnd(
   ) {
     return index + 1;
   }
-  const end = closingDelimiterEnd(input, index, insideQuotes, curlyClosingQuote);
+  const end = closingDelimiterEnd(input, index, quoteDepth, curlyClosingQuote);
   if (end < input.length && !/\s/.test(input[end])) {
     return isUnspacedSentenceBoundary(input, index, end, caseNeutral) ? end : -1;
   }
@@ -806,11 +811,17 @@ function sentenceEnd(
 }
 
 function isDialogueAttribution(input: string, closesQuotation: boolean): boolean {
-  if (!closesQuotation) {
+  if (
+    !closesQuotation ||
+    (/^(?:am|is|are|was|were|be|been|being|has|have|had|will|would|can|could|should|must)\b/i.test(
+      input,
+    ) &&
+      /^[^.!?\r\n]*\?/.test(input))
+  ) {
     return false;
   }
   return (
-    /^(?:aloud\b|(?:am|is|are|was|were|be|been|being|has|have|had|will|would|can|could|should|must)\s+(?![^.!?\r\n]{0,256}\?)(?!(?:i|we|he|she|they|you|it|this|that|these|those)\b))/i.test(
+    /^(?:aloud\b|(?:am|is|are|was|were|be|been|being|has|have|had|will|would|can|could|should|must)\s+(?!(?:i|we|he|she|they|you|it|this|that|these|those)\b))/i.test(
       input,
     ) ||
     /^(?:(?!(?:am|is|are|was|were|be|been|being|has|have|had)\b)[\p{Letter}\p{Mark}'’-]+\s+){1,3}(?:said|thought|asked|replied|answered)(?=\s*[,.;!?]|\s*$)/iu.test(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,8 +98,19 @@ function quotationState(input: string, index: number, insideQuotes: boolean): bo
   );
 }
 
-function curlyQuotationState(input: string, index: number, insideQuotes: boolean): boolean {
-  return input[index] === '“' || (insideQuotes && input[index] !== '”');
+function curlyQuotationState(
+  input: string,
+  index: number,
+  closingQuote: string | undefined,
+): string | undefined {
+  const character = input[index];
+  if (character === closingQuote) {
+    return undefined;
+  }
+  if (character === '„') {
+    return '“';
+  }
+  return character === '“' ? '”' : closingQuote;
 }
 
 function remainsInsideNestedQuotation(
@@ -107,11 +118,17 @@ function remainsInsideNestedQuotation(
   start: number,
   end: number,
   insideStraightQuotes: boolean,
-  insideCurlyQuotes: boolean,
+  insideSingleQuotes: boolean,
+  curlyClosingQuote: string | undefined,
 ): boolean {
+  if (curlyClosingQuote === undefined || !(insideStraightQuotes || insideSingleQuotes)) {
+    return false;
+  }
   const closing = input.slice(start + 1, end);
   return (
-    insideStraightQuotes && insideCurlyQuotes && !(closing.includes('"') && closing.includes('”'))
+    (insideStraightQuotes && !closing.includes('"')) ||
+    (insideSingleQuotes && !closing.includes("'")) ||
+    !closing.includes(curlyClosingQuote)
   );
 }
 
@@ -180,7 +197,7 @@ class SentenceBuffer {
   #words: { titleCase: boolean; lowerCase: boolean }[] = [];
   #openingDelimiters: string[] = [];
   #insideDoubleQuotes = false;
-  #insideCurlyQuotes = false;
+  #curlyClosingQuote: string | undefined;
   #insideSingleQuotes = false;
   #lastCharacter = '';
   hasLineBreaks = false;
@@ -208,7 +225,9 @@ class SentenceBuffer {
   }
 
   get #insideQuotation(): boolean {
-    return this.#insideDoubleQuotes || this.#insideCurlyQuotes || this.#insideSingleQuotes;
+    return (
+      this.#insideDoubleQuotes || this.#curlyClosingQuote !== undefined || this.#insideSingleQuotes
+    );
   }
 
   get suffix(): string {
@@ -254,7 +273,7 @@ class SentenceBuffer {
   #trackDelimiters(text: string): void {
     for (let index = 0; index < text.length; index++) {
       const character = text[index];
-      if (/["“”]/.test(character)) {
+      if (/["“”„]/.test(character)) {
         this.#trackDoubleQuote(text, index);
       } else if (character === "'") {
         this.#trackSingleQuote(text, index);
@@ -277,7 +296,7 @@ class SentenceBuffer {
   #trackDoubleQuote(text: string, index: number): void {
     const character = text[index];
     if (character !== '"') {
-      this.#insideCurlyQuotes = character === '“';
+      this.#curlyClosingQuote = curlyQuotationState(text, index, this.#curlyClosingQuote);
       return;
     }
     const previous = index === 0 ? this.#lastCharacter : text[index - 1];
@@ -560,15 +579,16 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
   let lastEnd = 0;
   let start = -1;
   let insideQuotes = false;
-  let insideCurlyQuotes = false;
+  let curlyClosingQuote: string | undefined;
   let insideSingleQuotes = false;
   const brackets = { depth: 0, standalone: false };
 
   for (let index = 0; index < input.length; index++) {
     const char = input[index];
     insideQuotes = quotationState(input, index, insideQuotes);
-    insideCurlyQuotes = curlyQuotationState(input, index, insideCurlyQuotes);
+    curlyClosingQuote = curlyQuotationState(input, index, curlyClosingQuote);
     insideSingleQuotes = singleQuotationState(input, index, insideSingleQuotes);
+    const insideCurlyQuotes = curlyClosingQuote !== undefined;
     if (openingBracketReg.test(char)) {
       if (brackets.depth === 0) {
         brackets.standalone = start === -1;
@@ -603,7 +623,14 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
       );
       if (
         end === -1 ||
-        remainsInsideNestedQuotation(input, index, end, insideQuotes, insideCurlyQuotes)
+        remainsInsideNestedQuotation(
+          input,
+          index,
+          end,
+          insideQuotes,
+          insideSingleQuotes,
+          curlyClosingQuote,
+        )
       ) {
         continue;
       }
@@ -672,8 +699,8 @@ function closingDelimiterEnd(input: string, index: number, insideQuotes: boolean
   let end = index + 1;
   let quotePending = insideQuotes;
   while (end < input.length) {
-    if (closingDelimiterReg.test(input[end])) {
-      quotePending &&= !/["'”]/.test(input[end]);
+    if (closingDelimiterReg.test(input[end]) || (quotePending && input[end] === '“')) {
+      quotePending &&= !/["'”“]/.test(input[end]);
       end++;
       continue;
     }
@@ -686,7 +713,7 @@ function closingDelimiterEnd(input: string, index: number, insideQuotes: boolean
     if (
       next > end &&
       next < input.length &&
-      (closingBracketReg.test(input[next]) || (quotePending && /["'”]/.test(input[next])))
+      (closingBracketReg.test(input[next]) || (quotePending && /["'”“]/.test(input[next])))
     ) {
       end = next;
       continue;
@@ -720,7 +747,7 @@ function sentenceEnd(
   }
 
   const closedBrackets = countClosingBrackets(input, index + 1, end);
-  const closesQuotation = insideQuotes && /["'”]/.test(input[end - 1]);
+  const closesQuotation = insideQuotes && /["'”“]/.test(input[end - 1]);
   if (
     closedBrackets > 0 &&
     (closedBrackets < brackets.depth || !(brackets.standalone || closesQuotation))
@@ -729,7 +756,7 @@ function sentenceEnd(
   }
 
   let next = end;
-  while (next < input.length && /[\s"'“([{<]/.test(input[next])) {
+  while (next < input.length && /[\s"'“„([{<]/.test(input[next])) {
     next++;
   }
   if (next === input.length) {
@@ -874,7 +901,8 @@ function isNeutralSentenceStart(
   const continuation = input.slice(next);
   return (
     !(
-      closesQuotation && /^(?:aloud|(?:he|she|they|we|i)\s+(?:said|thought))\b/i.test(continuation)
+      closesQuotation &&
+      /^(?:aloud\b|(?:he|she|they|we|i)\s+(?:said|thought)(?=\s*[,.;!?]|\s*$))/i.test(continuation)
     ) &&
     (!sentenceContinuationReg.test(continuation) ||
       independentSentenceReg.test(continuation) ||

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,9 +81,6 @@ function opensDoubleQuote(input: string, index: number, insideQuotes: boolean): 
 }
 
 function quotationState(input: string, index: number, insideQuotes: boolean): boolean {
-  if (input[index] === '“' || input[index] === '”') {
-    return input[index] === '“';
-  }
   if (input[index] === '"') {
     return opensDoubleQuote(input, index, insideQuotes);
   }
@@ -101,6 +98,23 @@ function quotationState(input: string, index: number, insideQuotes: boolean): bo
   );
 }
 
+function curlyQuotationState(input: string, index: number, insideQuotes: boolean): boolean {
+  return input[index] === '“' || (insideQuotes && input[index] !== '”');
+}
+
+function remainsInsideNestedQuotation(
+  input: string,
+  start: number,
+  end: number,
+  insideStraightQuotes: boolean,
+  insideCurlyQuotes: boolean,
+): boolean {
+  const closing = input.slice(start + 1, end);
+  return (
+    insideStraightQuotes && insideCurlyQuotes && !(closing.includes('"') && closing.includes('”'))
+  );
+}
+
 function singleQuotationState(
   input: string,
   index: number,
@@ -115,13 +129,15 @@ function singleQuotationState(
     const possessive =
       previous.toLowerCase() === 's' &&
       /\s/.test(following) &&
-      /^(?:\p{Lu}|\p{Ll}+\s+\p{Lu})/u.test(input.slice(index + 1).trimStart());
+      /^(?:\p{Lu}\p{Ll}*\s+\p{Lu}|\p{Ll}+\s+\p{Lu})/u.test(input.slice(index + 1).trimStart());
     return possessive || (following.length > 0 && !/[\s.,!?;:)\]}\p{Pd}]/u.test(following));
   }
   return (
     (previous.length === 0 || /^[\s\p{Punctuation}]$/u.test(previous)) &&
     /\S/.test(following) &&
-    !/^(?:(?:twen|thir|for|fif|six|seven|eigh|nine)ties|\d{2}s)\b/i.test(input.slice(index + 1))
+    !/^(?:tis|twas|em|cause|(?:twen|thir|for|fif|six|seven|eigh|nine)ties|\d{2}s)\b/i.test(
+      input.slice(index + 1),
+    )
   );
 }
 
@@ -164,6 +180,7 @@ class SentenceBuffer {
   #words: { titleCase: boolean; lowerCase: boolean }[] = [];
   #openingDelimiters: string[] = [];
   #insideDoubleQuotes = false;
+  #insideCurlyQuotes = false;
   #insideSingleQuotes = false;
   #lastCharacter = '';
   hasLineBreaks = false;
@@ -187,9 +204,11 @@ class SentenceBuffer {
   }
 
   get hasOpenDelimiter(): boolean {
-    return (
-      this.#openingDelimiters.length > 0 || this.#insideDoubleQuotes || this.#insideSingleQuotes
-    );
+    return this.#openingDelimiters.length > 0 || this.#insideQuotation;
+  }
+
+  get #insideQuotation(): boolean {
+    return this.#insideDoubleQuotes || this.#insideCurlyQuotes || this.#insideSingleQuotes;
   }
 
   get suffix(): string {
@@ -240,15 +259,12 @@ class SentenceBuffer {
       } else if (character === "'") {
         this.#trackSingleQuote(text, index);
       } else if (
-        !(this.#insideDoubleQuotes || this.#insideSingleQuotes) &&
+        !this.#insideQuotation &&
         openingBracketReg.test(character) &&
         (character !== '<' || /^\p{Letter}$/u.test(characterAt(text, index + 1)))
       ) {
         this.#openingDelimiters.push(character);
-      } else if (
-        !(this.#insideDoubleQuotes || this.#insideSingleQuotes) &&
-        closingBracketReg.test(character)
-      ) {
+      } else if (!this.#insideQuotation && closingBracketReg.test(character)) {
         const opener = '([{<'[')]}>'.indexOf(character)];
         if (this.#openingDelimiters.at(-1) === opener) {
           this.#openingDelimiters.pop();
@@ -261,7 +277,7 @@ class SentenceBuffer {
   #trackDoubleQuote(text: string, index: number): void {
     const character = text[index];
     if (character !== '"') {
-      this.#insideDoubleQuotes = character === '“';
+      this.#insideCurlyQuotes = character === '“';
       return;
     }
     const previous = index === 0 ? this.#lastCharacter : text[index - 1];
@@ -544,12 +560,14 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
   let lastEnd = 0;
   let start = -1;
   let insideQuotes = false;
+  let insideCurlyQuotes = false;
   let insideSingleQuotes = false;
   const brackets = { depth: 0, standalone: false };
 
   for (let index = 0; index < input.length; index++) {
     const char = input[index];
     insideQuotes = quotationState(input, index, insideQuotes);
+    insideCurlyQuotes = curlyQuotationState(input, index, insideCurlyQuotes);
     insideSingleQuotes = singleQuotationState(input, index, insideSingleQuotes);
     if (openingBracketReg.test(char)) {
       if (brackets.depth === 0) {
@@ -579,11 +597,14 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
       const end = sentenceEnd(
         input,
         index,
-        insideQuotes || insideSingleQuotes,
+        insideQuotes || insideCurlyQuotes || insideSingleQuotes,
         brackets,
         caseNeutral,
       );
-      if (end === -1) {
+      if (
+        end === -1 ||
+        remainsInsideNestedQuotation(input, index, end, insideQuotes, insideCurlyQuotes)
+      ) {
         continue;
       }
       // Captured line wraps can only occur between the terminal and closing delimiters.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,6 +81,9 @@ function opensDoubleQuote(input: string, index: number, insideQuotes: boolean): 
 }
 
 function quotationState(input: string, index: number, insideQuotes: boolean): boolean {
+  if (input[index] === '“' || input[index] === '”') {
+    return input[index] === '“';
+  }
   if (input[index] === '"') {
     return opensDoubleQuote(input, index, insideQuotes);
   }
@@ -95,6 +98,30 @@ function quotationState(input: string, index: number, insideQuotes: boolean): bo
     opensDoubleQuote(input, index, false) &&
     /^[\p{Letter}\p{Number}\p{Sc}\p{Ps}]$/u.test(characterAt(input, index + 2)) &&
     input.slice(index + 2).includes("''")
+  );
+}
+
+function singleQuotationState(
+  input: string,
+  index: number,
+  insideQuotes: boolean,
+  previous = input[index - 1] ?? '',
+): boolean {
+  if (input[index] !== "'") {
+    return insideQuotes;
+  }
+  const following = input[index + 1] ?? '';
+  if (insideQuotes) {
+    const possessive =
+      previous.toLowerCase() === 's' &&
+      /\s/.test(following) &&
+      /^(?:\p{Lu}|\p{Ll}+\s+\p{Lu})/u.test(input.slice(index + 1).trimStart());
+    return possessive || (following.length > 0 && !/[\s.,!?;:)\]}\p{Pd}]/u.test(following));
+  }
+  return (
+    (previous.length === 0 || /^[\s\p{Punctuation}]$/u.test(previous)) &&
+    /\S/.test(following) &&
+    !/^(?:(?:twen|thir|for|fif|six|seven|eigh|nine)ties|\d{2}s)\b/i.test(input.slice(index + 1))
   );
 }
 
@@ -117,7 +144,7 @@ const breakReg = /[\r\n]+/;
 const ellipseReg = /\.{2,10}$/;
 const excepReg = new RegExp(`\\b(${GATE_EXCEPTIONS.map(escapeRegExp).join('|')})[.!?] ?$`, 'i');
 const sentenceSuffixLength = Math.max(10, ...GATE_SUBSTITUTIONS.map((word) => word.length + 2));
-const closingDelimiterReg = /[\])}>"']/;
+const closingDelimiterReg = /[\])}>"'”]/;
 const openingBracketReg = /[([{<]/;
 const closingBracketReg = /[\])}>]/;
 const listMarkerReg =
@@ -208,11 +235,8 @@ class SentenceBuffer {
   #trackDelimiters(text: string): void {
     for (let index = 0; index < text.length; index++) {
       const character = text[index];
-      if (character === '"') {
-        const previous = index === 0 ? this.#lastCharacter : text[index - 1];
-        this.#insideDoubleQuotes =
-          !this.#insideDoubleQuotes &&
-          (previous.length === 0 || /^[\s\p{Punctuation}]$/u.test(previous));
+      if (/["“”]/.test(character)) {
+        this.#trackDoubleQuote(text, index);
       } else if (character === "'") {
         this.#trackSingleQuote(text, index);
       } else if (
@@ -234,20 +258,26 @@ class SentenceBuffer {
     this.#lastCharacter = text.at(-1) ?? this.#lastCharacter;
   }
 
-  #trackSingleQuote(text: string, index: number): void {
-    const previous = index === 0 ? this.#lastCharacter : text[index - 1];
-    const following = text[index + 1] ?? '';
-    if (this.#insideSingleQuotes) {
-      const possessive =
-        previous.toLowerCase() === 's' &&
-        /\s/.test(following) &&
-        /^(?:\p{Lu}|\p{Ll}+\s+\p{Lu})/u.test(text.slice(index + 1).trimStart());
-      this.#insideSingleQuotes =
-        possessive || (following.length > 0 && !/[\s.,!?;:)\]}]/.test(following));
+  #trackDoubleQuote(text: string, index: number): void {
+    const character = text[index];
+    if (character !== '"') {
+      this.#insideDoubleQuotes = character === '“';
       return;
     }
-    this.#insideSingleQuotes =
-      (previous.length === 0 || /^[\s\p{Punctuation}]$/u.test(previous)) && /\S/.test(following);
+    const previous = index === 0 ? this.#lastCharacter : text[index - 1];
+    this.#insideDoubleQuotes =
+      !this.#insideDoubleQuotes &&
+      (previous.length === 0 || /^[\s\p{Punctuation}]$/u.test(previous));
+  }
+
+  #trackSingleQuote(text: string, index: number): void {
+    const previous = index === 0 ? this.#lastCharacter : text[index - 1];
+    this.#insideSingleQuotes = singleQuotationState(
+      text,
+      index,
+      this.#insideSingleQuotes,
+      previous,
+    );
   }
 
   trimEnd(): void {
@@ -514,11 +544,13 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
   let lastEnd = 0;
   let start = -1;
   let insideQuotes = false;
+  let insideSingleQuotes = false;
   const brackets = { depth: 0, standalone: false };
 
   for (let index = 0; index < input.length; index++) {
     const char = input[index];
     insideQuotes = quotationState(input, index, insideQuotes);
+    insideSingleQuotes = singleQuotationState(input, index, insideSingleQuotes);
     if (openingBracketReg.test(char)) {
       if (brackets.depth === 0) {
         brackets.standalone = start === -1;
@@ -544,7 +576,13 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
       char === '?' ||
       char === '!'
     ) {
-      const end = sentenceEnd(input, index, insideQuotes, brackets, caseNeutral);
+      const end = sentenceEnd(
+        input,
+        index,
+        insideQuotes || insideSingleQuotes,
+        brackets,
+        caseNeutral,
+      );
       if (end === -1) {
         continue;
       }
@@ -614,7 +652,7 @@ function closingDelimiterEnd(input: string, index: number, insideQuotes: boolean
   let quotePending = insideQuotes;
   while (end < input.length) {
     if (closingDelimiterReg.test(input[end])) {
-      quotePending &&= input[end] !== '"';
+      quotePending &&= input[end] !== '"' && input[end] !== '”';
       end++;
       continue;
     }
@@ -627,7 +665,7 @@ function closingDelimiterEnd(input: string, index: number, insideQuotes: boolean
     if (
       next > end &&
       next < input.length &&
-      (closingBracketReg.test(input[next]) || (quotePending && input[next] === '"'))
+      (closingBracketReg.test(input[next]) || (quotePending && /["”]/.test(input[next])))
     ) {
       end = next;
       continue;
@@ -657,12 +695,11 @@ function sentenceEnd(
     return isUnspacedSentenceBoundary(input, index, end, caseNeutral) ? end : -1;
   }
   if (end === index + 1) {
-    return end;
+    return standaloneTerminalEnd(input, end, insideQuotes);
   }
 
   const closedBrackets = countClosingBrackets(input, index + 1, end);
-  const closesQuotation =
-    insideQuotes && (input[end - 1] === '"' || input.slice(end - 2, end) === "''");
+  const closesQuotation = insideQuotes && /["'”]/.test(input[end - 1]);
   if (
     closedBrackets > 0 &&
     (closedBrackets < brackets.depth || !(brackets.standalone || closesQuotation))
@@ -671,7 +708,7 @@ function sentenceEnd(
   }
 
   let next = end;
-  while (next < input.length && /[\s"'([{<]/.test(input[next])) {
+  while (next < input.length && /[\s"'“([{<]/.test(input[next])) {
     next++;
   }
   if (next === input.length) {
@@ -681,14 +718,9 @@ function sentenceEnd(
   const gateSuffix = caseNeutral ? suffix.toLowerCase() : suffix;
   const nextCharacter = characterAt(input, next);
   const startsWithLetter = caseNeutral
-    ? isNeutralSentenceStart(input, end, next)
+    ? isNeutralSentenceStart(input, end, next, closesQuotation)
     : charIsUpperCase(nextCharacter);
-  const startsWithNumber =
-    /^\p{Number}$/u.test(nextCharacter) &&
-    !abbrvReg.test(gateSuffix) &&
-    !/^\S+(?:\s*%|\s+(?:time|year)s?\b|\s+(?:month|week|day|hour|minute|second|star|point|percent)s?(?=\s*[.!?](?:\s|$)|\s*$))/iu.test(
-      input.slice(next),
-    );
+  const startsWithNumber = isNumericSentenceStart(input, next, nextCharacter, gateSuffix);
   if (!(startsWithLetter || startsWithNumber)) {
     return -1;
   }
@@ -698,6 +730,25 @@ function sentenceEnd(
     return -1;
   }
   return abbrvReg.test(gateSuffix) && excepReg.test(gateSuffix) ? -1 : end;
+}
+
+function standaloneTerminalEnd(input: string, end: number, insideQuotes: boolean): number {
+  return insideQuotes && !/[\r\n]/.test(input[end] ?? '') ? -1 : end;
+}
+
+function isNumericSentenceStart(
+  input: string,
+  index: number,
+  character: string,
+  suffix: string,
+): boolean {
+  return (
+    /^\p{Number}$/u.test(character) &&
+    !abbrvReg.test(suffix) &&
+    !/^\S+(?:\s*%|\s+(?:time|year)s?\b|\s+(?:month|week|day|hour|minute|second|star|point|percent)s?(?=\s*[.!?](?:\s|$)|\s*$))/iu.test(
+      input.slice(index),
+    )
+  );
 }
 
 function countClosingBrackets(input: string, start: number, end: number): number {
@@ -789,16 +840,24 @@ function isUnspacedSentenceBoundary(
   );
 }
 
-function isNeutralSentenceStart(input: string, previousEnd: number, next: number): boolean {
+function isNeutralSentenceStart(
+  input: string,
+  previousEnd: number,
+  next: number,
+  closesQuotation: boolean,
+): boolean {
   if (!isCasedCharacter(characterAt(input, next))) {
     return false;
   }
 
   const continuation = input.slice(next);
   return (
-    !sentenceContinuationReg.test(continuation) ||
-    independentSentenceReg.test(continuation) ||
-    input.slice(previousEnd, next).includes('"')
+    !(
+      closesQuotation && /^(?:aloud|(?:he|she|they|we|i)\s+(?:said|thought))\b/i.test(continuation)
+    ) &&
+    (!sentenceContinuationReg.test(continuation) ||
+      independentSentenceReg.test(continuation) ||
+      input.slice(previousEnd, next).includes('"'))
   );
 }
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1196,9 +1196,16 @@ describe('Utility Functions', () => {
       expect(segmentCaseNeutrally(input)).toEqual(expected);
     });
 
-    test('retains outer straight quotations around nested curly quotations', () => {
-      const input = 'She said "She answered “No.” Then left." Next.';
-      const expected = ['She said "She answered “No.” Then left."', 'Next.'];
+    test.each([
+      [
+        'She said "She answered “No.” Then left." Next.',
+        ['She said "She answered “No.” Then left."', 'Next.'],
+      ],
+      [
+        "She said 'She answered “No.” Then left.' Next.",
+        ["She said 'She answered “No.” Then left.'", 'Next.'],
+      ],
+    ])('retains outer quotations around nested curly quotations: %s', (input, expected) => {
       expect(ss(input)).toEqual(expected);
       expect(segmentCaseNeutrally(input)).toEqual(expected);
     });
@@ -1220,9 +1227,23 @@ describe('Utility Functions', () => {
     test.each([
       ['“Alpha.” Beta.', ['“Alpha.”', 'Beta.']],
       ['She said “First! Second!” Next she left.', ['She said “First! Second!”', 'Next she left.']],
+      [
+        'Er sagte „Hallo.“ Dann ging er. Nächster Satz.',
+        ['Er sagte „Hallo.“', 'Dann ging er.', 'Nächster Satz.'],
+      ],
     ])('keeps curly closing quotations with their sentence in %s', (input, expected) => {
       expect(ss(input)).toEqual(expected);
       expect(segmentCaseNeutrally(input)).toEqual(expected);
+    });
+
+    test('keeps independent reporting-verb sentences separate', () => {
+      const input = '"It ended." He said nothing afterward. Next.';
+      const expected = ['"It ended."', 'He said nothing afterward.', 'Next.'];
+      expect(ss(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+        expected.map((sentence) => sentence.toLowerCase()),
+      );
     });
 
     test('scores reordered curly-quoted reference sentences correctly', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1189,6 +1189,7 @@ describe('Utility Functions', () => {
       ["'twas late. We left.", ["'twas late.", 'We left.']],
       ["'Til tomorrow. We can wait.", ["'Til tomorrow.", 'We can wait.']],
       ["'round the bend. We continued.", ["'round the bend.", 'We continued.']],
+      ["It happened in '99. Next event.", ["It happened in '99.", 'Next event.']],
       ["She told 'em to leave. They refused.", ["She told 'em to leave.", 'They refused.']],
       ["She said 'cause it rained. We stayed.", ["She said 'cause it rained.", 'We stayed.']],
     ])('does not interpret apostrophe-led contractions as quotations: %s', (input, expected) => {
@@ -1240,6 +1241,16 @@ describe('Utility Functions', () => {
     test('keeps independent reporting-verb sentences separate', () => {
       const input = '"It ended." He said nothing afterward. Next.';
       const expected = ['"It ended."', 'He said nothing afterward.', 'Next.'];
+      expect(ss(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+        expected.map((sentence) => sentence.toLowerCase()),
+      );
+    });
+
+    test('keeps proper-name dialogue attributions with the quotation', () => {
+      const input = '“Stop!” Alice said. Next.';
+      const expected = ['“Stop!” Alice said.', 'Next.'];
       expect(ss(input)).toEqual(expected);
       expect(segmentCaseNeutrally(input)).toEqual(expected);
       expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1162,6 +1162,40 @@ describe('Utility Functions', () => {
       ]);
     });
 
+    test.each([
+      "She said 'First! Second!' aloud.",
+      'She said "First! Second!" aloud.',
+      "'Well?' she thought, 'First! Second!' aloud.",
+    ])('keeps internal sentence punctuation inside quoted spans: %s', (input) => {
+      expect(ss(input)).toEqual([input]);
+      expect(segmentCaseNeutrally(input)).toEqual([input]);
+    });
+
+    test('does not mistake apostrophe-prefixed decades for opening quotations', () => {
+      expect(
+        ss(
+          "I wrote this in the 'nineties. It has four sentences. This is the third, isn't it? And this is the last",
+        ),
+      ).toEqual([
+        "I wrote this in the 'nineties.",
+        'It has four sentences.',
+        "This is the third, isn't it?",
+        'And this is the last',
+      ]);
+    });
+
+    test.each([
+      ['“Alpha.” Beta.', ['“Alpha.”', 'Beta.']],
+      ['She said “First! Second!” Next she left.', ['She said “First! Second!”', 'Next she left.']],
+    ])('keeps curly closing quotations with their sentence in %s', (input, expected) => {
+      expect(ss(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+    });
+
+    test('scores reordered curly-quoted reference sentences correctly', () => {
+      expect(rouge.l('Beta “Alpha.”', '“Alpha.” Beta.')).toBeCloseTo(4 / 5);
+    });
+
     test('should keep closing double quotes with their sentence', () => {
       expect(ss('He said... "what?" Next.')).toEqual(['He said... "what?"', 'Next.']);
       expect(ss('He said "hello." Then left.')).toEqual(['He said "hello."', 'Then left.']);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1240,6 +1240,16 @@ describe('Utility Functions', () => {
       expect(segmentCaseNeutrally(input)).toEqual(expected);
     });
 
+    test.each(['in English', 'on Monday', 'from Alice'])(
+      'closes s-ending quoted words before %s',
+      (continuation) => {
+        const input = `The word 'news' ${continuation} is useful. Next sentence.`;
+        const expected = [`The word 'news' ${continuation} is useful.`, 'Next sentence.'];
+        expect(ss(input)).toEqual(expected);
+        expect(segmentCaseNeutrally(input)).toEqual(expected);
+      },
+    );
+
     test.each([
       ['“Alpha.” Beta.', ['“Alpha.”', 'Beta.']],
       ['She said “First! Second!” Next she left.', ['She said “First! Second!”', 'Next she left.']],
@@ -1267,12 +1277,15 @@ describe('Utility Functions', () => {
       ]);
     });
 
-    test('keeps auxiliary-led questions separate from preceding quotations', () => {
-      const input = '"It ended." Was it really over? Next.';
-      const expected = ['"It ended."', 'Was it really over?', 'Next.'];
-      expect(ss(input)).toEqual(expected);
-      expect(segmentCaseNeutrally(input)).toEqual(expected);
-    });
+    test.each(['Was it really over?', 'Was Alice ready?', 'Is John ready?', 'Can anyone help?'])(
+      'keeps auxiliary-led question %s separate from preceding quotations',
+      (question) => {
+        const input = `"It ended." ${question} Next.`;
+        const expected = ['"It ended."', question, 'Next.'];
+        expect(ss(input)).toEqual(expected);
+        expect(segmentCaseNeutrally(input)).toEqual(expected);
+      },
+    );
 
     test('keeps proper-name dialogue attributions with the quotation', () => {
       const input = '“Stop!” Alice said. Next.';

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1212,6 +1212,20 @@ describe('Utility Functions', () => {
       expect(segmentCaseNeutrally(input)).toEqual(expected);
     });
 
+    test.each([
+      [
+        'She said "He answered \'No.\'" Next. Last.',
+        ['She said "He answered \'No.\'"', 'Next.', 'Last.'],
+      ],
+      [
+        "She said “He answered 'No.'” Next. Last.",
+        ["She said “He answered 'No.'”", 'Next.', 'Last.'],
+      ],
+    ])('closes an inner single quote before its outer quotation: %s', (input, expected) => {
+      expect(ss(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+    });
+
     test('keeps spaced single closing quotations with their sentence', () => {
       const input = "He said 'Stop. ' Next.";
       const expected = ["He said 'Stop. '", 'Next.'];
@@ -1251,6 +1265,13 @@ describe('Utility Functions', () => {
         'Nothing was said.',
         'Next.',
       ]);
+    });
+
+    test('keeps auxiliary-led questions separate from preceding quotations', () => {
+      const input = '"It ended." Was it really over? Next.';
+      const expected = ['"It ended."', 'Was it really over?', 'Next.'];
+      expect(ss(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
     });
 
     test('keeps proper-name dialogue attributions with the quotation', () => {
@@ -1506,6 +1527,13 @@ describe('Utility Functions', () => {
     // Using 500ms threshold to account for CI environment variability
     describe('ReDoS prevention', () => {
       const TIMEOUT_MS = 500;
+
+      test('rejects uninterrupted verb-first attribution subjects without backtracking', () => {
+        const input = `"Stop." said ${'a'.repeat(700)}#`;
+        const started = Date.now();
+        expect(ss(input)).toEqual([input]);
+        expect(Date.now() - started).toBeLessThan(TIMEOUT_MS);
+      });
 
       test('segments large spaced-ellipsis runs within a constrained heap', () => {
         expectBundledScriptToPass(

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1234,6 +1234,13 @@ describe('Utility Functions', () => {
       expect(segmentCaseNeutrally(input)).toEqual(expected);
     });
 
+    test('keeps a spaced outer closing quotation after an inner closer', () => {
+      const input = 'She said "He answered \'No.\' " Next. Last.';
+      const expected = ['She said "He answered \'No.\' "', 'Next.', 'Last.'];
+      expect(ss(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+    });
+
     test('keeps spaced single closing quotations with their sentence', () => {
       const input = "He said 'Stop. ' Next.";
       const expected = ["He said 'Stop. '", 'Next.'];
@@ -1294,6 +1301,13 @@ describe('Utility Functions', () => {
         expect(segmentCaseNeutrally(input)).toEqual(expected);
       },
     );
+
+    test('keeps long auxiliary-led questions separate from preceding quotations', () => {
+      const question = `Was Alice ${'really '.repeat(50)}ready?`;
+      const input = `"It ended." ${question} Next.`;
+      expect(ss(input)).toEqual(['"It ended."', question, 'Next.']);
+      expect(segmentCaseNeutrally(input)).toEqual(['"It ended."', question, 'Next.']);
+    });
 
     test('keeps proper-name dialogue attributions with the quotation', () => {
       const input = '“Stop!” Alice said. Next.';

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1246,6 +1246,11 @@ describe('Utility Functions', () => {
       expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
         expected.map((sentence) => sentence.toLowerCase()),
       );
+      expect(segmentCaseNeutrally('"It ended." Nothing was said. Next.')).toEqual([
+        '"It ended."',
+        'Nothing was said.',
+        'Next.',
+      ]);
     });
 
     test('keeps proper-name dialogue attributions with the quotation', () => {
@@ -1256,6 +1261,21 @@ describe('Utility Functions', () => {
       expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
         expected.map((sentence) => sentence.toLowerCase()),
       );
+      expect(segmentCaseNeutrally('"Stop!" said Alice. Next.')).toEqual([
+        '"Stop!" said Alice.',
+        'Next.',
+      ]);
+      expect(segmentCaseNeutrally('The word “No.” was written. Next.')).toEqual([
+        'The word “No.” was written.',
+        'Next.',
+      ]);
+    });
+
+    test('keeps curly-quoted list markers attached to their items', () => {
+      const input = '1. “Alpha.” 2. “Beta.”';
+      const expected = ['1. “Alpha.”', '2. “Beta.”'];
+      expect(ss(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
     });
 
     test('scores reordered curly-quoted reference sentences correctly', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1171,6 +1171,14 @@ describe('Utility Functions', () => {
       expect(segmentCaseNeutrally(input)).toEqual([input]);
     });
 
+    test.each([
+      ['She said ‘First. Second.’ Next.', ['She said ‘First. Second.’', 'Next.']],
+      ['She said ‘It’s fine. Really.’ Next.', ['She said ‘It’s fine. Really.’', 'Next.']],
+    ])('keeps curly single quotations intact in %s', (input, expected) => {
+      expect(ss(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+    });
+
     test('does not mistake apostrophe-prefixed decades for opening quotations', () => {
       expect(
         ss(

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1187,6 +1187,8 @@ describe('Utility Functions', () => {
     test.each([
       ["'Tis the season. It is cold.", ["'Tis the season.", 'It is cold.']],
       ["'twas late. We left.", ["'twas late.", 'We left.']],
+      ["'Til tomorrow. We can wait.", ["'Til tomorrow.", 'We can wait.']],
+      ["'round the bend. We continued.", ["'round the bend.", 'We continued.']],
       ["She told 'em to leave. They refused.", ["She told 'em to leave.", 'They refused.']],
       ["She said 'cause it rained. We stayed.", ["She said 'cause it rained.", 'We stayed.']],
     ])('does not interpret apostrophe-led contractions as quotations: %s', (input, expected) => {
@@ -1197,6 +1199,13 @@ describe('Utility Functions', () => {
     test('retains outer straight quotations around nested curly quotations', () => {
       const input = 'She said "She answered “No.” Then left." Next.';
       const expected = ['She said "She answered “No.” Then left."', 'Next.'];
+      expect(ss(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+    });
+
+    test('keeps spaced single closing quotations with their sentence', () => {
+      const input = "He said 'Stop. ' Next.";
+      const expected = ["He said 'Stop. '", 'Next.'];
       expect(ss(input)).toEqual(expected);
       expect(segmentCaseNeutrally(input)).toEqual(expected);
     });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1185,6 +1185,30 @@ describe('Utility Functions', () => {
     });
 
     test.each([
+      ["'Tis the season. It is cold.", ["'Tis the season.", 'It is cold.']],
+      ["'twas late. We left.", ["'twas late.", 'We left.']],
+      ["She told 'em to leave. They refused.", ["She told 'em to leave.", 'They refused.']],
+      ["She said 'cause it rained. We stayed.", ["She said 'cause it rained.", 'We stayed.']],
+    ])('does not interpret apostrophe-led contractions as quotations: %s', (input, expected) => {
+      expect(ss(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+    });
+
+    test('retains outer straight quotations around nested curly quotations', () => {
+      const input = 'She said "She answered “No.” Then left." Next.';
+      const expected = ['She said "She answered “No.” Then left."', 'Next.'];
+      expect(ss(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+    });
+
+    test('closes s-ending quotations before capitalized continuations', () => {
+      const input = "The response 'Yes' Alice selected was accepted. Bob objected.";
+      const expected = ["The response 'Yes' Alice selected was accepted.", 'Bob objected.'];
+      expect(ss(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+    });
+
+    test.each([
       ['“Alpha.” Beta.', ['“Alpha.”', 'Beta.']],
       ['She said “First! Second!” Next she left.', ['She said “First! Second!”', 'Next she left.']],
     ])('keeps curly closing quotations with their sentence in %s', (input, expected) => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1205,6 +1205,7 @@ describe('Utility Functions', () => {
         "She said 'She answered “No.” Then left.' Next.",
         ["She said 'She answered “No.” Then left.'", 'Next.'],
       ],
+      ['He said "First. “Second.” Then." Next.', ['He said "First. “Second.” Then."', 'Next.']],
     ])('retains outer quotations around nested curly quotations: %s', (input, expected) => {
       expect(ss(input)).toEqual(expected);
       expect(segmentCaseNeutrally(input)).toEqual(expected);


### PR DESCRIPTION
## Summary

- Keep punctuation inside straight or curly single-quoted and double-quoted passages until the quotation actually closes.
- Recognize nested, German-style, and spaced quotation delimiters while preserving dialogue tags, auxiliary-led questions, independent reporting sentences, possessives, quoted plurals, line wrapping, and elisions.
- Match verb-first dialogue attributions without polynomial regex backtracking.

## Verification

- `npm run type-check`
- `npx biome ci . --error-on-warnings`
- `npm run test:package`
- `npm test -- --runInBand` (781 tests)
- 160 upstream English sentence-segmentation cases: three fixed, no new regressions.
- A 900-character uninterrupted attribution subject is rejected in 4 ms.
