### PR TITLE
fix: retain numeric citation sentence boundaries

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -770,7 +770,13 @@ function citationEnd(
   const following = characterAt(input, delimiterEnd);
   if (
     (closedBrackets > 0 && brackets.depth > 0 && !brackets.standalone) ||
-    !isCitationContext(input, index, following, Math.max(0, brackets.depth - closedBrackets))
+    !isCitationContext(
+      input,
+      index,
+      following,
+      Math.max(0, brackets.depth - closedBrackets),
+      caseNeutral,
+    )
   ) {
     return undefined;
   }
@@ -850,6 +856,7 @@ function isCitationContext(
   index: number,
   following: string,
   bracketDepth: number,
+  caseNeutral: boolean,
 ): boolean {
   if (bracketDepth > 0 || (following !== '[' && !/^\p{Number}$/u.test(following))) {
     return false;
@@ -863,7 +870,10 @@ function isCitationContext(
   const precedingToken =
     input.slice(Math.max(0, index - 64), index).match(/[\p{Letter}\p{Mark}\p{Number}_-]+$/u)?.[0] ??
     '';
-  const standaloneIdentifier = /^[\p{Lu}\p{Number}_-]{2,}$/u.test(precedingToken);
+  const standaloneIdentifier =
+    input[index] === '.' &&
+    (/^[\p{Lu}\p{Number}_-]{2,}$/u.test(precedingToken) ||
+      (caseNeutral && index === precedingToken.length && /^[a-z\d_-]{2,}$/u.test(precedingToken)));
   const labeledSection =
     /\b(?:appendix|section|chapter|part|figure|table|paragraph|article|clause)\s+[\p{Letter}\p{Number}_-]+$/iu.test(
       input.slice(Math.max(0, index - 96), index),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -545,7 +545,7 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
       char === '!'
     ) {
       const end =
-        citationEnd(input, index, caseNeutral) ??
+        citationEnd(input, index, caseNeutral, insideQuotes, brackets.depth) ??
         sentenceEnd(input, index, insideQuotes, brackets, caseNeutral);
       if (end === -1) {
         continue;
@@ -702,9 +702,17 @@ function sentenceEnd(
   return abbrvReg.test(gateSuffix) && excepReg.test(gateSuffix) ? -1 : end;
 }
 
-function citationEnd(input: string, index: number, caseNeutral: boolean): number | undefined {
+function citationEnd(
+  input: string,
+  index: number,
+  caseNeutral: boolean,
+  insideQuotes: boolean,
+  bracketDepth: number,
+): number | undefined {
   const following = input[index + 1] ?? '';
   if (
+    insideQuotes ||
+    bracketDepth > 0 ||
     input[index] !== '.' ||
     (following !== '[' && !/^\p{Number}$/u.test(following)) ||
     (following !== '[' && !/^[\p{Letter}\p{Mark})\]]$/u.test(input[index - 1] ?? ''))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -517,10 +517,12 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
   let start = -1;
   let insideQuotes = false;
   const brackets = { depth: 0, standalone: false };
+  const citationQuotationClosers: string[] = [];
 
   for (let index = 0; index < input.length; index++) {
     const char = input[index];
     insideQuotes = quotationState(input, index, insideQuotes);
+    updateCitationQuotationState(input, index, citationQuotationClosers);
     if (openingBracketReg.test(char)) {
       if (brackets.depth === 0) {
         brackets.standalone = start === -1;
@@ -547,7 +549,7 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
       char === '!'
     ) {
       const end =
-        citationEnd(input, index, caseNeutral, insideQuotes, brackets.depth) ??
+        citationEnd(input, index, caseNeutral, insideQuotes, brackets, citationQuotationClosers) ??
         sentenceEnd(input, index, insideQuotes, brackets, caseNeutral);
       if (end === -1) {
         continue;
@@ -561,6 +563,41 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
 
   chunks.push(input.slice(lastEnd));
   return chunks;
+}
+
+function updateCitationQuotationState(input: string, index: number, closers: string[]): void {
+  const character = input[index];
+  if (character === '“' || character === '‘') {
+    closers.push(character === '“' ? '”' : '’');
+    return;
+  }
+  if (character === '”' || character === '’') {
+    if (closers.at(-1) === character) {
+      closers.pop();
+    }
+    return;
+  }
+  if (character !== "'") {
+    return;
+  }
+
+  const previous = input[index - 1] ?? '';
+  const following = input[index + 1] ?? '';
+  if (closers.at(-1) === "'") {
+    if (following.length === 0 || /[\s.,!?;:)\]}\p{Pd}]/u.test(following)) {
+      closers.pop();
+    }
+    return;
+  }
+  if (
+    (previous.length === 0 || /^[\s\p{Punctuation}]$/u.test(previous)) &&
+    /\S/.test(following) &&
+    !/^(?:\d{2}s|t(?:is|was|were|will|would|il|ill)|em|cause|cos|round|bout|neath|fore|tween|gainst|cept|(?:twen|thir|for|fif|six|seven|eigh|nine)ties)\b/i.test(
+      input.slice(index + 1, index + 32),
+    )
+  ) {
+    closers.push("'");
+  }
 }
 
 interface SpacedEllipsisRange {
@@ -707,32 +744,42 @@ function citationEnd(
   index: number,
   caseNeutral: boolean,
   insideQuotes: boolean,
-  bracketDepth: number,
+  brackets: { depth: number; standalone: boolean },
+  quotationClosers: readonly string[],
 ): number | undefined {
-  const delimiterEnd = closingDelimiterEnd(input, index, insideQuotes);
+  const nextCharacter = characterAt(input, index + 1);
+  if (nextCharacter !== '[' && !/^[\p{Number}\])}>"'”’]$/u.test(nextCharacter)) {
+    return undefined;
+  }
+  if (/^["'“‘]$/.test(nextCharacter) && !insideQuotes && quotationClosers.length === 0) {
+    return undefined;
+  }
+
+  const delimiterEnd = citationDelimiterEnd(input, index, insideQuotes);
   const closedBrackets = countClosingBrackets(input, index + 1, delimiterEnd);
   const following = characterAt(input, delimiterEnd);
-  if (!isCitationContext(input, index, following, Math.max(0, bracketDepth - closedBrackets))) {
+  if (
+    (closedBrackets > 0 && brackets.depth > 0 && !brackets.standalone) ||
+    !isCitationContext(input, index, following, Math.max(0, brackets.depth - closedBrackets))
+  ) {
     return undefined;
   }
 
   const citation = input
     .slice(delimiterEnd)
     .match(
-      /^(?:(?:\[\p{Number}+(?:\s*[,;\p{Pd}]\s*\p{Number}+)*\])+|\p{Number}+(?:[^\S\r\n]+\p{Number}+)?)/u,
+      /^(?:(?:\[\p{Number}+(?:\s*[,;\p{Pd}]\s*\p{Number}+)*\])+|\p{Number}+(?:[^\S\r\n]+\p{Number}+)*)/u,
     );
   if (citation === null) {
     return undefined;
   }
 
   const contentEnd = delimiterEnd + citation[0].length;
-  const closedQuote = insideQuotes && input.slice(index + 1, delimiterEnd).includes('"');
-  const closingQuote = closedQuote ? undefined : citationClosingQuote(input, index, insideQuotes);
-  let end = closingDelimiterEnd(input, contentEnd - 1, insideQuotes && !closedQuote);
-  if (closingQuote !== undefined && input[end] === closingQuote) {
-    end = closingDelimiterEnd(input, end, false);
-  }
-  if (closingQuote !== undefined && !input.slice(contentEnd, end).includes(closingQuote)) {
+  const leadingClosers = input.slice(index + 1, delimiterEnd);
+  const closedQuote = insideQuotes && leadingClosers.includes('"');
+  const end = citationDelimiterEnd(input, contentEnd - 1, insideQuotes && !closedQuote);
+  const closing = leadingClosers + input.slice(contentEnd, end);
+  if (!closesCitationQuotations(closing, insideQuotes, quotationClosers)) {
     return undefined;
   }
   if (!/\s/.test(input[end] ?? '')) {
@@ -740,7 +787,7 @@ function citationEnd(
   }
 
   let next = end;
-  while (next < input.length && /[\s"'([{<]/.test(input[next])) {
+  while (next < input.length && /[\s"'“‘([{<]/.test(input[next])) {
     next++;
   }
   const suffix = input.slice(Math.max(0, index + 1 - sentenceSuffixLength), index + 1);
@@ -754,42 +801,38 @@ function citationEnd(
     return undefined;
   }
 
-  const nextCharacter = characterAt(input, next);
+  const sentenceStart = characterAt(input, next);
   const startsWithLetter = caseNeutral
     ? isNeutralSentenceStart(input, end, next)
-    : nextCharacter.length > 0 && charIsUpperCase(nextCharacter);
+    : sentenceStart.length > 0 && charIsUpperCase(sentenceStart);
   const startsWithNumber =
-    /^\p{Number}$/u.test(nextCharacter) && !numericSentenceContinuationReg.test(continuation);
+    /^\p{Number}$/u.test(sentenceStart) && !numericSentenceContinuationReg.test(continuation);
   return startsWithLetter || startsWithNumber ? end : undefined;
 }
 
-function citationClosingQuote(
-  input: string,
-  index: number,
-  insideQuotes: boolean,
-): string | undefined {
-  if (insideQuotes) {
-    return '"';
+function citationDelimiterEnd(input: string, index: number, insideQuotes: boolean): number {
+  let end = closingDelimiterEnd(input, index, insideQuotes);
+  while (end < input.length && /[”’]/.test(input[end])) {
+    end = closingDelimiterEnd(input, end, false);
   }
-  for (const [opening, closing] of [
-    ['‘', '’'],
-    ['“', '”'],
-  ]) {
-    if (input.lastIndexOf(opening, index) > input.lastIndexOf(closing, index)) {
-      return closing;
+  return end;
+}
+
+function closesCitationQuotations(
+  closing: string,
+  insideQuotes: boolean,
+  quotationClosers: readonly string[],
+): boolean {
+  if (insideQuotes && !closing.includes('"')) {
+    return false;
+  }
+  let remaining = quotationClosers.length;
+  for (const character of closing) {
+    if (remaining > 0 && character === quotationClosers[remaining - 1]) {
+      remaining--;
     }
   }
-
-  const opening = input.lastIndexOf("'", index);
-  const preceding = input[opening - 1] ?? '';
-  if (
-    opening >= 0 &&
-    (opening === 0 || /^[\s\p{Punctuation}]$/u.test(preceding)) &&
-    input.indexOf("'", index + 1) !== -1
-  ) {
-    return "'";
-  }
-  return undefined;
+  return remaining === 0;
 }
 
 function isCitationContext(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,6 +112,8 @@ const upperCaseReg = /^\p{Uppercase}$/u;
 // Recognize unambiguous page-reference forms: p. 10, p. (10), and p. #10.
 const pageNumberContinuationReg =
   /^\s*(?:\(\s*\p{Number}+\s*\)|#\s*\p{Number}+|\p{Number}+)(?=\s|[.,;:!?)]|$)/u;
+const numericSentenceContinuationReg =
+  /^\S+(?:\s*%|\s+(?:time|year)s?\b|\s+(?:month|week|day|hour|minute|second|star|point|percent)s?(?=\s*[.!?](?:\s|$)|\s*$))/iu;
 const breakReg = /[\r\n]+/;
 // Match a bounded ellipsis suffix to avoid excessive backtracking.
 const ellipseReg = /\.{2,10}$/;
@@ -688,9 +690,7 @@ function sentenceEnd(
   const startsWithNumber =
     /^\p{Number}$/u.test(nextCharacter) &&
     !abbrvReg.test(gateSuffix) &&
-    !/^\S+(?:\s*%|\s+(?:time|year)s?\b|\s+(?:month|week|day|hour|minute|second|star|point|percent)s?(?=\s*[.!?](?:\s|$)|\s*$))/iu.test(
-      input.slice(next),
-    );
+    !numericSentenceContinuationReg.test(input.slice(next));
   if (!(startsWithLetter || startsWithNumber)) {
     return -1;
   }
@@ -709,14 +709,8 @@ function citationEnd(
   insideQuotes: boolean,
   bracketDepth: number,
 ): number | undefined {
-  const following = input[index + 1] ?? '';
-  if (
-    insideQuotes ||
-    bracketDepth > 0 ||
-    input[index] !== '.' ||
-    (following !== '[' && !/^\p{Number}$/u.test(following)) ||
-    (following !== '[' && !/^[\p{Letter}\p{Mark})\]]$/u.test(input[index - 1] ?? ''))
-  ) {
+  const following = characterAt(input, index + 1);
+  if (!isCitationContext(input, index, following, bracketDepth)) {
     return undefined;
   }
 
@@ -727,7 +721,11 @@ function citationEnd(
     return undefined;
   }
 
-  const end = index + 1 + citation[0].length;
+  const contentEnd = index + 1 + citation[0].length;
+  const end = closingDelimiterEnd(input, contentEnd - 1, insideQuotes);
+  if (insideQuotes && !/["']/.test(input.slice(contentEnd, end))) {
+    return undefined;
+  }
   if (!/\s/.test(input[end] ?? '')) {
     return undefined;
   }
@@ -736,10 +734,49 @@ function citationEnd(
   while (next < input.length && /[\s"'([{<]/.test(input[next])) {
     next++;
   }
-  const startsSentence = caseNeutral
+  const suffix = input.slice(Math.max(0, index + 1 - sentenceSuffixLength), index + 1);
+  const gateSuffix = caseNeutral ? suffix.toLowerCase() : suffix;
+  const continuation = input.slice(next);
+  if (
+    abbrvReg.test(gateSuffix) &&
+    (excepReg.test(gateSuffix) ||
+      (geographicAcronymReg.test(gateSuffix) && geographicContinuationReg.test(continuation)))
+  ) {
+    return undefined;
+  }
+
+  const nextCharacter = characterAt(input, next);
+  const startsWithLetter = caseNeutral
     ? isNeutralSentenceStart(input, end, next)
-    : charIsUpperCase(characterAt(input, next));
-  return startsSentence ? end : undefined;
+    : nextCharacter.length > 0 && charIsUpperCase(nextCharacter);
+  const startsWithNumber =
+    /^\p{Number}$/u.test(nextCharacter) && !numericSentenceContinuationReg.test(continuation);
+  return startsWithLetter || startsWithNumber ? end : undefined;
+}
+
+function isCitationContext(
+  input: string,
+  index: number,
+  following: string,
+  bracketDepth: number,
+): boolean {
+  if (bracketDepth > 0 || (following !== '[' && !/^\p{Number}$/u.test(following))) {
+    return false;
+  }
+  if (following === '[') {
+    return true;
+  }
+
+  const previous = Array.from(input.slice(Math.max(0, index - 2), index)).at(-1) ?? '';
+  const previousStart = index - previous.length;
+  return (
+    /^[\p{Letter}\p{Mark})\]]$/u.test(previous) &&
+    !(
+      input[index] === '.' &&
+      /^\p{Letter}$/u.test(previous) &&
+      (previousStart === 0 || /\s/.test(input[previousStart - 1]))
+    )
+  );
 }
 
 function countClosingBrackets(input: string, start: number, end: number): number {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -716,14 +716,20 @@ function citationEnd(
 
   const citation = input
     .slice(index + 1)
-    .match(/^(?:(?:\[\p{Number}+\])+|\p{Number}+(?:[^\S\r\n]+\p{Number}+)?)/u);
+    .match(
+      /^(?:(?:\[\p{Number}+(?:\s*[,;\p{Pd}]\s*\p{Number}+)*\])+|\p{Number}+(?:[^\S\r\n]+\p{Number}+)?)/u,
+    );
   if (citation === null) {
     return undefined;
   }
 
   const contentEnd = index + 1 + citation[0].length;
-  const end = closingDelimiterEnd(input, contentEnd - 1, insideQuotes);
-  if (insideQuotes && !/["']/.test(input.slice(contentEnd, end))) {
+  const closingQuote = citationClosingQuote(input, index, insideQuotes);
+  let end = closingDelimiterEnd(input, contentEnd - 1, insideQuotes);
+  if (closingQuote !== undefined && input[end] === closingQuote) {
+    end = closingDelimiterEnd(input, end, false);
+  }
+  if (closingQuote !== undefined && !input.slice(contentEnd, end).includes(closingQuote)) {
     return undefined;
   }
   if (!/\s/.test(input[end] ?? '')) {
@@ -752,6 +758,35 @@ function citationEnd(
   const startsWithNumber =
     /^\p{Number}$/u.test(nextCharacter) && !numericSentenceContinuationReg.test(continuation);
   return startsWithLetter || startsWithNumber ? end : undefined;
+}
+
+function citationClosingQuote(
+  input: string,
+  index: number,
+  insideQuotes: boolean,
+): string | undefined {
+  if (insideQuotes) {
+    return '"';
+  }
+  for (const [opening, closing] of [
+    ['‘', '’'],
+    ['“', '”'],
+  ]) {
+    if (input.lastIndexOf(opening, index) > input.lastIndexOf(closing, index)) {
+      return closing;
+    }
+  }
+
+  const opening = input.lastIndexOf("'", index);
+  const preceding = input[opening - 1] ?? '';
+  if (
+    opening >= 0 &&
+    (opening === 0 || /^[\s\p{Punctuation}]$/u.test(preceding)) &&
+    input.indexOf("'", index + 1) !== -1
+  ) {
+    return "'";
+  }
+  return undefined;
 }
 
 function isCitationContext(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -544,7 +544,9 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
       char === '?' ||
       char === '!'
     ) {
-      const end = sentenceEnd(input, index, insideQuotes, brackets, caseNeutral);
+      const end =
+        citationEnd(input, index, caseNeutral) ??
+        sentenceEnd(input, index, insideQuotes, brackets, caseNeutral);
       if (end === -1) {
         continue;
       }
@@ -698,6 +700,38 @@ function sentenceEnd(
     return -1;
   }
   return abbrvReg.test(gateSuffix) && excepReg.test(gateSuffix) ? -1 : end;
+}
+
+function citationEnd(input: string, index: number, caseNeutral: boolean): number | undefined {
+  const following = input[index + 1] ?? '';
+  if (
+    input[index] !== '.' ||
+    (following !== '[' && !/^\p{Number}$/u.test(following)) ||
+    (following !== '[' && !/^[\p{Letter}\p{Mark})\]]$/u.test(input[index - 1] ?? ''))
+  ) {
+    return undefined;
+  }
+
+  const citation = input
+    .slice(index + 1)
+    .match(/^(?:(?:\[\p{Number}+\])+|\p{Number}+(?:[^\S\r\n]+\p{Number}+)?)/u);
+  if (citation === null) {
+    return undefined;
+  }
+
+  const end = index + 1 + citation[0].length;
+  if (!/\s/.test(input[end] ?? '')) {
+    return undefined;
+  }
+
+  let next = end;
+  while (next < input.length && /[\s"'([{<]/.test(input[next])) {
+    next++;
+  }
+  const startsSentence = caseNeutral
+    ? isNeutralSentenceStart(input, end, next)
+    : charIsUpperCase(characterAt(input, next));
+  return startsSentence ? end : undefined;
 }
 
 function countClosingBrackets(input: string, start: number, end: number): number {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -571,7 +571,11 @@ function updateCitationQuotationState(input: string, index: number, closers: str
     closers.push(character === '“' ? '”' : '’');
     return;
   }
-  if (character === '”' || character === '’') {
+  if (character === '«') {
+    closers.push('»');
+    return;
+  }
+  if (character === '”' || character === '’' || character === '»') {
     if (closers.at(-1) === character) {
       closers.pop();
     }
@@ -787,7 +791,7 @@ function citationEnd(
   }
 
   let next = end;
-  while (next < input.length && /[\s"'“‘([{<]/.test(input[next])) {
+  while (next < input.length && /[\s"'“‘«([{<]/.test(input[next])) {
     next++;
   }
   const suffix = input.slice(Math.max(0, index + 1 - sentenceSuffixLength), index + 1);
@@ -812,7 +816,7 @@ function citationEnd(
 
 function citationDelimiterEnd(input: string, index: number, insideQuotes: boolean): number {
   let end = closingDelimiterEnd(input, index, insideQuotes);
-  while (end < input.length && /[”’]/.test(input[end])) {
+  while (end < input.length && /[”’»]/.test(input[end])) {
     end = closingDelimiterEnd(input, end, false);
   }
   return end;
@@ -850,12 +854,17 @@ function isCitationContext(
 
   const previous = Array.from(input.slice(Math.max(0, index - 2), index)).at(-1) ?? '';
   const previousStart = index - previous.length;
+  const precedingToken =
+    input.slice(Math.max(0, index - 64), index).match(/[\p{Letter}\p{Mark}\p{Number}_-]+$/u)?.[0] ??
+    '';
+  const standaloneIdentifier = /^[\p{Lu}\p{Number}_-]{2,}$/u.test(precedingToken);
   const labeledSection =
     /\b(?:appendix|section|chapter|part|figure|table|paragraph|article|clause)\s+[\p{Letter}\p{Number}_-]+$/iu.test(
       input.slice(Math.max(0, index - 96), index),
     );
   return (
     /^[\p{Letter}\p{Mark})\]]$/u.test(previous) &&
+    !standaloneIdentifier &&
     !labeledSection &&
     !(
       input[index] === '.' &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -709,13 +709,15 @@ function citationEnd(
   insideQuotes: boolean,
   bracketDepth: number,
 ): number | undefined {
-  const following = characterAt(input, index + 1);
-  if (!isCitationContext(input, index, following, bracketDepth)) {
+  const delimiterEnd = closingDelimiterEnd(input, index, insideQuotes);
+  const closedBrackets = countClosingBrackets(input, index + 1, delimiterEnd);
+  const following = characterAt(input, delimiterEnd);
+  if (!isCitationContext(input, index, following, Math.max(0, bracketDepth - closedBrackets))) {
     return undefined;
   }
 
   const citation = input
-    .slice(index + 1)
+    .slice(delimiterEnd)
     .match(
       /^(?:(?:\[\p{Number}+(?:\s*[,;\p{Pd}]\s*\p{Number}+)*\])+|\p{Number}+(?:[^\S\r\n]+\p{Number}+)?)/u,
     );
@@ -723,9 +725,10 @@ function citationEnd(
     return undefined;
   }
 
-  const contentEnd = index + 1 + citation[0].length;
-  const closingQuote = citationClosingQuote(input, index, insideQuotes);
-  let end = closingDelimiterEnd(input, contentEnd - 1, insideQuotes);
+  const contentEnd = delimiterEnd + citation[0].length;
+  const closedQuote = insideQuotes && input.slice(index + 1, delimiterEnd).includes('"');
+  const closingQuote = closedQuote ? undefined : citationClosingQuote(input, index, insideQuotes);
+  let end = closingDelimiterEnd(input, contentEnd - 1, insideQuotes && !closedQuote);
   if (closingQuote !== undefined && input[end] === closingQuote) {
     end = closingDelimiterEnd(input, end, false);
   }
@@ -804,8 +807,13 @@ function isCitationContext(
 
   const previous = Array.from(input.slice(Math.max(0, index - 2), index)).at(-1) ?? '';
   const previousStart = index - previous.length;
+  const labeledSection =
+    /\b(?:appendix|section|chapter|part|figure|table|paragraph|article|clause)\s+[\p{Letter}\p{Number}_-]+$/iu.test(
+      input.slice(Math.max(0, index - 96), index),
+    );
   return (
     /^[\p{Letter}\p{Mark})\]]$/u.test(previous) &&
+    !labeledSection &&
     !(
       input[index] === '.' &&
       /^\p{Letter}$/u.test(previous) &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -568,11 +568,11 @@ function sentenceChunks(input: string, caseNeutral: boolean): string[] {
 function updateCitationQuotationState(input: string, index: number, closers: string[]): void {
   const character = input[index];
   if (character === '“' || character === '‘') {
-    closers.push(character === '“' ? '”' : '’');
+    pushCitationQuotation(closers, character === '“' ? '”' : '’');
     return;
   }
   if (character === '«') {
-    closers.push('»');
+    pushCitationQuotation(closers, '»');
     return;
   }
   if (character === '”' || character === '’' || character === '»') {
@@ -600,7 +600,13 @@ function updateCitationQuotationState(input: string, index: number, closers: str
       input.slice(index + 1, index + 32),
     )
   ) {
-    closers.push("'");
+    pushCitationQuotation(closers, "'");
+  }
+}
+
+function pushCitationQuotation(closers: string[], closing: string): void {
+  if (closers.length < 64) {
+    closers.push(closing);
   }
 }
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -703,6 +703,13 @@ describe('Utility Functions', () => {
       expect(segmentCaseNeutrally(input)).toEqual([input]);
     });
 
+    test('preserves unlabeled dotted identifiers under case folding', () => {
+      const uppercase = 'ABC.1 Introduction.';
+      const lowercase = uppercase.toLowerCase();
+      expect(segmentCaseNeutrally(lowercase)).toEqual([lowercase]);
+      expect(rouge.l(uppercase, lowercase, { caseSensitive: false })).toBe(1);
+    });
+
     test.each([
       'She said "Alpha.[1] Beta." aloud.',
       "She said 'Alpha.[1] Beta.' aloud.",

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -660,6 +660,12 @@ describe('Utility Functions', () => {
       ['Alpha.[12] Beta.[34] Gamma.', ['Alpha.[12]', 'Beta.[34]', 'Gamma.']],
       ['A conclusion.11 12 The next sentence.', ['A conclusion.11 12', 'The next sentence.']],
       ['A conclusion (1987).1 The next sentence.', ['A conclusion (1987).1', 'The next sentence.']],
+      ['Text𐐀.1 Next.', ['Text𐐀.1', 'Next.']],
+      ['He said "Alpha.[1]" Beta.', ['He said "Alpha.[1]"', 'Beta.']],
+      ['Alpha.[1] 2 people remained.', ['Alpha.[1]', '2 people remained.']],
+      ['Really?[1] Next sentence.', ['Really?[1]', 'Next sentence.']],
+      ['Really?1 Next sentence.', ['Really?1', 'Next sentence.']],
+      ['Great![1] Next sentence.', ['Great![1]', 'Next sentence.']],
     ])('keeps numeric citation suffixes with sentence boundaries in %s', (input, expected) => {
       expect(ss(input)).toEqual(expected);
       expect(segmentCaseNeutrally(input)).toEqual(expected);
@@ -673,6 +679,14 @@ describe('Utility Functions', () => {
       expect(ss(input)).toEqual([input]);
       expect(segmentCaseNeutrally(input)).toEqual([input]);
     });
+
+    test.each(['Appendix A.1 Introduction', 'I work for the U.S.[1] Government agency.'])(
+      'preserves dotted section identifiers and cited abbreviation continuations: %s',
+      (input) => {
+        expect(ss(input)).toEqual([input]);
+        expect(segmentCaseNeutrally(input)).toEqual([input]);
+      },
+    );
 
     test.each([
       'She said "Alpha.[1] Beta." aloud.',

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -664,6 +664,8 @@ describe('Utility Functions', () => {
       ['A conclusion (1987).1 The next sentence.', ['A conclusion (1987).1', 'The next sentence.']],
       ['Text𐐀.1 Next.', ['Text𐐀.1', 'Next.']],
       ['He said "Alpha.[1]" Beta.', ['He said "Alpha.[1]"', 'Beta.']],
+      ['He said "Alpha."[1] Beta.', ['He said "Alpha."[1]', 'Beta.']],
+      ['(Alpha.)[1] Beta.', ['(Alpha.)[1]', 'Beta.']],
       ['“Alpha.[1]” Beta.', ['“Alpha.[1]”', 'Beta.']],
       ['Alpha.[1] 2 people remained.', ['Alpha.[1]', '2 people remained.']],
       ['Really?[1] Next sentence.', ['Really?[1]', 'Next sentence.']],
@@ -683,13 +685,15 @@ describe('Utility Functions', () => {
       expect(segmentCaseNeutrally(input)).toEqual([input]);
     });
 
-    test.each(['Appendix A.1 Introduction', 'I work for the U.S.[1] Government agency.'])(
-      'preserves dotted section identifiers and cited abbreviation continuations: %s',
-      (input) => {
-        expect(ss(input)).toEqual([input]);
-        expect(segmentCaseNeutrally(input)).toEqual([input]);
-      },
-    );
+    test.each([
+      'Appendix A.1 Introduction',
+      'Appendix IV.1 Introduction',
+      'Section ABC.1 Introduction',
+      'I work for the U.S.[1] Government agency.',
+    ])('preserves dotted section identifiers and cited abbreviation continuations: %s', (input) => {
+      expect(ss(input)).toEqual([input]);
+      expect(segmentCaseNeutrally(input)).toEqual([input]);
+    });
 
     test.each([
       'She said "Alpha.[1] Beta." aloud.',

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -661,12 +661,18 @@ describe('Utility Functions', () => {
       ['Alpha.[1–3] Beta.', ['Alpha.[1–3]', 'Beta.']],
       ['Alpha.[12] Beta.[34] Gamma.', ['Alpha.[12]', 'Beta.[34]', 'Gamma.']],
       ['A conclusion.11 12 The next sentence.', ['A conclusion.11 12', 'The next sentence.']],
+      ['A conclusion.11 12 13 The next sentence.', ['A conclusion.11 12 13', 'The next sentence.']],
       ['A conclusion (1987).1 The next sentence.', ['A conclusion (1987).1', 'The next sentence.']],
       ['Text𐐀.1 Next.', ['Text𐐀.1', 'Next.']],
       ['He said "Alpha.[1]" Beta.', ['He said "Alpha.[1]"', 'Beta.']],
       ['He said "Alpha."[1] Beta.', ['He said "Alpha."[1]', 'Beta.']],
       ['(Alpha.)[1] Beta.', ['(Alpha.)[1]', 'Beta.']],
       ['“Alpha.[1]” Beta.', ['“Alpha.[1]”', 'Beta.']],
+      ['Alpha.[1] “Beta.”', ['Alpha.[1]', '“Beta.”']],
+      [
+        "In the '90s, Alpha.[1] Today's report follows.",
+        ["In the '90s, Alpha.[1]", "Today's report follows."],
+      ],
       ['Alpha.[1] 2 people remained.', ['Alpha.[1]', '2 people remained.']],
       ['Really?[1] Next sentence.', ['Really?[1]', 'Next sentence.']],
       ['Really?1 Next sentence.', ['Really?1', 'Next sentence.']],
@@ -700,14 +706,27 @@ describe('Utility Functions', () => {
       "She said 'Alpha.[1] Beta.' aloud.",
       'She said ‘Alpha.[1] Beta.’ aloud.',
       'She said “Alpha.[1] Beta.” aloud.',
+      'She said “He called ‘Alpha.[1]’ Beta.” aloud.',
+      'He asked (really?)[1] John to continue.',
       'He noted (Alpha.[1] Beta.) today.',
       'See [Alpha.[1] Beta.] today.',
     ])('does not split citations inside surrounding delimiters: %s', (input) => {
       expect(ss(input)).toEqual([input]);
     });
 
+    test('does not mistake a quoted numeric sentence start for a citation', () => {
+      const input = 'Alpha."2 people agreed."';
+      const expected = ['Alpha.', '"2 people agreed."'];
+      expect(ss(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+    });
+
     test('scores reordered cited reference sentences correctly', () => {
       expect(rouge.l('Beta Alpha.[1]', 'Alpha.[1] Beta.')).toBeCloseTo(10 / 11);
+    });
+
+    test('segments citation-heavy documents without repeated quotation searches', () => {
+      expect(ss('Alpha.[1] Beta. '.repeat(4000))).toHaveLength(8000);
     });
 
     test('keeps parenthesized page references inside their sentence', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1495,6 +1495,21 @@ describe('Utility Functions', () => {
         );
       }, 25_000);
 
+      test('bounds unmatched citation quotation state within a constrained heap', () => {
+        expectBundledScriptToPass(
+          `
+            const summary = '‘'.repeat(7000000);
+            const sentences = module.exports.sentenceSegment(summary);
+            if (sentences.length !== 1 || sentences[0] !== summary) {
+              throw new Error('Unmatched quotation content changed');
+            }
+            process.stdout.write('ok');
+          `,
+          20_000,
+          ['--max-old-space-size=64'],
+        );
+      }, 25_000);
+
       test('should segment abbreviation chains within a small heap', () => {
         expectBundledScriptToPass(
           `

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -668,6 +668,7 @@ describe('Utility Functions', () => {
       ['He said "Alpha."[1] Beta.', ['He said "Alpha."[1]', 'Beta.']],
       ['(Alpha.)[1] Beta.', ['(Alpha.)[1]', 'Beta.']],
       ['“Alpha.[1]” Beta.', ['“Alpha.[1]”', 'Beta.']],
+      ['«Alpha.[1]» Beta.', ['«Alpha.[1]»', 'Beta.']],
       ['Alpha.[1] “Beta.”', ['Alpha.[1]', '“Beta.”']],
       [
         "In the '90s, Alpha.[1] Today's report follows.",
@@ -695,6 +696,7 @@ describe('Utility Functions', () => {
       'Appendix A.1 Introduction',
       'Appendix IV.1 Introduction',
       'Section ABC.1 Introduction',
+      'ABC.1 Introduction.',
       'I work for the U.S.[1] Government agency.',
     ])('preserves dotted section identifiers and cited abbreviation continuations: %s', (input) => {
       expect(ss(input)).toEqual([input]);
@@ -707,6 +709,7 @@ describe('Utility Functions', () => {
       'She said ‘Alpha.[1] Beta.’ aloud.',
       'She said “Alpha.[1] Beta.” aloud.',
       'She said “He called ‘Alpha.[1]’ Beta.” aloud.',
+      'He said «Alpha.[1] Beta.» aloud.',
       'He asked (really?)[1] John to continue.',
       'He noted (Alpha.[1] Beta.) today.',
       'See [Alpha.[1] Beta.] today.',

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -654,6 +654,30 @@ describe('Utility Functions', () => {
       ]);
     });
 
+    test.each([
+      ['Alpha.[1] Beta.', ['Alpha.[1]', 'Beta.']],
+      ['Alpha.[7][8] Beta.', ['Alpha.[7][8]', 'Beta.']],
+      ['Alpha.[12] Beta.[34] Gamma.', ['Alpha.[12]', 'Beta.[34]', 'Gamma.']],
+      ['A conclusion.11 12 The next sentence.', ['A conclusion.11 12', 'The next sentence.']],
+      ['A conclusion (1987).1 The next sentence.', ['A conclusion (1987).1', 'The next sentence.']],
+    ])('keeps numeric citation suffixes with sentence boundaries in %s', (input, expected) => {
+      expect(ss(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input)).toEqual(expected);
+      expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+        expected.map((sentence) => sentence.toLowerCase()),
+      );
+    });
+
+    test('does not mistake decimal numbers for numeric citation suffixes', () => {
+      const input = 'She has $100.00 in her bag.';
+      expect(ss(input)).toEqual([input]);
+      expect(segmentCaseNeutrally(input)).toEqual([input]);
+    });
+
+    test('scores reordered cited reference sentences correctly', () => {
+      expect(rouge.l('Beta Alpha.[1]', 'Alpha.[1] Beta.')).toBeCloseTo(10 / 11);
+    });
+
     test('keeps parenthesized page references inside their sentence', () => {
       const input = 'See p.(10) for details.';
       expect(ss(input)).toEqual([input]);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -674,6 +674,14 @@ describe('Utility Functions', () => {
       expect(segmentCaseNeutrally(input)).toEqual([input]);
     });
 
+    test.each([
+      'She said "Alpha.[1] Beta." aloud.',
+      'He noted (Alpha.[1] Beta.) today.',
+      'See [Alpha.[1] Beta.] today.',
+    ])('does not split citations inside surrounding delimiters: %s', (input) => {
+      expect(ss(input)).toEqual([input]);
+    });
+
     test('scores reordered cited reference sentences correctly', () => {
       expect(rouge.l('Beta Alpha.[1]', 'Alpha.[1] Beta.')).toBeCloseTo(10 / 11);
     });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -657,11 +657,14 @@ describe('Utility Functions', () => {
     test.each([
       ['Alpha.[1] Beta.', ['Alpha.[1]', 'Beta.']],
       ['Alpha.[7][8] Beta.', ['Alpha.[7][8]', 'Beta.']],
+      ['Alpha.[1,2] Beta.', ['Alpha.[1,2]', 'Beta.']],
+      ['Alpha.[1–3] Beta.', ['Alpha.[1–3]', 'Beta.']],
       ['Alpha.[12] Beta.[34] Gamma.', ['Alpha.[12]', 'Beta.[34]', 'Gamma.']],
       ['A conclusion.11 12 The next sentence.', ['A conclusion.11 12', 'The next sentence.']],
       ['A conclusion (1987).1 The next sentence.', ['A conclusion (1987).1', 'The next sentence.']],
       ['Text𐐀.1 Next.', ['Text𐐀.1', 'Next.']],
       ['He said "Alpha.[1]" Beta.', ['He said "Alpha.[1]"', 'Beta.']],
+      ['“Alpha.[1]” Beta.', ['“Alpha.[1]”', 'Beta.']],
       ['Alpha.[1] 2 people remained.', ['Alpha.[1]', '2 people remained.']],
       ['Really?[1] Next sentence.', ['Really?[1]', 'Next sentence.']],
       ['Really?1 Next sentence.', ['Really?1', 'Next sentence.']],
@@ -690,6 +693,9 @@ describe('Utility Functions', () => {
 
     test.each([
       'She said "Alpha.[1] Beta." aloud.',
+      "She said 'Alpha.[1] Beta.' aloud.",
+      'She said ‘Alpha.[1] Beta.’ aloud.',
+      'She said “Alpha.[1] Beta.” aloud.',
       'He noted (Alpha.[1] Beta.) today.',
       'See [Alpha.[1] Beta.] today.',
     ])('does not split citations inside surrounding delimiters: %s', (input) => {


### PR DESCRIPTION
## Summary

- Retain bracketed/chained/grouped citations and bare numeric footnotes after periods, questions, and exclamations, including closing quotes and numeric sentence starts.
- Track nested quotation state in one bounded forward pass; preserve decimals, apostrophes, section identifiers, guillemets, quoted/bracketed passages, and page references.

## Verification

- `npm run type-check`
- `npx biome ci . --error-on-warnings`
- `npm run test:package`
- `npm test -- --runInBand` (784 tests)
- 160 upstream English sentence-segmentation cases: five fixed, no new regressions.
- Adversarial 256 KB citation-heavy input: 35 ms with no repeated document scans.
- Seven million unmatched quotation marks complete under a 64 MB Node heap.
