### PR TITLE
fix: recognize terminal three-dot ellipses

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -212,7 +212,7 @@ class SentenceBuffer {
   #trackDelimiters(text: string): void {
     for (let index = 0; index < text.length; index++) {
       const character = text[index];
-      if (this.#trackTypographicQuote(character)) {
+      if (this.#trackTypographicQuote(text, index)) {
         continue;
       }
       if (character === '"') {
@@ -241,12 +241,21 @@ class SentenceBuffer {
     this.#lastCharacter = text.at(-1) ?? this.#lastCharacter;
   }
 
-  #trackTypographicQuote(character: string): boolean {
+  #trackTypographicQuote(text: string, index: number): boolean {
+    const character = text[index];
     if (character === '“' || character === '‘') {
       this.#typographicQuoteClosers.push(character === '“' ? '”' : '’');
       return true;
     }
     if (character === this.#typographicQuoteClosers.at(-1)) {
+      const previous = index === 0 ? this.#lastCharacter : text[index - 1];
+      if (
+        character === '’' &&
+        /^\p{Letter}$/u.test(previous) &&
+        /^\p{Letter}$/u.test(characterAt(text, index + 1))
+      ) {
+        return false;
+      }
       this.#typographicQuoteClosers.pop();
       return true;
     }
@@ -447,13 +456,14 @@ export function sentenceSegment(
         // Catch mid-sentence ellipses (and their derivatives) and merge them
         const nextChunk = chunks[idx + 1];
         const nextSentence = nextChunk.trim() || chunks[idx + 2] || '';
+        const sentenceStart = nextSentence.replace(/^[\s"'“‘«„([{<]+/, '');
         const startsSentence = caseNeutral
-          ? startsWithCasedCharacter(nextSentence) &&
+          ? startsWithCasedCharacter(sentenceStart) &&
             (/\.{4}$/.test(suffix) ||
-              (!/^(?:what|and\s+then)\b/i.test(nextSentence) &&
-                (!sentenceContinuationReg.test(nextSentence) ||
-                  independentSentenceReg.test(nextSentence))))
-          : strIsTitleCase(nextSentence);
+              (!/^(?:what|and\s+then)\b/i.test(sentenceStart) &&
+                (!sentenceContinuationReg.test(sentenceStart) ||
+                  independentSentenceReg.test(sentenceStart))))
+          : strIsTitleCase(sentenceStart);
         if (
           /\.{3,4}$/.test(suffix) &&
           startsSentence &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -428,10 +428,14 @@ export function sentenceSegment(
         // Catch mid-sentence ellipses (and their derivatives) and merge them
         const nextChunk = chunks[idx + 1];
         const nextSentence = nextChunk.trim() || chunks[idx + 2] || '';
-        if (
-          /\.{4}$/.test(suffix) &&
-          (caseNeutral ? startsWithCasedCharacter(nextSentence) : strIsTitleCase(nextSentence))
-        ) {
+        const startsSentence = caseNeutral
+          ? startsWithCasedCharacter(nextSentence) &&
+            (/\.{4}$/.test(suffix) ||
+              (!/^(?:what|and\s+then)\b/i.test(nextSentence) &&
+                (!sentenceContinuationReg.test(nextSentence) ||
+                  independentSentenceReg.test(nextSentence))))
+          : strIsTitleCase(nextSentence);
+        if (/\.{3,4}$/.test(suffix) && startsSentence) {
           acc.push(chunk.text());
           continue;
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -136,6 +136,7 @@ class SentenceBuffer {
   #normalizedThrough = 0;
   #words: { titleCase: boolean; lowerCase: boolean }[] = [];
   #openingDelimiters: string[] = [];
+  #typographicQuoteClosers: string[] = [];
   #insideDoubleQuotes = false;
   #insideSingleQuotes = false;
   #lastCharacter = '';
@@ -161,7 +162,10 @@ class SentenceBuffer {
 
   get hasOpenDelimiter(): boolean {
     return (
-      this.#openingDelimiters.length > 0 || this.#insideDoubleQuotes || this.#insideSingleQuotes
+      this.#openingDelimiters.length > 0 ||
+      this.#typographicQuoteClosers.length > 0 ||
+      this.#insideDoubleQuotes ||
+      this.#insideSingleQuotes
     );
   }
 
@@ -208,6 +212,9 @@ class SentenceBuffer {
   #trackDelimiters(text: string): void {
     for (let index = 0; index < text.length; index++) {
       const character = text[index];
+      if (this.#trackTypographicQuote(character)) {
+        continue;
+      }
       if (character === '"') {
         const previous = index === 0 ? this.#lastCharacter : text[index - 1];
         this.#insideDoubleQuotes =
@@ -232,6 +239,18 @@ class SentenceBuffer {
       }
     }
     this.#lastCharacter = text.at(-1) ?? this.#lastCharacter;
+  }
+
+  #trackTypographicQuote(character: string): boolean {
+    if (character === '“' || character === '‘') {
+      this.#typographicQuoteClosers.push(character === '“' ? '”' : '’');
+      return true;
+    }
+    if (character === this.#typographicQuoteClosers.at(-1)) {
+      this.#typographicQuoteClosers.pop();
+      return true;
+    }
+    return false;
   }
 
   #trackSingleQuote(text: string, index: number): void {
@@ -441,8 +460,7 @@ export function sentenceSegment(
           (/\.{4}$/.test(suffix) ||
             !(
               chunk.hasOpenDelimiter ||
-              hasOpenTypographicQuote(chunk.text()) ||
-              /\b(?:am|is|are|was|were|i)\.{3}$/i.test(suffix)
+              /\b(?:am|is|are|was|were|be|been|being|i)\.{3}$/i.test(suffix)
             ))
         ) {
           acc.push(chunk.text());
@@ -463,13 +481,6 @@ export function sentenceSegment(
 
   // If no matches were found, return the input treated as a single sentence
   return acc.length === 0 ? [input] : acc;
-}
-
-function hasOpenTypographicQuote(input: string): boolean {
-  return (
-    input.lastIndexOf('“') > input.lastIndexOf('”') ||
-    input.lastIndexOf('‘') > input.lastIndexOf('’')
-  );
 }
 
 function nextListMarker(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -519,6 +519,14 @@ function hasInlineParenthetical(input: string, caseNeutral: boolean): boolean {
   const closing = ')]}>"\'”’»“'[openingIndex];
   let depth = 1;
   for (let index = 1; index < Math.min(input.length, 512); index++) {
+    if (
+      input[index] === closing &&
+      /['’]/.test(closing) &&
+      /^\p{Letter}$/u.test(characterAt(input, index - 1)) &&
+      /^\p{Letter}$/u.test(characterAt(input, index + 1))
+    ) {
+      continue;
+    }
     if (input[index] === opening && opening !== closing) {
       depth++;
     } else if (input[index] === closing && --depth === 0) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,6 +112,8 @@ const upperCaseReg = /^\p{Uppercase}$/u;
 // Recognize unambiguous page-reference forms: p. 10, p. (10), and p. #10.
 const pageNumberContinuationReg =
   /^\s*(?:\(\s*\p{Number}+\s*\)|#\s*\p{Number}+|\p{Number}+)(?=\s|[.,;:!?)]|$)/u;
+const numericSentenceContinuationReg =
+  /^\S+(?:\s*%|\s+(?:time|year)s?\b|\s+(?:month|week|day|hour|minute|second|star|point|percent)s?(?=\s*[.!?](?:\s|$)|\s*$))/iu;
 const breakReg = /[\r\n]+/;
 // Match a bounded ellipsis suffix to avoid excessive backtracking.
 const ellipseReg = /\.{2,10}$/;
@@ -243,8 +245,14 @@ class SentenceBuffer {
 
   #trackTypographicQuote(text: string, index: number): boolean {
     const character = text[index];
-    if (character === '“' || character === '‘') {
-      this.#typographicQuoteClosers.push(character === '“' ? '”' : '’');
+    if (character === '“' || character === '‘' || character === '«') {
+      if (this.#typographicQuoteClosers.length < 64) {
+        if (character === '«') {
+          this.#typographicQuoteClosers.push('»');
+        } else {
+          this.#typographicQuoteClosers.push(character === '“' ? '”' : '’');
+        }
+      }
       return true;
     }
     if (character === this.#typographicQuoteClosers.at(-1)) {
@@ -457,13 +465,17 @@ export function sentenceSegment(
         const nextChunk = chunks[idx + 1];
         const nextSentence = nextChunk.trim() || chunks[idx + 2] || '';
         const sentenceStart = nextSentence.replace(/^[\s"'“‘«„([{<]+/, '');
-        const startsSentence = caseNeutral
+        const startsWithLetter = caseNeutral
           ? startsWithCasedCharacter(sentenceStart) &&
             (/\.{4}$/.test(suffix) ||
               (!/^(?:what|and\s+then)\b/i.test(sentenceStart) &&
                 (!sentenceContinuationReg.test(sentenceStart) ||
                   independentSentenceReg.test(sentenceStart))))
           : strIsTitleCase(sentenceStart);
+        const startsWithNumber =
+          /^\p{Number}/u.test(sentenceStart) && !numericSentenceContinuationReg.test(sentenceStart);
+        const inlineParenthetical = /^[([{<][^.!?]*[\])}>][^\S\r\n]+\p{Ll}/u.test(nextSentence);
+        const startsSentence = (startsWithLetter || startsWithNumber) && !inlineParenthetical;
         if (
           /\.{3,4}$/.test(suffix) &&
           startsSentence &&
@@ -727,9 +739,7 @@ function sentenceEnd(
   const startsWithNumber =
     /^\p{Number}$/u.test(nextCharacter) &&
     !abbrvReg.test(gateSuffix) &&
-    !/^\S+(?:\s*%|\s+(?:time|year)s?\b|\s+(?:month|week|day|hour|minute|second|star|point|percent)s?(?=\s*[.!?](?:\s|$)|\s*$))/iu.test(
-      input.slice(next),
-    );
+    !numericSentenceContinuationReg.test(input.slice(next));
   if (!(startsWithLetter || startsWithNumber)) {
     return -1;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -479,7 +479,7 @@ export function sentenceSegment(
         const startsWithNumber =
           /^\p{Number}/u.test(sentenceStart) &&
           !ellipsisQuantityContinuationReg.test(sentenceStart);
-        const inlineParenthetical = hasInlineParenthetical(nextSentence);
+        const inlineParenthetical = hasInlineParenthetical(nextSentence, caseNeutral);
         const startsSentence = (startsWithLetter || startsWithNumber) && !inlineParenthetical;
         if (
           /\.{3,4}$/.test(suffix) &&
@@ -510,19 +510,22 @@ export function sentenceSegment(
   return acc.length === 0 ? [input] : acc;
 }
 
-function hasInlineParenthetical(input: string): boolean {
+function hasInlineParenthetical(input: string, caseNeutral: boolean): boolean {
   const opening = input[0];
-  const openingIndex = '([{<'.indexOf(opening);
+  const openingIndex = '([{<"\'“‘«„'.indexOf(opening);
   if (openingIndex === -1) {
     return false;
   }
-  const closing = ')]}>'[openingIndex];
-  let depth = 0;
-  for (let index = 0; index < Math.min(input.length, 512); index++) {
-    if (input[index] === opening) {
+  const closing = ')]}>"\'”’»“'[openingIndex];
+  let depth = 1;
+  for (let index = 1; index < Math.min(input.length, 512); index++) {
+    if (input[index] === opening && opening !== closing) {
       depth++;
     } else if (input[index] === closing && --depth === 0) {
-      return /^[^\S\r\n]+\p{Ll}/u.test(input.slice(index + 1, index + 64));
+      const continuation = input.slice(index + 1, index + 64);
+      return caseNeutral
+        ? /^[^\S\r\n]+\p{Cased}/u.test(continuation)
+        : /^[^\S\r\n]+\p{Ll}/u.test(continuation);
     }
   }
   return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -479,7 +479,10 @@ export function sentenceSegment(
         const startsWithNumber =
           /^\p{Number}/u.test(sentenceStart) &&
           !ellipsisQuantityContinuationReg.test(sentenceStart);
-        const inlineParenthetical = hasInlineParenthetical(nextSentence, caseNeutral);
+        const parentheticalContext = breakReg.test(nextChunk)
+          ? `${nextChunk.trimStart()}${chunks[idx + 2] ?? ''}`
+          : nextSentence;
+        const inlineParenthetical = hasInlineParenthetical(parentheticalContext, caseNeutral);
         const startsSentence = (startsWithLetter || startsWithNumber) && !inlineParenthetical;
         if (
           /\.{3,4}$/.test(suffix) &&
@@ -531,9 +534,7 @@ function hasInlineParenthetical(input: string, caseNeutral: boolean): boolean {
       depth++;
     } else if (input[index] === closing && --depth === 0) {
       const continuation = input.slice(index + 1, index + 64);
-      return caseNeutral
-        ? /^[^\S\r\n]+\p{Cased}/u.test(continuation)
-        : /^[^\S\r\n]+\p{Ll}/u.test(continuation);
+      return caseNeutral ? /^\s+\p{Cased}/u.test(continuation) : /^\s+\p{Ll}/u.test(continuation);
     }
   }
   return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,6 +114,8 @@ const pageNumberContinuationReg =
   /^\s*(?:\(\s*\p{Number}+\s*\)|#\s*\p{Number}+|\p{Number}+)(?=\s|[.,;:!?)]|$)/u;
 const numericSentenceContinuationReg =
   /^\S+(?:\s*%|\s+(?:time|year)s?\b|\s+(?:month|week|day|hour|minute|second|star|point|percent)s?(?=\s*[.!?](?:\s|$)|\s*$))/iu;
+const ellipsisQuantityContinuationReg =
+  /^\S+(?:\s*%|\s+(?:time|year|month|week|day|hour|minute|second|star|point|percent)s?)(?=\s*[.!?](?:\s|$)|\s*$)/iu;
 const breakReg = /[\r\n]+/;
 // Match a bounded ellipsis suffix to avoid excessive backtracking.
 const ellipseReg = /\.{2,10}$/;
@@ -245,16 +247,6 @@ class SentenceBuffer {
 
   #trackTypographicQuote(text: string, index: number): boolean {
     const character = text[index];
-    if (character === '“' || character === '‘' || character === '«') {
-      if (this.#typographicQuoteClosers.length < 64) {
-        if (character === '«') {
-          this.#typographicQuoteClosers.push('»');
-        } else {
-          this.#typographicQuoteClosers.push(character === '“' ? '”' : '’');
-        }
-      }
-      return true;
-    }
     if (character === this.#typographicQuoteClosers.at(-1)) {
       const previous = index === 0 ? this.#lastCharacter : text[index - 1];
       if (
@@ -265,6 +257,18 @@ class SentenceBuffer {
         return false;
       }
       this.#typographicQuoteClosers.pop();
+      return true;
+    }
+    if (character === '“' || character === '‘' || character === '«' || character === '„') {
+      if (this.#typographicQuoteClosers.length < 64) {
+        if (character === '«') {
+          this.#typographicQuoteClosers.push('»');
+        } else if (character === '„') {
+          this.#typographicQuoteClosers.push('“');
+        } else {
+          this.#typographicQuoteClosers.push(character === '“' ? '”' : '’');
+        }
+      }
       return true;
     }
     return false;
@@ -473,8 +477,9 @@ export function sentenceSegment(
                   independentSentenceReg.test(sentenceStart))))
           : strIsTitleCase(sentenceStart);
         const startsWithNumber =
-          /^\p{Number}/u.test(sentenceStart) && !numericSentenceContinuationReg.test(sentenceStart);
-        const inlineParenthetical = /^[([{<][^.!?]*[\])}>][^\S\r\n]+\p{Ll}/u.test(nextSentence);
+          /^\p{Number}/u.test(sentenceStart) &&
+          !ellipsisQuantityContinuationReg.test(sentenceStart);
+        const inlineParenthetical = hasInlineParenthetical(nextSentence);
         const startsSentence = (startsWithLetter || startsWithNumber) && !inlineParenthetical;
         if (
           /\.{3,4}$/.test(suffix) &&
@@ -503,6 +508,24 @@ export function sentenceSegment(
 
   // If no matches were found, return the input treated as a single sentence
   return acc.length === 0 ? [input] : acc;
+}
+
+function hasInlineParenthetical(input: string): boolean {
+  const opening = input[0];
+  const openingIndex = '([{<'.indexOf(opening);
+  if (openingIndex === -1) {
+    return false;
+  }
+  const closing = ')]}>'[openingIndex];
+  let depth = 0;
+  for (let index = 0; index < Math.min(input.length, 512); index++) {
+    if (input[index] === opening) {
+      depth++;
+    } else if (input[index] === closing && --depth === 0) {
+      return /^[^\S\r\n]+\p{Ll}/u.test(input.slice(index + 1, index + 64));
+    }
+  }
+  return false;
 }
 
 function nextListMarker(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -435,7 +435,11 @@ export function sentenceSegment(
                 (!sentenceContinuationReg.test(nextSentence) ||
                   independentSentenceReg.test(nextSentence))))
           : strIsTitleCase(nextSentence);
-        if (/\.{3,4}$/.test(suffix) && startsSentence) {
+        if (
+          /\.{3,4}$/.test(suffix) &&
+          startsSentence &&
+          (/\.{4}$/.test(suffix) || !chunk.hasOpenDelimiter)
+        ) {
           acc.push(chunk.text());
           continue;
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -438,7 +438,12 @@ export function sentenceSegment(
         if (
           /\.{3,4}$/.test(suffix) &&
           startsSentence &&
-          (/\.{4}$/.test(suffix) || !chunk.hasOpenDelimiter)
+          (/\.{4}$/.test(suffix) ||
+            !(
+              chunk.hasOpenDelimiter ||
+              hasOpenTypographicQuote(chunk.text()) ||
+              /\b(?:am|is|are|was|were|i)\.{3}$/i.test(suffix)
+            ))
         ) {
           acc.push(chunk.text());
           continue;
@@ -458,6 +463,13 @@ export function sentenceSegment(
 
   // If no matches were found, return the input treated as a single sentence
   return acc.length === 0 ? [input] : acc;
+}
+
+function hasOpenTypographicQuote(input: string): boolean {
+  return (
+    input.lastIndexOf('“') > input.lastIndexOf('”') ||
+    input.lastIndexOf('‘') > input.lastIndexOf('’')
+  );
 }
 
 function nextListMarker(

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1574,6 +1574,14 @@ describe('Utility Functions', () => {
         },
       );
 
+      test.each(['She said, "I... I cannot go."', 'We noted (Alpha... Beta) today.'])(
+        'keeps three-dot ellipses inside surrounding delimiters: %s',
+        (input) => {
+          expect(ss(input)).toEqual([input]);
+          expect(segmentCaseNeutrally(input)).toEqual([input]);
+        },
+      );
+
       test('scores reference sentences ending in a three-dot ellipsis correctly', () => {
         expect(rouge.l('Beta Alpha...', 'Alpha... Beta.')).toBeCloseTo(6 / 7);
       });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1552,6 +1552,32 @@ describe('Utility Functions', () => {
         expect(ss('Wait...what?')).toEqual(['Wait...what?']);
       });
 
+      test.each([
+        ['Alpha... Beta.', ['Alpha...', 'Beta.']],
+        [
+          'This is e.g. Mr. Smith, who talks slowly... And this is another sentence.',
+          ['This is e.g. Mr. Smith, who talks slowly...', 'And this is another sentence.'],
+        ],
+      ])('recognizes terminal three-dot ellipses in %s', (input, expected) => {
+        expect(ss(input)).toEqual(expected);
+        expect(segmentCaseNeutrally(input)).toEqual(expected);
+        expect(segmentCaseNeutrally(input.toLowerCase())).toEqual(
+          expected.map((sentence) => sentence.toLowerCase()),
+        );
+      });
+
+      test.each(['Wait... what?', 'Wait... and then continued.'])(
+        'keeps lowercase ellipsis continuations together in %s',
+        (input) => {
+          expect(ss(input)).toEqual([input]);
+          expect(segmentCaseNeutrally(input)).toEqual([input]);
+        },
+      );
+
+      test('scores reference sentences ending in a three-dot ellipsis correctly', () => {
+        expect(rouge.l('Beta Alpha...', 'Alpha... Beta.')).toBeCloseTo(6 / 7);
+      });
+
       test.each(lineBreaks)('joins wrapped ellipses across %j', (lineBreak) => {
         expect(ss(`Wait...${lineBreak}what?`)).toEqual(['Wait... what?']);
         expect(ss(`Wait...${lineBreak}what? Next step`)).toEqual(['Wait... what?', 'Next step']);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1637,6 +1637,13 @@ describe('Utility Functions', () => {
         expect(rouge.l(uppercase, uppercase.toLowerCase(), { caseSensitive: false })).toBe(1);
       });
 
+      test.each(lineBreaks)('keeps wrapped continuations after inline asides across %j', (wrap) => {
+        const input = `He paused... (Perhaps deliberately)${wrap}before answering.`;
+        const expected = ['He paused... (Perhaps deliberately) before answering.'];
+        expect(ss(input)).toEqual(expected);
+        expect(segmentCaseNeutrally(input)).toEqual(expected);
+      });
+
       test('scores reference sentences ending in a three-dot ellipsis correctly', () => {
         expect(rouge.l('Beta Alpha...', 'Alpha... Beta.')).toBeCloseTo(6 / 7);
       });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1572,6 +1572,8 @@ describe('Utility Functions', () => {
         ['Alpha... "Beta."', ['Alpha...', '"Beta."']],
         ['Alpha... (Beta.)', ['Alpha...', '(Beta.)']],
         ['Alpha... 2024 was different.', ['Alpha...', '2024 was different.']],
+        ['Alpha... 100% of voters agreed.', ['Alpha...', '100% of voters agreed.']],
+        ['Alpha... 100 years have passed.', ['Alpha...', '100 years have passed.']],
         [
           'This is e.g. Mr. Smith, who talks slowly... And this is another sentence.',
           ['This is e.g. Mr. Smith, who talks slowly...', 'And this is another sentence.'],
@@ -1597,6 +1599,7 @@ describe('Utility Functions', () => {
         'She said, “I... I cannot go.”',
         'She said, ‘I can’t... Alpha.’',
         'She said, «I... Beta.»',
+        'Er sagte: „Ich... Ich kann nicht.“',
         'We noted (Alpha... Beta) today.',
       ])('keeps three-dot ellipses inside surrounding delimiters: %s', (input) => {
         expect(ss(input)).toEqual([input]);
@@ -1619,9 +1622,13 @@ describe('Utility Functions', () => {
       });
 
       test('keeps inline parentheticals with their ellipsis continuation', () => {
-        const input = 'He paused... (Perhaps deliberately) before answering.';
-        expect(ss(input)).toEqual([input]);
-        expect(segmentCaseNeutrally(input)).toEqual([input]);
+        for (const input of [
+          'He paused... (Perhaps deliberately) before answering.',
+          'He paused... (Perhaps, e.g., deliberately) before answering.',
+        ]) {
+          expect(ss(input)).toEqual([input]);
+          expect(segmentCaseNeutrally(input)).toEqual([input]);
+        }
       });
 
       test('scores reference sentences ending in a three-dot ellipsis correctly', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1574,8 +1574,17 @@ describe('Utility Functions', () => {
         },
       );
 
-      test.each(['She said, "I... I cannot go."', 'We noted (Alpha... Beta) today.'])(
-        'keeps three-dot ellipses inside surrounding delimiters: %s',
+      test.each([
+        'She said, "I... I cannot go."',
+        'She said, “I... I cannot go.”',
+        'We noted (Alpha... Beta) today.',
+      ])('keeps three-dot ellipses inside surrounding delimiters: %s', (input) => {
+        expect(ss(input)).toEqual([input]);
+        expect(segmentCaseNeutrally(input)).toEqual([input]);
+      });
+
+      test.each(['And the winner is... Alice Smith.', 'I... I cannot go.'])(
+        'keeps capitalized ellipsis continuations in the same sentence: %s',
         (input) => {
           expect(ss(input)).toEqual([input]);
           expect(segmentCaseNeutrally(input)).toEqual([input]);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1554,6 +1554,8 @@ describe('Utility Functions', () => {
 
       test.each([
         ['Alpha... Beta.', ['Alpha...', 'Beta.']],
+        ['Alpha... "Beta."', ['Alpha...', '"Beta."']],
+        ['Alpha... (Beta.)', ['Alpha...', '(Beta.)']],
         [
           'This is e.g. Mr. Smith, who talks slowly... And this is another sentence.',
           ['This is e.g. Mr. Smith, who talks slowly...', 'And this is another sentence.'],
@@ -1577,6 +1579,7 @@ describe('Utility Functions', () => {
       test.each([
         'She said, "I... I cannot go."',
         'She said, “I... I cannot go.”',
+        'She said, ‘I can’t... Alpha.’',
         'We noted (Alpha... Beta) today.',
       ])('keeps three-dot ellipses inside surrounding delimiters: %s', (input) => {
         expect(ss(input)).toEqual([input]);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1583,13 +1583,20 @@ describe('Utility Functions', () => {
         expect(segmentCaseNeutrally(input)).toEqual([input]);
       });
 
-      test.each(['And the winner is... Alice Smith.', 'I... I cannot go.'])(
-        'keeps capitalized ellipsis continuations in the same sentence: %s',
-        (input) => {
-          expect(ss(input)).toEqual([input]);
-          expect(segmentCaseNeutrally(input)).toEqual([input]);
-        },
-      );
+      test.each([
+        'And the winner is... Alice Smith.',
+        'And the winner will be... Alice Smith.',
+        'The winner has been... Alice Smith.',
+        'The winner is being... Alice Smith.',
+        'I... I cannot go.',
+      ])('keeps capitalized ellipsis continuations in the same sentence: %s', (input) => {
+        expect(ss(input)).toEqual([input]);
+        expect(segmentCaseNeutrally(input)).toEqual([input]);
+      });
+
+      test('handles long sequences of merged ellipses in one scan', () => {
+        expect(ss('It is... Alpha '.repeat(4000))).toHaveLength(1);
+      });
 
       test('scores reference sentences ending in a three-dot ellipsis correctly', () => {
         expect(rouge.l('Beta Alpha...', 'Alpha... Beta.')).toBeCloseTo(6 / 7);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1417,6 +1417,21 @@ describe('Utility Functions', () => {
         );
       }, 25_000);
 
+      test('bounds unmatched typographic quotation state within a constrained heap', () => {
+        expectBundledScriptToPass(
+          `
+            const summary = '‘'.repeat(7000000);
+            const sentences = module.exports.sentenceSegment(summary);
+            if (sentences.length !== 1 || sentences[0] !== summary) {
+              throw new Error('Unmatched quotation content changed');
+            }
+            process.stdout.write('ok');
+          `,
+          20_000,
+          ['--max-old-space-size=64'],
+        );
+      }, 25_000);
+
       test('should segment abbreviation chains within a small heap', () => {
         expectBundledScriptToPass(
           `
@@ -1556,6 +1571,7 @@ describe('Utility Functions', () => {
         ['Alpha... Beta.', ['Alpha...', 'Beta.']],
         ['Alpha... "Beta."', ['Alpha...', '"Beta."']],
         ['Alpha... (Beta.)', ['Alpha...', '(Beta.)']],
+        ['Alpha... 2024 was different.', ['Alpha...', '2024 was different.']],
         [
           'This is e.g. Mr. Smith, who talks slowly... And this is another sentence.',
           ['This is e.g. Mr. Smith, who talks slowly...', 'And this is another sentence.'],
@@ -1580,6 +1596,7 @@ describe('Utility Functions', () => {
         'She said, "I... I cannot go."',
         'She said, “I... I cannot go.”',
         'She said, ‘I can’t... Alpha.’',
+        'She said, «I... Beta.»',
         'We noted (Alpha... Beta) today.',
       ])('keeps three-dot ellipses inside surrounding delimiters: %s', (input) => {
         expect(ss(input)).toEqual([input]);
@@ -1599,6 +1616,12 @@ describe('Utility Functions', () => {
 
       test('handles long sequences of merged ellipses in one scan', () => {
         expect(ss('It is... Alpha '.repeat(4000))).toHaveLength(1);
+      });
+
+      test('keeps inline parentheticals with their ellipsis continuation', () => {
+        const input = 'He paused... (Perhaps deliberately) before answering.';
+        expect(ss(input)).toEqual([input]);
+        expect(segmentCaseNeutrally(input)).toEqual([input]);
       });
 
       test('scores reference sentences ending in a three-dot ellipsis correctly', () => {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1626,6 +1626,8 @@ describe('Utility Functions', () => {
           'He paused... (Perhaps deliberately) before answering.',
           'He paused... (Perhaps, e.g., deliberately) before answering.',
           'He paused... “Perhaps deliberately,” before answering.',
+          "He paused... 'Perhaps it's deliberate,' before answering.",
+          'He paused... ‘Perhaps it’s deliberate,’ before answering.',
         ]) {
           expect(ss(input)).toEqual([input]);
           expect(segmentCaseNeutrally(input)).toEqual([input]);

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1625,10 +1625,14 @@ describe('Utility Functions', () => {
         for (const input of [
           'He paused... (Perhaps deliberately) before answering.',
           'He paused... (Perhaps, e.g., deliberately) before answering.',
+          'He paused... “Perhaps deliberately,” before answering.',
         ]) {
           expect(ss(input)).toEqual([input]);
           expect(segmentCaseNeutrally(input)).toEqual([input]);
         }
+        const uppercase = 'HE PAUSED... (PERHAPS) BEFORE ANSWERING.';
+        expect(segmentCaseNeutrally(uppercase)).toEqual([uppercase]);
+        expect(rouge.l(uppercase, uppercase.toLowerCase(), { caseSensitive: false })).toBe(1);
       });
 
       test('scores reference sentences ending in a three-dot ellipsis correctly', () => {


### PR DESCRIPTION
## Summary

- Treat a terminal three-dot ellipsis as a sentence boundary when an independent sentence follows.
- Track typographic quote state incrementally and preserve modal/copula continuations, quoted or bracketed ellipses, contraction apostrophes, wrapped inline asides, existing four-dot behavior, and case-folding invariance.

## Verification

- `npm run type-check`
- `npx biome ci . --error-on-warnings`
- `npm run test:package`
- `npm test -- --runInBand` (771 tests)
- 160 upstream English sentence-segmentation cases: one fixed, no new regressions.
- Adversarial 240 KB merged-ellipsis input: 35 ms without repeated buffer materialization.
- Seven million unmatched quotation marks complete under a 64 MB Node heap.
